### PR TITLE
Feature: Passive Event Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Added additional support for asynchonrous event handling.
 
 - Added AsyncEventHandler to represent an event handler that can be awaited by the sender.
 - Added a MulticastDelegateExtensions.InvokeAsync method that will await the invocation of a multicast delegate that returns a Task.
+- Added a MulticastDelegateExtensions.PassiveInvokeAsync method that will await the invocation of a multicast delegate that returns a Task and absorb any error encountered.
+- Added a MulticastDelegateExtensions.PassiveInvoke method that will invoke a multicast delegate absorb any errors encountered.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ Added additional support for asynchonrous event handling.
 - Added a MulticastDelegateExtensions.InvokeAsync method that will await the invocation of a multicast delegate that returns a Task.
 - Added a MulticastDelegateExtensions.PassiveInvokeAsync method that will await the invocation of a multicast delegate that returns a Task and absorb any error encountered.
 - Added a MulticastDelegateExtensions.PassiveInvoke method that will invoke a multicast delegate absorb any errors encountered.
+- Changed the invocation of the ProcessStateChanged event handler of Processing.Processor to utilize the passive implementation.
+- Changed the invocation of the DiagnosticsEmitted event handler of Processing.TimedJobQueue to utilize the passive implementation.
+
+## Bug Fixes
+
+- Corrected the scope for the State setter on Processing.Processor

--- a/src/MooVC.Tests/Diagnostics/EmitDiagnosticsExtensionsTests/DiagnosticEmitter.cs
+++ b/src/MooVC.Tests/Diagnostics/EmitDiagnosticsExtensionsTests/DiagnosticEmitter.cs
@@ -16,7 +16,7 @@
         {
             if (isEmitting)
             {
-                DiagnosticsEmitted?.Invoke(this, new DiagnosticsEmittedEventArgs());
+                DiagnosticsEmitted?.PassiveInvoke(this, new DiagnosticsEmittedEventArgs());
             }
         }
     }

--- a/src/MooVC.Tests/MulticastDelegateExtensionsTests/TestEventArgs.cs
+++ b/src/MooVC.Tests/MulticastDelegateExtensionsTests/TestEventArgs.cs
@@ -1,0 +1,9 @@
+﻿namespace MooVC.MulticastDelegateExtensionsTests
+{
+    using System;
+
+    internal sealed class TestEventArgs
+        : EventArgs
+    {
+    }
+}

--- a/src/MooVC.Tests/MulticastDelegateExtensionsTests/WhenPassiveInvokeIsCalled.cs
+++ b/src/MooVC.Tests/MulticastDelegateExtensionsTests/WhenPassiveInvokeIsCalled.cs
@@ -1,0 +1,109 @@
+﻿namespace MooVC.MulticastDelegateExtensionsTests
+{
+    using System;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public sealed class WhenPassiveInvokeIsCalled
+    {
+        private event EventHandler? Tested;
+
+        private event Action<Exception, EventArgs>? TypedSender;
+
+        private event EventHandler<TestEventArgs>? TypedArgs;
+
+        private event AsyncEventHandler? Invalid;
+
+        private event Action<object?, EventArgs, object>? IncorrectParameters;
+
+        [Fact]
+        public void GivenAHandlerThenTheHandlerIsInvoked()
+        {
+            bool wasInvoked = false;
+
+            Tested += (sender, e) => wasInvoked = true;
+
+            Tested.PassiveInvoke(this, EventArgs.Empty);
+
+            Assert.True(wasInvoked);
+        }
+
+        [Fact]
+        public void GivenMultipleHandlersThenEachHandlerIsInvoked()
+        {
+            const byte Expected = 3;
+            byte actual = 0;
+
+            void Handler(object? sender, EventArgs e)
+            {
+                actual++;
+            }
+
+            Tested += Handler;
+            Tested += Handler;
+            Tested += Handler;
+
+            Tested.PassiveInvoke(this, EventArgs.Empty);
+
+            Assert.Equal(Expected, actual);
+        }
+
+        [Fact]
+        public void GivenAnExceptionThenTheExceptionIsPassedthrough()
+        {
+            bool wasInvoked = false;
+            var expected = new InvalidOperationException();
+
+            Tested += (sender, e) => throw expected;
+
+            Tested.PassiveInvoke(
+                this,
+                EventArgs.Empty,
+                onFailure: actual =>
+                {
+                    wasInvoked = true;
+
+                    Assert.Equal(expected, actual.InnerException?.InnerException);
+                });
+
+            Assert.True(wasInvoked);
+        }
+
+        [Fact]
+        public void GivenAnInvalidHandlerThenANotSupportedExceptionIsThrown()
+        {
+            Invalid += (_, _) => Task.CompletedTask;
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => Invalid.PassiveInvoke(this, EventArgs.Empty));
+        }
+
+        [Fact]
+        public void GivenAnInvalidSenderThenANotSupportedExceptionIsThrown()
+        {
+            TypedSender += (_, _) => { };
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => TypedSender.PassiveInvoke(this, EventArgs.Empty));
+        }
+
+        [Fact]
+        public void GivenAnInvalidArgsThenANotSupportedExceptionIsThrown()
+        {
+            TypedArgs += (_, _) => { };
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => TypedArgs.PassiveInvoke(this, EventArgs.Empty));
+        }
+
+        [Fact]
+        public void GivenAnInvalidNumberOfParametersThenANotSupportedExceptionIsThrown()
+        {
+            IncorrectParameters += (_, _, _) => { };
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(
+                () => IncorrectParameters.PassiveInvoke(this, EventArgs.Empty));
+        }
+    }
+}

--- a/src/MooVC/MulticastDelegateExtensions.EnsureParameters.cs
+++ b/src/MooVC/MulticastDelegateExtensions.EnsureParameters.cs
@@ -1,0 +1,40 @@
+﻿namespace MooVC
+{
+    using System;
+    using System.Reflection;
+    using static System.String;
+    using static MooVC.Resources;
+
+    public static partial class MulticastDelegateExtensions
+    {
+        private static void EnsureParameters<TSender, TArgs>(MethodInfo method)
+            where TSender : class
+            where TArgs : EventArgs
+        {
+            ParameterInfo[] parameters = method.GetParameters();
+
+            if (parameters.Length != 2)
+            {
+                throw new NotSupportedException(MulticastDelegateExtensionsEnsureParametersIncorrectNumberOfParameters);
+            }
+
+            Type senderType = typeof(TSender);
+
+            if (!parameters[0].ParameterType.IsAssignableFrom(senderType))
+            {
+                throw new NotSupportedException(Format(
+                    MulticastDelegateExtensionsEnsureParametersIncorrectSenderParameterType,
+                    senderType.FullName));
+            }
+
+            Type argsType = typeof(TArgs);
+
+            if (!parameters[1].ParameterType.IsAssignableFrom(argsType))
+            {
+                throw new NotSupportedException(Format(
+                    MulticastDelegateExtensionsEnsureParametersIncorrectArgsParameterType,
+                    argsType.FullName));
+            }
+        }
+    }
+}

--- a/src/MooVC/MulticastDelegateExtensions.InvokeAsync.cs
+++ b/src/MooVC/MulticastDelegateExtensions.InvokeAsync.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using System.Reflection;
     using System.Threading.Tasks;
-    using static System.String;
     using static MooVC.Resources;
 
     public static partial class MulticastDelegateExtensions
@@ -25,30 +24,7 @@
                     throw new NotSupportedException(MulticastDelegateExtensionsInvokeAsyncIncorrectReturnType);
                 }
 
-                ParameterInfo[] parameters = method.GetParameters();
-
-                if (parameters.Length != 2)
-                {
-                    throw new NotSupportedException(MulticastDelegateExtensionsInvokeAsyncIncorrectNumberOfParameters);
-                }
-
-                Type senderType = typeof(TSender);
-
-                if (!parameters[0].ParameterType.IsAssignableFrom(senderType))
-                {
-                    throw new NotSupportedException(Format(
-                        MulticastDelegateExtensionsInvokeAsyncIncorrectSenderParameterType,
-                        senderType.FullName));
-                }
-
-                Type argsType = typeof(TArgs);
-
-                if (!parameters[1].ParameterType.IsAssignableFrom(argsType))
-                {
-                    throw new NotSupportedException(Format(
-                        MulticastDelegateExtensionsInvokeAsyncIncorrectArgsParameterType,
-                        argsType.FullName));
-                }
+                EnsureParameters<TSender, TArgs>(method);
 
                 Delegate[] delegates = handler.GetInvocationList();
 

--- a/src/MooVC/MulticastDelegateExtensions.PassiveInvoke.cs
+++ b/src/MooVC/MulticastDelegateExtensions.PassiveInvoke.cs
@@ -1,0 +1,42 @@
+﻿namespace MooVC
+{
+    using System;
+    using System.Reflection;
+    using MooVC.Collections.Generic;
+    using static MooVC.Resources;
+
+    public static partial class MulticastDelegateExtensions
+    {
+        public static void PassiveInvoke<TSender, TArgs>(
+            this MulticastDelegate? handler,
+            TSender? sender,
+            TArgs e,
+            Action<AggregateException>? onFailure = default)
+            where TSender : class
+            where TArgs : EventArgs
+        {
+            if (handler is { })
+            {
+                try
+                {
+                    MethodInfo method = handler.GetMethodInfo();
+
+                    if (method.ReturnType != typeof(void))
+                    {
+                        throw new NotSupportedException(MulticastDelegateExtensionsPassiveInvokeIncorrectReturnType);
+                    }
+
+                    EnsureParameters<TSender, TArgs>(method);
+
+                    handler
+                        .GetInvocationList()
+                        .ForAll(@delegate => @delegate.DynamicInvoke(sender, e));
+                }
+                catch (AggregateException ex)
+                {
+                    onFailure?.Invoke(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/MooVC/MulticastDelegateExtensions.PassiveInvokeAsync.cs
+++ b/src/MooVC/MulticastDelegateExtensions.PassiveInvokeAsync.cs
@@ -1,0 +1,29 @@
+﻿namespace MooVC
+{
+    using System;
+    using System.Reflection;
+    using System.Threading.Tasks;
+
+    public static partial class MulticastDelegateExtensions
+    {
+        public static async Task PassiveInvokeAsync<TSender, TArgs>(
+            this MulticastDelegate? handler,
+            TSender? sender,
+            TArgs e,
+            Action<TargetInvocationException>? onFailure = default)
+            where TSender : class
+            where TArgs : EventArgs
+        {
+            try
+            {
+                await handler
+                    .InvokeAsync(sender, e)
+                    .ConfigureAwait(false);
+            }
+            catch (TargetInvocationException tie)
+            {
+                onFailure?.Invoke(tie);
+            }
+        }
+    }
+}

--- a/src/MooVC/Processing/Processor.cs
+++ b/src/MooVC/Processing/Processor.cs
@@ -133,7 +133,7 @@
             Exception? cause = default,
             string? message = default)
         {
-            DiagnosticsEmitted?.Invoke(
+            DiagnosticsEmitted?.PassiveInvoke(
                 this,
                 new DiagnosticsEmittedEventArgs(
                     cause: cause,
@@ -143,7 +143,13 @@
 
         protected virtual void OnProcessingStateChanged(ProcessorState state)
         {
-            ProcessStateChanged?.Invoke(this, new ProcessorStateChangedEventArgs(state));
+            ProcessStateChanged?.PassiveInvoke(
+                this,
+                new ProcessorStateChangedEventArgs(state),
+                onFailure: failure => OnDiagnosticsEmitted(
+                    Level.Warning,
+                    cause: failure,
+                    message: ProcessorOnProcessingStateChangedFailure));
         }
 
         protected abstract Task PerformStartAsync(CancellationToken cancellationToken);

--- a/src/MooVC/Processing/Processor.cs
+++ b/src/MooVC/Processing/Processor.cs
@@ -19,7 +19,7 @@
         public ProcessorState State
         {
             get => state;
-            set
+            private set
             {
                 if (state != value)
                 {

--- a/src/MooVC/Processing/Resources.Designer.cs
+++ b/src/MooVC/Processing/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace MooVC.Processing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A failure has prevented one or more listeners for changes to the state of the processor from successfully handling a change..
+        /// </summary>
+        internal static string ProcessorOnProcessingStateChangedFailure {
+            get {
+                return ResourceManager.GetString("ProcessorOnProcessingStateChangedFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The processor could not be started..
         /// </summary>
         internal static string ProcessorTryStartFailure {

--- a/src/MooVC/Processing/Resources.resx
+++ b/src/MooVC/Processing/Resources.resx
@@ -120,6 +120,9 @@
   <data name="JobQueueTimerRequired" xml:space="preserve">
     <value>The timer that manages the job queue must be provided.</value>
   </data>
+  <data name="ProcessorOnProcessingStateChangedFailure" xml:space="preserve">
+    <value>A failure has prevented one or more listeners for changes to the state of the processor from successfully handling a change.</value>
+  </data>
   <data name="ProcessorTryStartFailure" xml:space="preserve">
     <value>The processor could not be started.</value>
   </data>

--- a/src/MooVC/Processing/TimedJobQueue.cs
+++ b/src/MooVC/Processing/TimedJobQueue.cs
@@ -65,7 +65,7 @@
             Exception? cause = default,
             string? message = default)
         {
-            DiagnosticsEmitted?.Invoke(
+            DiagnosticsEmitted?.PassiveInvoke(
                 this,
                 new DiagnosticsEmittedEventArgs(
                     cause: cause,

--- a/src/MooVC/Resources.Designer.cs
+++ b/src/MooVC/Resources.Designer.cs
@@ -99,18 +99,27 @@ namespace MooVC {
         /// <summary>
         ///   Looks up a localized string similar to The multicast delegate supplied does not specify the required type of {0} for the arguments..
         /// </summary>
-        internal static string MulticastDelegateExtensionsInvokeAsyncIncorrectArgsParameterType {
+        internal static string MulticastDelegateExtensionsEnsureParametersIncorrectArgsParameterType {
             get {
-                return ResourceManager.GetString("MulticastDelegateExtensionsInvokeAsyncIncorrectArgsParameterType", resourceCulture);
+                return ResourceManager.GetString("MulticastDelegateExtensionsEnsureParametersIncorrectArgsParameterType", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to The multicast delegate supplied does not specify the two required parameters..
         /// </summary>
-        internal static string MulticastDelegateExtensionsInvokeAsyncIncorrectNumberOfParameters {
+        internal static string MulticastDelegateExtensionsEnsureParametersIncorrectNumberOfParameters {
             get {
-                return ResourceManager.GetString("MulticastDelegateExtensionsInvokeAsyncIncorrectNumberOfParameters", resourceCulture);
+                return ResourceManager.GetString("MulticastDelegateExtensionsEnsureParametersIncorrectNumberOfParameters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The multicast delegate supplied does not specify the required type of {0} for the sender..
+        /// </summary>
+        internal static string MulticastDelegateExtensionsEnsureParametersIncorrectSenderParameterType {
+            get {
+                return ResourceManager.GetString("MulticastDelegateExtensionsEnsureParametersIncorrectSenderParameterType", resourceCulture);
             }
         }
         
@@ -124,11 +133,11 @@ namespace MooVC {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The multicast delegate supplied does not specify the required type of {0} for the sender..
+        ///   Looks up a localized string similar to The multicast delegate supplied is not marked as void..
         /// </summary>
-        internal static string MulticastDelegateExtensionsInvokeAsyncIncorrectSenderParameterType {
+        internal static string MulticastDelegateExtensionsPassiveInvokeIncorrectReturnType {
             get {
-                return ResourceManager.GetString("MulticastDelegateExtensionsInvokeAsyncIncorrectSenderParameterType", resourceCulture);
+                return ResourceManager.GetString("MulticastDelegateExtensionsPassiveInvokeIncorrectReturnType", resourceCulture);
             }
         }
         

--- a/src/MooVC/Resources.resx
+++ b/src/MooVC/Resources.resx
@@ -129,17 +129,20 @@
   <data name="ExceptionExtensionsExplodeHandlerRequired" xml:space="preserve">
     <value>The handler for each exception must be provided.</value>
   </data>
-  <data name="MulticastDelegateExtensionsInvokeAsyncIncorrectArgsParameterType" xml:space="preserve">
+  <data name="MulticastDelegateExtensionsEnsureParametersIncorrectArgsParameterType" xml:space="preserve">
     <value>The multicast delegate supplied does not specify the required type of {0} for the arguments.</value>
   </data>
-  <data name="MulticastDelegateExtensionsInvokeAsyncIncorrectNumberOfParameters" xml:space="preserve">
+  <data name="MulticastDelegateExtensionsEnsureParametersIncorrectNumberOfParameters" xml:space="preserve">
     <value>The multicast delegate supplied does not specify the two required parameters.</value>
+  </data>
+  <data name="MulticastDelegateExtensionsEnsureParametersIncorrectSenderParameterType" xml:space="preserve">
+    <value>The multicast delegate supplied does not specify the required type of {0} for the sender.</value>
   </data>
   <data name="MulticastDelegateExtensionsInvokeAsyncIncorrectReturnType" xml:space="preserve">
     <value>The multicast delegate supplied does not return a task.</value>
   </data>
-  <data name="MulticastDelegateExtensionsInvokeAsyncIncorrectSenderParameterType" xml:space="preserve">
-    <value>The multicast delegate supplied does not specify the required type of {0} for the sender.</value>
+  <data name="MulticastDelegateExtensionsPassiveInvokeIncorrectReturnType" xml:space="preserve">
+    <value>The multicast delegate supplied is not marked as void.</value>
   </data>
   <data name="ProcessorContinuationAbortFailure" xml:space="preserve">
     <value>Processor {0} has encountered an issue that has prevented it from waiting for continuation to cease.</value>


### PR DESCRIPTION
## Enhancements

- Added a MulticastDelegateExtensions.PassiveInvokeAsync method that will await the invocation of a multicast delegate that returns a Task and absorb any error encountered.
- Added a MulticastDelegateExtensions.PassiveInvoke method that will invoke a multicast delegate absorb any errors encountered.
- Changed the invocation of the ProcessStateChanged event handler of Processing.Processor to utilize the passive implementation.
- Changed the invocation of the DiagnosticsEmitted event handler of Processing.TimedJobQueue to utilize the passive implementation.

## Bug Fixes

- Corrected the scope for the State setter on Processing.Processor