### PR TITLE
1.2.0 Release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,10 @@ insert_final_newline = false
 
 #### .NET Coding Conventions ####
 
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:warning
 dotnet_style_qualification_for_field = false:warning
@@ -84,10 +88,12 @@ csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_conditional_delegate_call = true:warning
 
 # Modifier preferences
+csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
 
 # Code-block preferences
 csharp_prefer_braces = true:warning
+csharp_prefer_simple_using_statement = true:suggestion
 
 # Expression-level preferences
 csharp_prefer_simple_default_expression = true:warning
@@ -96,6 +102,9 @@ csharp_style_prefer_index_operator = true:warning
 csharp_style_prefer_range_operator = true:warning
 csharp_style_unused_value_assignment_preference = discard_variable:warning
 csharp_style_unused_value_expression_statement_preference = discard_variable:warning
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:silent
 
 #### C# Formatting Rules ####
 
@@ -113,7 +122,7 @@ csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = false
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = no_change
 csharp_indent_switch_labels = true
 
 # Space preferences
@@ -144,3 +153,65 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
 
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = error
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_static_field_should_be_pascal_case.severity = error
+dotnet_naming_rule.private_or_internal_static_field_should_be_pascal_case.symbols = private_or_internal_static_field
+dotnet_naming_rule.private_or_internal_static_field_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.severity = error
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.style = camel_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private
+dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+
+dotnet_naming_symbols.private_or_internal_static_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_static_field.applicable_accessibilities = internal, private
+dotnet_naming_symbols.private_or_internal_static_field.required_modifiers = static
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.camel_case.required_prefix = 
+dotnet_naming_style.camel_case.required_suffix = 
+dotnet_naming_style.camel_case.word_separator = 
+dotnet_naming_style.camel_case.capitalization = camel_case

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   buildPlatform: 'Any CPU'
   solution: '**/*.sln'
   majorVersion: '1'
-  minorVersion: '1'
+  minorVersion: '2'
   patchVersion: '0'
   version: '$(majorVersion).$(minorVersion).$(patchVersion)'
 

--- a/src/MooVC.Tests/Collections/Generic/CollectionExtensionsTests/WhenAddRangeIsCalled.cs
+++ b/src/MooVC.Tests/Collections/Generic/CollectionExtensionsTests/WhenAddRangeIsCalled.cs
@@ -1,0 +1,51 @@
+namespace MooVC.Collections.Generic.CollectionExtensionsTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public sealed class WhenAddRangeIsCalled
+    {
+        [Fact]
+        public void GivenANullListThenNoArgumentNullExcetionIsThrown()
+        {
+            ICollection<int> target = new List<int>();
+            int[] items = null;
+
+            target.AddRange(items);
+        }
+
+        [Fact]
+        public void GivenANullTargetThenAnArgumentNullExcetionIsThrown()
+        {
+            ICollection<int> target = null;
+            int[] items = new[] { 1, 2, 3 };
+
+            _ = Assert.Throws<ArgumentNullException>(() => target.AddRange(items));
+        }
+
+        [Fact]
+        public void GivenItemsWhenTheTargetIsEmptyThenTheItemsAreAddedToTheTarget()
+        {
+            ICollection<int> expected = new List<int>();
+            int[] actual = new[] { 1, 2, 3 };
+
+            expected.AddRange(actual);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GivenItemsWhenTheTargetIsNotEmptyThenTheItemsAreAddedToTheTargetWithoutRemovingTheExistingEntries()
+        {
+            ICollection<int> actual = new List<int> { 1, 2, 3 };
+            int[] items = new[] { 4, 5, 6 };
+            IEnumerable<int> expected = Enumerable.Range(1, 6);
+
+            actual.AddRange(items);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/MooVC.Tests/Collections/Generic/CollectionExtensionsTests/WhenReplaceIsCalled.cs
+++ b/src/MooVC.Tests/Collections/Generic/CollectionExtensionsTests/WhenReplaceIsCalled.cs
@@ -2,10 +2,9 @@ namespace MooVC.Collections.Generic.CollectionExtensionsTests
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Xunit;
 
-    public sealed class WhenAddRangeIsCalled
+    public sealed class WhenReplaceIsCalled
     {
         [Fact]
         public void GivenANullListThenNoArgumentNullExcetionIsThrown()
@@ -13,7 +12,7 @@ namespace MooVC.Collections.Generic.CollectionExtensionsTests
             ICollection<int> target = new List<int>();
             int[] items = null;
 
-            target.AddRange(items);
+            target.Replace(items);
         }
 
         [Fact]
@@ -22,7 +21,7 @@ namespace MooVC.Collections.Generic.CollectionExtensionsTests
             ICollection<int> target = null;
             int[] items = new[] { 1, 2, 3 };
 
-            _ = Assert.Throws<ArgumentNullException>(() => target.AddRange(items));
+            _ = Assert.Throws<ArgumentNullException>(() => target.Replace(items));
         }
 
         [Fact]
@@ -31,19 +30,18 @@ namespace MooVC.Collections.Generic.CollectionExtensionsTests
             ICollection<int> actual = new List<int>();
             int[] expected = new[] { 1, 2, 3 };
 
-            actual.AddRange(expected);
+            actual.Replace(expected);
 
             Assert.Equal(expected, actual);
         }
 
         [Fact]
-        public void GivenItemsWhenTheTargetIsNotEmptyThenTheItemsAreAddedToTheTargetWithoutRemovingTheExistingEntries()
+        public void GivenItemsWhenTheTargetIsNotEmptyThenTheItemsAreAddedToTheTargetAndTheExistingEntriesAreRemoved()
         {
             ICollection<int> actual = new List<int> { 1, 2, 3 };
-            int[] items = new[] { 4, 5, 6 };
-            IEnumerable<int> expected = Enumerable.Range(1, 6);
+            int[] expected = new[] { 4, 5, 6 };
 
-            actual.AddRange(items);
+            actual.Replace(expected);
 
             Assert.Equal(expected, actual);
         }

--- a/src/MooVC.Tests/Collections/Generic/EnumerableExtensionsTests/WhenForAllIsCalled.cs
+++ b/src/MooVC.Tests/Collections/Generic/EnumerableExtensionsTests/WhenForAllIsCalled.cs
@@ -1,6 +1,8 @@
 namespace MooVC.Collections.Generic.EnumerableExtensionsTests
 {
+    using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Linq;
     using Xunit;
 
@@ -37,6 +39,27 @@ namespace MooVC.Collections.Generic.EnumerableExtensionsTests
 
             Assert.All(enumeration, value => Assert.Contains(value, invocations));
             Assert.Equal(enumeration.Length, invocations.Count);
+        }
+
+        [Theory]
+        [InlineData(1, 3)]
+        [InlineData(2, 6)]
+        [InlineData(3, 9)]
+        public void GivenAnEnumerationThatRaisesExceptionsThenAnAggregateExceptionIsThrownContainingAllExceptions(int mod, int range)
+        {
+            IEnumerable<int> enumeration = Enumerable.Range(0, range);
+
+            void Action(int value)
+            {
+                if (value % mod == 0)
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+
+            AggregateException exception = Assert.Throws<AggregateException>(() => enumeration.ForAll(Action));
+
+            Assert.Equal(range / mod, exception.InnerExceptions.Count);
         }
     }
 }

--- a/src/MooVC.Tests/EnsureTests/WhenArgumentNotNullIsCalled.cs
+++ b/src/MooVC.Tests/EnsureTests/WhenArgumentNotNullIsCalled.cs
@@ -15,9 +15,9 @@
         [InlineData(false)]
         [InlineData("")]
         [InlineData(" ")]
-        public void GivenANonNullValueThenNotExceptionIsThrown(object argument)
+        public void GivenANonNullValueThenNoExceptionIsThrown(object argument)
         {
-            Ensure.ArgumentNotNull(argument, string.Empty);
+            Ensure.ArgumentNotNull(argument, nameof(argument));
         }
 
         [Theory]
@@ -30,9 +30,9 @@
         [InlineData(false)]
         [InlineData("")]
         [InlineData(" ")]
-        public void GivenANonNullValueAndAMessageThenNotExceptionIsThrown(object argument)
+        public void GivenANonNullValueAndAMessageThenNoExceptionIsThrown(object argument)
         {
-            Ensure.ArgumentNotNull(argument, string.Empty, "Some message.");
+            Ensure.ArgumentNotNull(argument, nameof(argument), "Some message.");
         }
 
         [Fact]

--- a/src/MooVC.Tests/EnsureTests/WhenArgumentNotNullOrWhiteSpaceIsCalled.cs
+++ b/src/MooVC.Tests/EnsureTests/WhenArgumentNotNullOrWhiteSpaceIsCalled.cs
@@ -1,0 +1,47 @@
+﻿namespace MooVC.EnsureTests
+{
+    using System;
+    using Xunit;
+
+    public sealed class WhenArgumentNotNullOrWhiteSpaceIsCalled
+    {
+        [Fact]
+        public void GivenANonNullValueThenNoExceptionIsThrown()
+        {
+            Ensure.ArgumentNotNullOrWhiteSpace("Some Value", "Value");
+        }
+
+        [Fact]
+        public void GivenANonNullValueAndAMessageThenNoExceptionIsThrown()
+        {
+            Ensure.ArgumentNotNullOrWhiteSpace("Some Value", "Value", "Some message.");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void GivenANullArgumentThenAnArgumentNullExceptionIsThrown(string argument)
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+                Ensure.ArgumentNotNullOrWhiteSpace(argument, nameof(argument)));
+
+            Assert.Equal(nameof(argument), exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void GivenANullArgumentThenAnArgumentNullExceptionIsThrownWithTheMessageAttached(string argument)
+        {
+            const string ExpectedMessage = "Expected is null.";
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+                Ensure.ArgumentNotNullOrWhiteSpace(null, nameof(argument), ExpectedMessage));
+
+            Assert.Equal(nameof(argument), exception.ParamName);
+            Assert.StartsWith(ExpectedMessage, exception.Message);
+        }
+    }
+}

--- a/src/MooVC.Tests/Linq/EnumerableExtensionsTests/WhenIndexOfIsCalled.cs
+++ b/src/MooVC.Tests/Linq/EnumerableExtensionsTests/WhenIndexOfIsCalled.cs
@@ -1,0 +1,43 @@
+namespace MooVC.Linq.EnumerableExtensionsTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Xunit;
+
+    public sealed class WhenIndexOfIsCalled
+    {
+        [Theory]
+        [InlineData(new object[] { new[] { 1, 2, 3 }, 2, 1 })]
+        [InlineData(new object[] { new[] { -1, -2, -3 }, -3, 2 })]
+        [InlineData(new object[] { new[] { 1, 2, 3 }, 1, 0 })]
+        public void GivenAListWithOneMatchingEntryThenTheIndexOfTheMatchingEntryIsReturned(int[] enumeration, int target, int expectedIndex)
+        {
+            int actualIndex = enumeration.IndexOf(item => item == target);
+
+            Assert.Equal(expectedIndex, actualIndex);
+        }
+
+        [Fact]
+        public void GivenAListWithNoMatchingEntryTheNegativeOneIsReturned()
+        {
+            const int ExpectedIndex = -1;
+            int[] enumeration = new[] { 1, 2, 3 };
+
+            int actualIndex = enumeration.IndexOf(item => item == 4);
+
+            Assert.Equal(ExpectedIndex, actualIndex);
+        }
+
+        [Theory]
+        [InlineData(new object[] { new[] { 1, 2, 2 }, 2, 1 })]
+        [InlineData(new object[] { new[] { -1, -2, -1 }, -1, 0 })]
+        [InlineData(new object[] { new[] { 1, 1, 1 }, 1, 0 })]
+        public void GivenAListWithTwoMatchingEntriesThenTheIndexOfTheFirstMatchingEntryIsReturned(int[] enumeration, int target, int expectedIndex)
+        {
+            int actualIndex = enumeration.IndexOf(item => item == target);
+
+            Assert.Equal(expectedIndex, actualIndex);
+        }
+    }
+}

--- a/src/MooVC.Tests/Linq/PagingExtensionsTests/WhenPageIsCalled.cs
+++ b/src/MooVC.Tests/Linq/PagingExtensionsTests/WhenPageIsCalled.cs
@@ -1,0 +1,39 @@
+﻿namespace MooVC.Linq.PagingExtensionsTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using Moq;
+    using Xunit;
+
+    public sealed class WhenPageIsCalled
+    {
+        [Fact]
+        public void GivenNoPagingThenTheQueryAbleIsReturned()
+        {
+            IQueryable<int> expected = Enumerable.Empty<int>().AsQueryable();
+            IQueryable<int> actual = expected.Page(null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GivenPagingThenApplyIsCalled()
+        {
+            var paging = new Mock<Paging>(Paging.FirstPage, Paging.MinimumSize);
+
+            IQueryable<int> expected = Enumerable.Empty<int>().AsQueryable();
+
+            _ = paging
+                .Setup(pg => pg.Apply(It.Is<IQueryable<int>>(value => value == expected)))
+                .Returns(expected);
+
+            IQueryable<int> actual = expected.Page(paging.Object);
+
+            paging.Verify(pg => pg.Apply(It.IsAny<IQueryable<int>>()), Times.Once);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/MooVC.Tests/Linq/PagingTests/WhenApplyIsCalled.cs
+++ b/src/MooVC.Tests/Linq/PagingTests/WhenApplyIsCalled.cs
@@ -1,0 +1,22 @@
+﻿namespace MooVC.Linq.PagingTests
+{
+    using System.Linq;
+    using Xunit;
+
+    public sealed class WhenApplyIsCalled
+    {
+        [Theory]
+        [InlineData(1, 5, new int[] { 0, 1, 2, 3, 4 })]
+        [InlineData(2, 1, new int[] { 1 })]
+        [InlineData(10, 2, new int[] { 18, 19 })]
+        public void GivenAQueryableThenTheResultsArePagedAsConfigured(ushort page, ushort size, int[] expected)
+        {
+            var paging = new Paging(page: page, size: size);
+            IQueryable<int> queryable = Enumerable.Range(0, 20).AsQueryable();
+
+            int[] actual = paging.Apply(queryable).ToArray();
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/MooVC.Tests/Linq/PagingTests/WhenPagingIsConstructed.cs
+++ b/src/MooVC.Tests/Linq/PagingTests/WhenPagingIsConstructed.cs
@@ -1,0 +1,49 @@
+﻿namespace MooVC.Linq.PagingTests
+{
+    using System;
+    using Xunit;
+
+    public sealed class WhenPagingIsConstructed
+    {
+        [Theory]
+        [InlineData(Paging.FirstPage, Paging.MinimumSize)]
+        [InlineData(Paging.FirstPage + 5, Paging.MinimumSize + 10)]
+        [InlineData(Paging.FirstPage, ushort.MaxValue)]
+        [InlineData(ushort.MaxValue, Paging.MinimumSize)]
+        public void GivenAValidPageAndSizeThenThePropertiesAreSetToMatch(ushort page, ushort size)
+        {
+            var paging = new Paging(page: page, size: size);
+
+            Assert.Equal(page, paging.Page);
+            Assert.Equal(size, paging.Size);
+        }
+
+        [Theory]
+        [InlineData(Paging.MinimumSize)]
+        [InlineData(Paging.MinimumSize + 10)]
+        [InlineData(ushort.MaxValue)]
+        public void GivenAnInvalidPageAndAValidSizeThenThePageIsSetToTheFirstPageAndTheSizeIsSetToTheConfigured(ushort size)
+        {
+            ushort page = Math.Min((ushort)(Paging.FirstPage - 1), ushort.MinValue);
+
+            var paging = new Paging(page: page, size: size);
+
+            Assert.Equal(Paging.FirstPage, paging.Page);
+            Assert.Equal(size, paging.Size);
+        }
+
+        [Theory]
+        [InlineData(Paging.FirstPage)]
+        [InlineData(Paging.FirstPage + 5)]
+        [InlineData(ushort.MaxValue)]
+        public void GivenAnValidPageAndAnInvalidSizeThenThePageIsSetToTheConfiguredAndTheSizeIsSetToTheMinimum(ushort page)
+        {
+            ushort size = Math.Min((ushort)(Paging.MinimumSize - 1), ushort.MinValue);
+
+            var paging = new Paging(page: page, size: size);
+
+            Assert.Equal(page, paging.Page);
+            Assert.Equal(Paging.MinimumSize, paging.Size);
+        }
+    }
+}

--- a/src/MooVC.Tests/Linq/PagingTests/WhenPagingIsSerialized.cs
+++ b/src/MooVC.Tests/Linq/PagingTests/WhenPagingIsSerialized.cs
@@ -28,7 +28,7 @@
 
             Assert.Equal(paging.Page, deserialized.Page);
             Assert.Equal(paging.Size, deserialized.Size);
-            Assert.NotStrictEqual(paging, deserialized);
+            Assert.NotSame(paging, deserialized);
         }
     }
 }

--- a/src/MooVC.Tests/Linq/PagingTests/WhenPagingIsSerialized.cs
+++ b/src/MooVC.Tests/Linq/PagingTests/WhenPagingIsSerialized.cs
@@ -1,0 +1,34 @@
+﻿namespace MooVC.Linq.PagingTests
+{
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Xunit;
+
+    public sealed class WhenPagingIsSerialized
+    {
+        [Theory]
+        [InlineData(Paging.FirstPage, Paging.MinimumSize)]
+        [InlineData(Paging.FirstPage + 5, Paging.MinimumSize + 10)]
+        [InlineData(Paging.FirstPage, ushort.MaxValue)]
+        [InlineData(ushort.MaxValue, Paging.MinimumSize)]
+        public void GivenAnInstanceThenAllPropertiesAreSerialized(ushort page, ushort size)
+        {
+            var paging = new Paging(page: page, size: size);
+            Paging deserialized;
+
+            var binaryFormatter = new BinaryFormatter();
+
+            using (var stream = new MemoryStream())
+            {
+                binaryFormatter.Serialize(stream, paging);
+                _ = stream.Seek(0, SeekOrigin.Begin);
+
+                deserialized = (Paging)binaryFormatter.Deserialize(stream);
+            }
+
+            Assert.Equal(paging.Page, deserialized.Page);
+            Assert.Equal(paging.Size, deserialized.Size);
+            Assert.NotStrictEqual(paging, deserialized);
+        }
+    }
+}

--- a/src/MooVC.Tests/MooVC.Tests.csproj
+++ b/src/MooVC.Tests/MooVC.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/MooVC.Tests/MooVC.Tests.csproj
+++ b/src/MooVC.Tests/MooVC.Tests.csproj
@@ -9,9 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
@@ -1,0 +1,16 @@
+namespace MooVC.Collections.Generic
+{
+    using System.Collections.Generic;
+    using static MooVC.Ensure;
+    using static Resources;
+
+    public static partial class CollectionExtensions
+    {
+        public static void AddRange<T>(this ICollection<T> target, IEnumerable<T> items)
+        {
+            ArgumentNotNull(target, nameof(target), CollectionExtensionsAddRangeTargetRequired);
+
+            items.ForEach(item => target.Add(item));
+        }
+    }
+}

--- a/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
@@ -6,11 +6,12 @@ namespace MooVC.Collections.Generic
 
     public static partial class CollectionExtensions
     {
-        public static void AddRange<T>(this ICollection<T> target, IEnumerable<T> items)
+        public static void Replace<T>(this ICollection<T> target, IEnumerable<T> replacements)
         {
             ArgumentNotNull(target, nameof(target), CollectionExtensionsGenericTargetRequired);
 
-            items.ForEach(item => target.Add(item));
+            target.Clear();
+            target.AddRange(replacements);
         }
     }
 }

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
@@ -1,6 +1,7 @@
 ﻿namespace MooVC.Collections.Generic
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
@@ -10,7 +11,26 @@
         {
             if (items != null)
             {
-                _ = Parallel.ForEach(items, action);
+                var exceptions = new ConcurrentQueue<Exception>();
+
+                _ = Parallel.ForEach(
+                    items, 
+                    item =>
+                    {
+                        try
+                        {
+                            action(item);
+                        }
+                        catch (Exception ex)
+                        {
+                            exceptions.Enqueue(ex);
+                        }
+                    });
+
+                if (exceptions.Count > 0)
+                {
+                    throw new AggregateException(exceptions);
+                }
             }
         }
     }

--- a/src/MooVC/Ensure.ArgumentIsAcceptable.cs
+++ b/src/MooVC/Ensure.ArgumentIsAcceptable.cs
@@ -10,7 +10,7 @@
             Func<T, bool> predicate, 
             string message)
         {
-            Ensure.ArgumentNotNull(argument, argumentName, message);
+            ArgumentNotNull(argument, argumentName, message);
 
             if (!predicate(argument))
             {

--- a/src/MooVC/Ensure.ArgumentNotNullOrWhiteSpace.cs
+++ b/src/MooVC/Ensure.ArgumentNotNullOrWhiteSpace.cs
@@ -1,0 +1,23 @@
+﻿namespace MooVC
+{
+    using System;
+
+    public static partial class Ensure
+    {
+        public static void ArgumentNotNullOrWhiteSpace(string argument, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+        }
+
+        public static void ArgumentNotNullOrWhiteSpace(string argument, string argumentName, string message)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                throw new ArgumentNullException(argumentName, message);
+            }
+        }
+    }
+}

--- a/src/MooVC/Linq/EnumerableExtensions.IndexOf.cs
+++ b/src/MooVC/Linq/EnumerableExtensions.IndexOf.cs
@@ -4,7 +4,7 @@ namespace MooVC.Linq
     using System.Collections.Generic;
     using System.Linq;
 
-    public static class EnumerableExtensions
+    public static partial class EnumerableExtensions
     {
         public static int IndexOf<T>(this IEnumerable<T> enumeration, Func<T, bool> predicate)
         {

--- a/src/MooVC/Linq/EnumerableExtensions.IndexOf.cs
+++ b/src/MooVC/Linq/EnumerableExtensions.IndexOf.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Linq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class EnumerableExtensions
+    {
+        public static int IndexOf<T>(this IEnumerable<T> enumeration, Func<T, bool> predicate)
+        {
+            return enumeration
+                .Select((item, index) => new { Index = index, Item = item })
+                .Where(item => predicate(item.Item))
+                .Select(item => item.Index)
+                .DefaultIfEmpty(-1)
+                .First();
+        }
+    }
+}

--- a/src/MooVC/Linq/Paging.cs
+++ b/src/MooVC/Linq/Paging.cs
@@ -2,7 +2,10 @@
 {
     using System;
     using System.Linq;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
 
+    [Serializable]
     public class Paging
     {
         public const ushort DefaultSize = 10,
@@ -15,6 +18,12 @@
             Size = Math.Max(size, MinimumSize);
         }
 
+        protected Paging(SerializationInfo info, StreamingContext context)
+        {
+            Page = (ushort)info.GetValue(nameof(Page), typeof(ushort));
+            Size = (ushort)info.GetValue(nameof(Size), typeof(ushort));
+        }
+
         public ushort Page { get; }
 
         public ushort Size { get; }
@@ -24,6 +33,13 @@
             int skip = (Page - FirstPage) * Size;
 
             return queryable.Skip(skip).Take(Size);
+        }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Page), Page);
+            info.AddValue(nameof(Size), Size);
         }
     }
 }

--- a/src/MooVC/Linq/Paging.cs
+++ b/src/MooVC/Linq/Paging.cs
@@ -1,0 +1,29 @@
+﻿namespace MooVC.Linq
+{
+    using System;
+    using System.Linq;
+
+    public class Paging
+    {
+        public const ushort DefaultSize = 10,
+            FirstPage = 1,
+            MinimumSize = 1;
+
+        public Paging(ushort page = FirstPage, ushort size = DefaultSize)
+        {
+            Page = Math.Max(page, FirstPage);
+            Size = Math.Max(size, MinimumSize);
+        }
+
+        public ushort Page { get; }
+
+        public ushort Size { get; }
+
+        public virtual IQueryable<T> Apply<T>(IQueryable<T> queryable)
+        {
+            int skip = (Page - FirstPage) * Size;
+
+            return queryable.Skip(skip).Take(Size);
+        }
+    }
+}

--- a/src/MooVC/Linq/PagingExtensions.Page.cs
+++ b/src/MooVC/Linq/PagingExtensions.Page.cs
@@ -1,0 +1,14 @@
+﻿namespace MooVC.Linq
+{
+    using System.Linq;
+
+    public static class PagingExtensions
+    {
+        public static IQueryable<T> Page<T>(this IQueryable<T> queryable, Paging paging)
+        {
+            return paging == null 
+                ? queryable 
+                : paging.Apply(queryable);
+        }
+    }
+}

--- a/src/MooVC/Linq/PagingExtensions.Page.cs
+++ b/src/MooVC/Linq/PagingExtensions.Page.cs
@@ -2,7 +2,7 @@
 {
     using System.Linq;
 
-    public static class PagingExtensions
+    public static partial class PagingExtensions
     {
         public static IQueryable<T> Page<T>(this IQueryable<T> queryable, Paging paging)
         {

--- a/src/MooVC/MooVC.csproj
+++ b/src/MooVC/MooVC.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/MooVC/MooVC.csproj
+++ b/src/MooVC/MooVC.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MooVC/moovc.git</RepositoryUrl>
     <Description>A collection of functionalities common to many applications, gathered to support the rapid development of a wide variety of applications targeting multiple platforms.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MooVC/Resources.Designer.cs
+++ b/src/MooVC/Resources.Designer.cs
@@ -63,9 +63,9 @@ namespace MooVC {
         /// <summary>
         ///   Looks up a localized string similar to You must provide the target collection..
         /// </summary>
-        internal static string CollectionExtensionsAddRangeTargetRequired {
+        internal static string CollectionExtensionsGenericTargetRequired {
             get {
-                return ResourceManager.GetString("CollectionExtensionsAddRangeTargetRequired", resourceCulture);
+                return ResourceManager.GetString("CollectionExtensionsGenericTargetRequired", resourceCulture);
             }
         }
         

--- a/src/MooVC/Resources.Designer.cs
+++ b/src/MooVC/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace MooVC {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You must provide the target collection..
+        /// </summary>
+        internal static string CollectionExtensionsAddRangeTargetRequired {
+            get {
+                return ResourceManager.GetString("CollectionExtensionsAddRangeTargetRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must provide a message..
         /// </summary>
         internal static string ExceptionEventArgsMessageRequired {

--- a/src/MooVC/Resources.resx
+++ b/src/MooVC/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CollectionExtensionsAddRangeTargetRequired" xml:space="preserve">
+    <value>You must provide the target collection.</value>
+  </data>
   <data name="ExceptionEventArgsMessageRequired" xml:space="preserve">
     <value>You must provide a message.</value>
   </data>

--- a/src/MooVC/Resources.resx
+++ b/src/MooVC/Resources.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CollectionExtensionsAddRangeTargetRequired" xml:space="preserve">
+  <data name="CollectionExtensionsGenericTargetRequired" xml:space="preserve">
     <value>You must provide the target collection.</value>
   </data>
   <data name="ExceptionEventArgsMessageRequired" xml:space="preserve">

--- a/src/MooVC/Serialization/SerializableExtensions.Clone.cs
+++ b/src/MooVC/Serialization/SerializableExtensions.Clone.cs
@@ -1,0 +1,23 @@
+namespace MooVC.Serialization
+{
+    using System.IO;
+    using System.Runtime.Serialization;
+    using System.Runtime.Serialization.Formatters.Binary;
+
+    public static class SerializableExtensions
+    {
+        public static T Clone<T>(this T original)
+            where T : ISerializable
+        {
+            var binaryFormatter = new BinaryFormatter();
+
+            using (var stream = new MemoryStream())
+            {
+                binaryFormatter.Serialize(stream, original);
+                _ = stream.Seek(0, SeekOrigin.Begin);
+
+                return (T)binaryFormatter.Deserialize(stream);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<b>Enhancements</b>

<ul>
 <li>Added a new AddRange extension for collections to simplify population/initialization.</li>
 <li>Added a new Clone extension for serializable objects.</li>
 <li>Added a new Ensure variant to check strings for null or white-space.</li>
 <li>Added a new Replace extension for collections to simplify population/initialization.</li>
 <li>Added an extension to return the index of an element within an enumeration.</li>
 <li>Changed Paging so that it is now serializable.</li>
</ul>

<b>Bug Fixes</b>

<ul>
 <li>Enumerable.ForAll will now return all exceptions that occur during the enumeration of the list.</li>
 <li>Corrected assertions relating to identical objects within unit tests.</li>
</ul>