### PR TITLE
2.1.1:  Type Mismatch Fix

### DIFF
--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryGetEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryGetEnumerable.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Runtime.Serialization;
+    using MooVC.Collections.Generic;
 
     public static partial class SerializationInfoExtensions
     {
@@ -12,7 +13,7 @@
 
         public static IEnumerable<T> TryGetEnumerable<T>(this SerializationInfo info, string name, IEnumerable<T> defaultValue)
         {
-            return info.TryGetValue(name, defaultValue);
+            return info.TryGetValue(name, defaultValue.Snapshot());
         }
     }
 }


### PR DESCRIPTION
<b>Bug Fixes</b>

<ul>
 <li>Changed TryGetEnumerable to use Snapshot on defaultValue, thereby instructing TryGetValue to cast the type as an array to alleviate concerns of type mismatches on de-serialization.</li>
</ul>