### PR TITLE
7.1.0: Documentation Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,57 +8,12 @@ MooVC was originally created as a PHP based framework back in 2009, intended to 
 
 While the original MooVC PHP based framework has long since been deprecated, many of the lessons learned from it have formed the basis of solutions the author has since developed.  This library, and those related to it, are all intended to support the rapid development of high quality software that addresses a variety of use-cases.
 
-# Release v7.0.0
+# Release v7.1.0
+
+In preparation for the removal of ISerializable as part of Microsoft's BinaryFormatter Obsoletion Strategy, all supporting elements have been marked as obsolete, with the intention of full removal in v8. Please see https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md for more information.
 
 ## Enhancements
 
-- Added a Collections.Generic.EnumerableExtensions.ToIndex extension that simplifies conversion to a dictionary when the subject of the enumerable is the key for the dictionary.
-- Added a Collections.Generic.EnumerableExtensions.ToSpan extension that snapshots an enumerable and returns it as a ReadOnlySpan.
-- Added a Collections.Generic.ObjectExtensions.AsArray extension that will return an array containing the value on which the request was made.
-- Added a Collections.Generic.ObjectExtensions.AsEnumerable extension that will return an enumerable containing the value on which the request was made.
-- Added a Compression.DeflateCompressor to encapsulate the System.IO.DeflateStream compression implementation.
-- Added a Ensure.ArgumentIsDefined method to facilitate validation of enumerations.
-- Added a new Linq.Paging.One static property to facilitate situations where a method may support paging but only one entry is desired.
-- Added a series of extensions relating to Diagnostics.IDiagnosticsRelay to simplify consumption by providing methods akin to that offered by most logging frameworks.
-- Added Diagnostics.DiagnosticsMessage to facilitate encapsulation of a parameterized message, to take advantage of custom logging sinks.
-- Added Diagnostics.DiagnosticsProxy to serve as a default implementaiton for Diagnostics.IDiagnosticsProxy.
-- Added Diagnostics.DiagnosticsRelay to serve as a default implementaiton for Diagnostics.IDiagnosticsRelay.
-- Added Diagnostics.IDiagnosticsProxy to simplify contextual configurability and filtering for diagnostics emission.
-- Added Diagnostics.IDiagnosticsRelay to simplify diagnostics implementation in class hierarchies (composition over inheritance).
-- Added Diagnostics.Impact to enable diagnostics emitters to communicate the impact on a workflow, thereby enabling the observer to determine the appropriate level.
-- Added Diagnostics.Level.Ignore to facilitate emission filtering via the DiagnosticsProxy (**Breaking Change**).
-- Changed Diagnostics.DiagnosticsEmittedAsyncEventArgs to include impact.
-- Changed Diagnostics.DiagnosticsEmittedAsyncEventArgs to utilize Diagnostics.DiagnosticsMessage as the data type for message, instead of string  (**Breaking Change**).
-- Changed Ensure.ArgumentInRange (now Ensure.InRange) so that a default value can now be passed and used if the argument fails to pass the assertion.
-- Changed Ensure.ArgumentInRange (now Ensure.InRange) so that the message is now a named optional parameter (**Breaking Change**).
-- Changed Ensure.ArgumentInRange (now Ensure.InRange) so that the name of the argument is now optional (**Breaking Change**).
-- Changed Ensure.ArgumentIsAcceptable (now Ensure.Satisfies) so that a default value can now be passed and used if the argument fails to pass the assertion.
-- Changed Ensure.ArgumentIsAcceptable (now Ensure.Satisfies) so that the name of the argument is now optional (**Breaking Change**).
-- Changed Ensure.ArgumentIsAcceptable (now Ensure.Satisfies) so the message is now a named optional parameter (**Breaking Change**).
-- Changed Ensure.ArgumentNotEmpty (now Ensure.IsNotEmpty) so that a default value can now be passed and used if the argument fails to pass the assertion.
-- Changed Ensure.ArgumentNotEmpty (now Ensure.IsNotEmpty) so that the message is now a named optional parameter (**Breaking Change**).
-- Changed Ensure.ArgumentNotEmpty (now Ensure.IsNotEmpty) so that the name of the argument is now optional (**Breaking Change**).
-- Changed Ensure.ArgumentNotNull (now Ensure.IsNotNull) so that a default value can now be passed and used if the argument fails to pass the assertion.
-- Changed Ensure.ArgumentNotNull (now Ensure.IsNotNull) so that the message is now a named optional parameter (**Breaking Change**).
-- Changed Ensure.ArgumentNotNull (now Ensure.IsNotNull) so that the name of the argument is now optional (**Breaking Change**).
-- Changed Ensure.ArgumentNotNullOrWhiteSpace (now Ensure.IsNotNullOrWhiteSpace) so that a default value can now be passed and used if the argument fails to pass the assertion.
-- Changed Ensure.ArgumentNotNullOrWhiteSpace (now Ensure.IsNotNullOrWhiteSpace) so that the message is now a named optional parameter (**Breaking Change**).
-- Changed Ensure.ArgumentNotNullOrWhiteSpace (now Ensure.IsNotNullOrWhiteSpace) so that the name of the argument is now optional (**Breaking Change**).
-- Changed Linq.Paging so that it can now be implicitly created from a Tuple<ushort, ushort> (assumed as page number followed by size).
-- Changed Linq.Paging so that it can now be implicitly created from a ushort (assumed as page size).
-- Changed Processing.Processor and it's implementations to optionally accept an instance of Diagnostics.IDiagnosticsProxy.
-- Changed the default level for Diagnostics.DiagnosticsEmittedAsyncEventArgs from Critical to Trace (**Breaking Change**).
-- Changed the return type for Persistence.IStore<T, TKey>.GetAsync(CancellationToken, Paging) from IEnumerable<T> to PagedResult<T> (**Breaking Change**).
-- Changed the return type for Persistence.MappedStore<T, TOutterKey, TInnerKey>.GetAsync(CancellationToken, Paging) from IEnumerable<T> to PagedResult<T> (**Breaking Change**).
-- Changed the return type for Persistence.SynchronousStore<T, TKey>.GetAsync(CancellationToken, Paging) from IEnumerable<T> to PagedResult<T> (**Breaking Change**).
-- Changed the return type for Persistence.SynchronousStore<T, TKey>.PerformGet(Paging) from IEnumerable<T> to PagedResult<T> (**Breaking Change**).
-- Changed Threading.Coordinator so that it is now extensible i.e. It is no longer static (**Breaking Change**).
-- Removed Processing.Processor.OnDiagnosticsEmittedAsync in favour of a new protected Diagnostics property that enabled access to diagnostics emission (**Breaking Change**).
-- Removed support for .Net 5 (**Breaking Change**).
-- Removed support for .Net Standard 2.1 (**Breaking Change**).
-- Renamed Ensure.ArgumentInRange to Ensure.InRange (**Breaking Change**).
-- Renamed Ensure.ArgumentIsAcceptable to Ensure.Satisfies (**Breaking Change**).
-- Renamed Ensure.ArgumentNotEmpty to Ensure.IsNotEmpty (**Breaking Change**).
-- Renamed Ensure.ArgumentNotNull to Ensure.IsNotNull (**Breaking Change**).
-- Renamed Ensure.ArgumentNotNullOrWhiteSpace to Ensure.IsNotNullOrWhiteSpace (**Breaking Change**).
-- Renamed Processing.IProcessor.ProcessStateChanged to Processing.IProcessor.StateChanged (**Breaking Change**).
+- Marked all Serialization.SerializationInfoExtensions as obsolete.
+- Marked all Serialization.SerializationInfoEnumeratorExtensions as obsolete.
+- Marked all implementations specific to ISerializable as obsolete.

--- a/directory.build.props
+++ b/directory.build.props
@@ -18,7 +18,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
-    <NoWarn>$(NoWarn);NU5105</NoWarn>
+    <NoWarn>$(NoWarn);CS0618;NU5105</NoWarn>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MooVC/moovc</PackageProjectUrl>

--- a/src/MooVC.Tests/Linq/PagingTests/WhenImplicitlyCastFromTuple.cs
+++ b/src/MooVC.Tests/Linq/PagingTests/WhenImplicitlyCastFromTuple.cs
@@ -1,6 +1,5 @@
 ﻿namespace MooVC.Linq.PagingTests;
 
-using System.Drawing;
 using Xunit;
 
 public sealed class WhenImplicitlyCastFromTuple

--- a/src/MooVC/ArrayExtensions.Append.cs
+++ b/src/MooVC/ArrayExtensions.Append.cs
@@ -3,6 +3,9 @@
 using System.Linq;
 using MooVC.Collections.Generic;
 
+/// <summary>
+/// Provides extensions relating to <see cref="Array"/>.
+/// </summary>
 public static partial class ArrayExtensions
 {
     /// <summary>

--- a/src/MooVC/ArrayExtensions.Append.cs
+++ b/src/MooVC/ArrayExtensions.Append.cs
@@ -5,6 +5,13 @@ using MooVC.Collections.Generic;
 
 public static partial class ArrayExtensions
 {
+    /// <summary>
+    /// Appends an element to the end of an array.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the array.</typeparam>
+    /// <param name="source">The array to append to.</param>
+    /// <param name="other">The element to append to the array.</param>
+    /// <returns>An array containing the original elements of the source array, with the other element appended at the end.</returns>
     public static T[] Append<T>(this T[]? source, T other)
     {
         return source.Combine(other).ToArray();

--- a/src/MooVC/ArrayExtensions.Extend.cs
+++ b/src/MooVC/ArrayExtensions.Extend.cs
@@ -5,6 +5,13 @@ using MooVC.Collections.Generic;
 
 public static partial class ArrayExtensions
 {
+    /// <summary>
+    /// Extends an array by appending the elements of another array.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the arrays.</typeparam>
+    /// <param name="source">The array to extend.</param>
+    /// <param name="other">The array containing the elements to append to the source array.</param>
+    /// <returns>An array containing the original elements of the source array, with the elements of the other array appended at the end.</returns>
     public static T[] Extend<T>(this T[]? source, T[]? other)
     {
         return source.Combine(other).ToArray();

--- a/src/MooVC/ArrayExtensions.Extend.cs
+++ b/src/MooVC/ArrayExtensions.Extend.cs
@@ -3,6 +3,9 @@
 using System.Linq;
 using MooVC.Collections.Generic;
 
+/// <summary>
+/// Provides extensions relating to <see cref="Array"/>.
+/// </summary>
 public static partial class ArrayExtensions
 {
     /// <summary>

--- a/src/MooVC/ArrayExtensions.Prepend.cs
+++ b/src/MooVC/ArrayExtensions.Prepend.cs
@@ -1,9 +1,29 @@
 ﻿namespace MooVC;
 
+using MooVC.Collections.Generic;
+
 public static partial class ArrayExtensions
 {
+    /// <summary>
+    /// Prepends an element to the beginning of an array.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the array.</typeparam>
+    /// <param name="source">The array to prepend to.</param>
+    /// <param name="other">The element to prepend to the array.</param>
+    /// <returns>An array containing the original elements of the source array, with the other element prepended at the beginning.</returns>
     public static T[] Prepend<T>(this T[]? source, T other)
     {
-        return new[] { other }.Extend(source);
+        if (source is null)
+        {
+            return other.AsArray();
+        }
+
+        var destination = new T[source.Length + 1];
+
+        Array.Copy(source, 0, destination, 1, source.Length);
+
+        destination[0] = other;
+
+        return destination;
     }
 }

--- a/src/MooVC/ArrayExtensions.Prepend.cs
+++ b/src/MooVC/ArrayExtensions.Prepend.cs
@@ -2,6 +2,9 @@
 
 using MooVC.Collections.Generic;
 
+/// <summary>
+/// Provides extensions relating to <see cref="Array"/>.
+/// </summary>
 public static partial class ArrayExtensions
 {
     /// <summary>

--- a/src/MooVC/AsyncEventArgs.cs
+++ b/src/MooVC/AsyncEventArgs.cs
@@ -24,6 +24,9 @@ public class AsyncEventArgs
     /// <summary>
     /// Gets the cancellation token associated with this event.
     /// </summary>
+    /// <value>
+    /// The cancellation token associated with this event.
+    /// </value>
     public CancellationToken CancellationToken { get; }
 
     /// <summary>

--- a/src/MooVC/AsyncEventArgs.cs
+++ b/src/MooVC/AsyncEventArgs.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using Token = System.Threading.CancellationToken;
 
 /// <summary>
 /// Represents a class that provides event data for async events.
@@ -12,30 +13,28 @@ public class AsyncEventArgs
     private static readonly Lazy<AsyncEventArgs> empty = new(() => new AsyncEventArgs());
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncEventArgs"/> class
-    /// with the specified cancellation token.
+    /// Initializes a new instance of the <see cref="AsyncEventArgs"/> class with the specified <see cref="Token"/>.
     /// </summary>
-    /// <param name="cancellationToken">The cancellation token associated with this event.</param>
-    protected AsyncEventArgs(CancellationToken? cancellationToken = default)
+    /// <param name="cancellationToken">An optional <see cref="Token"/> associated with this event.</param>
+    protected AsyncEventArgs(Token? cancellationToken = default)
     {
         CancellationToken = cancellationToken.GetValueOrDefault();
     }
 
     /// <summary>
-    /// Gets the cancellation token associated with this event.
+    /// Gets the <see cref="CancellationToken"/> associated with this event.
     /// </summary>
     /// <value>
-    /// The cancellation token associated with this event.
+    /// The <see cref="CancellationToken"/> associated with this event.
     /// </value>
-    public CancellationToken CancellationToken { get; }
+    public Token CancellationToken { get; }
 
     /// <summary>
-    /// Gets an empty instance of the <see cref="AsyncEventArgs"/> class
-    /// with the specified cancellation token.
+    /// Gets an empty instance of the <see cref="AsyncEventArgs"/> class with the specified <see cref="Token"/>.
     /// </summary>
-    /// <param name="cancellationToken">The cancellation token associated with this event.</param>
+    /// <param name="cancellationToken">The <see cref="Token"/> associated with this event.</param>
     /// <returns>An empty instance of the <see cref="AsyncEventArgs"/> class.</returns>
-    public static new AsyncEventArgs Empty(CancellationToken? cancellationToken = default)
+    public static new AsyncEventArgs Empty(Token? cancellationToken = default)
     {
         if (cancellationToken is { })
         {

--- a/src/MooVC/AsyncEventArgs.cs
+++ b/src/MooVC/AsyncEventArgs.cs
@@ -3,18 +3,35 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Represents a class that provides event data for async events.
+/// </summary>
 public class AsyncEventArgs
     : EventArgs
 {
     private static readonly Lazy<AsyncEventArgs> empty = new(() => new AsyncEventArgs());
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncEventArgs"/> class
+    /// with the specified cancellation token.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token associated with this event.</param>
     protected AsyncEventArgs(CancellationToken? cancellationToken = default)
     {
         CancellationToken = cancellationToken.GetValueOrDefault();
     }
 
+    /// <summary>
+    /// Gets the cancellation token associated with this event.
+    /// </summary>
     public CancellationToken CancellationToken { get; }
 
+    /// <summary>
+    /// Gets an empty instance of the <see cref="AsyncEventArgs"/> class
+    /// with the specified cancellation token.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token associated with this event.</param>
+    /// <returns>An empty instance of the <see cref="AsyncEventArgs"/> class.</returns>
     public static new AsyncEventArgs Empty(CancellationToken? cancellationToken = default)
     {
         if (cancellationToken is { })

--- a/src/MooVC/AsyncEventHandler.cs
+++ b/src/MooVC/AsyncEventHandler.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 /// </summary>
 /// <param name="sender">The source of the event.</param>
 /// <param name="e">An object that contains data relating to the event.</param>
+/// <returns>A task representing the asynchronous operation.</returns>
 public delegate Task AsyncEventHandler(object? sender, AsyncEventArgs e);
 
 /// <summary>
@@ -15,6 +16,7 @@ public delegate Task AsyncEventHandler(object? sender, AsyncEventArgs e);
 /// <typeparam name="TArgs">The type of the event data.</typeparam>
 /// <param name="sender">The source of the event.</param>
 /// <param name="e">The type specific event data.</param>
+/// <returns>A task representing the asynchronous operation.</returns>
 public delegate Task AsyncEventHandler<TArgs>(object? sender, TArgs e)
     where TArgs : AsyncEventArgs;
 
@@ -25,6 +27,7 @@ public delegate Task AsyncEventHandler<TArgs>(object? sender, TArgs e)
 /// <typeparam name="TArgs">The type of the event data.</typeparam>
 /// <param name="sender">The source of the event.</param>
 /// <param name="e">The type specific event data.</param>
+/// <returns>A task representing the asynchronous operation.</returns>
 public delegate Task AsyncEventHandler<TSender, TArgs>(TSender? sender, TArgs e)
     where TSender : class
     where TArgs : AsyncEventArgs;

--- a/src/MooVC/AsyncEventHandler.cs
+++ b/src/MooVC/AsyncEventHandler.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 /// </summary>
 /// <param name="sender">The source of the event.</param>
 /// <param name="e">An object that contains data relating to the event.</param>
-/// <returns>A task representing the asynchronous operation.</returns>
+/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 public delegate Task AsyncEventHandler(object? sender, AsyncEventArgs e);
 
 /// <summary>
@@ -16,7 +16,7 @@ public delegate Task AsyncEventHandler(object? sender, AsyncEventArgs e);
 /// <typeparam name="TArgs">The type of the event data.</typeparam>
 /// <param name="sender">The source of the event.</param>
 /// <param name="e">The type specific event data.</param>
-/// <returns>A task representing the asynchronous operation.</returns>
+/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 public delegate Task AsyncEventHandler<TArgs>(object? sender, TArgs e)
     where TArgs : AsyncEventArgs;
 
@@ -27,7 +27,7 @@ public delegate Task AsyncEventHandler<TArgs>(object? sender, TArgs e)
 /// <typeparam name="TArgs">The type of the event data.</typeparam>
 /// <param name="sender">The source of the event.</param>
 /// <param name="e">The type specific event data.</param>
-/// <returns>A task representing the asynchronous operation.</returns>
+/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 public delegate Task AsyncEventHandler<TSender, TArgs>(TSender? sender, TArgs e)
     where TSender : class
     where TArgs : AsyncEventArgs;

--- a/src/MooVC/AsyncEventHandler.cs
+++ b/src/MooVC/AsyncEventHandler.cs
@@ -2,11 +2,29 @@
 
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents the method that will handle an asynchronous event that has event data within an abstract envelope.
+/// </summary>
+/// <param name="sender">The source of the event.</param>
+/// <param name="e">An object that contains data relating to the event.</param>
 public delegate Task AsyncEventHandler(object? sender, AsyncEventArgs e);
 
+/// <summary>
+/// Represents the method that will handle an asynchronous event that has type specific event data.
+/// </summary>
+/// <typeparam name="TArgs">The type of the event data.</typeparam>
+/// <param name="sender">The source of the event.</param>
+/// <param name="e">The type specific event data.</param>
 public delegate Task AsyncEventHandler<TArgs>(object? sender, TArgs e)
     where TArgs : AsyncEventArgs;
 
+/// <summary>
+/// Represents the method that will handle an asynchronous event that has a type specific source and type specific event data.
+/// </summary>
+/// <typeparam name="TSender">The type of the sender.</typeparam>
+/// <typeparam name="TArgs">The type of the event data.</typeparam>
+/// <param name="sender">The source of the event.</param>
+/// <param name="e">The type specific event data.</param>
 public delegate Task AsyncEventHandler<TSender, TArgs>(TSender? sender, TArgs e)
     where TSender : class
     where TArgs : AsyncEventArgs;

--- a/src/MooVC/Collections/Concurrent/ProducerConsumerCollectionExtensions.Extract.cs
+++ b/src/MooVC/Collections/Concurrent/ProducerConsumerCollectionExtensions.Extract.cs
@@ -4,6 +4,10 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
+/// <summary>
+/// Provides extensions relating to IProducerConsumerCollection{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
 public static partial class ProducerConsumerCollectionExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Concurrent/ProducerConsumerCollectionExtensions.Extract.cs
+++ b/src/MooVC/Collections/Concurrent/ProducerConsumerCollectionExtensions.Extract.cs
@@ -2,9 +2,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using System.Linq;
-using MooVC.Collections.Generic;
 
 public static partial class ProducerConsumerCollectionExtensions
 {

--- a/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
@@ -4,6 +4,10 @@ using System.Collections.Generic;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to ICollection{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
 public static partial class CollectionExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
@@ -5,7 +5,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to ICollection{T}.
+/// Provides extensions relating to <see cref="ICollection{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
 public static partial class CollectionExtensions

--- a/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.AddRange.cs
@@ -16,7 +16,7 @@ public static partial class CollectionExtensions
     /// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
     /// <param name="target">The collection to which the elements are inserted.</param>
     /// <param name="items">The items to be inserted into the collection.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="target" /> is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="target" /> is <see langword="null" />.</exception>
     public static void AddRange<T>(this ICollection<T> target, IEnumerable<T>? items)
     {
         _ = IsNotNull(target, message: CollectionExtensionsAddRangeTargetRequired);

--- a/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
@@ -1,9 +1,13 @@
 namespace MooVC.Collections.Generic;
 
 using System.Collections.Generic;
+using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
-using static Resources;
 
+/// <summary>
+/// Provides extensions relating to ICollection{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
 public static partial class CollectionExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
@@ -17,7 +17,7 @@ public static partial class CollectionExtensions
     /// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
     /// <param name="target">The collection in which the elements are to be replaced.</param>
     /// <param name="replacements">The elements to be inserted into the collection once the collection has been cleared.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="target" /> is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="target" /> is <see langword="null" />.</exception>
     public static void Replace<T>(this ICollection<T> target, IEnumerable<T>? replacements)
     {
         _ = IsNotNull(target, message: CollectionExtensionsReplaceTargetRequired);

--- a/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
+++ b/src/MooVC/Collections/Generic/CollectionExtensions.Replace.cs
@@ -5,7 +5,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to ICollection{T}.
+/// Provides extensions relating to <see cref="ICollection{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
 public static partial class CollectionExtensions

--- a/src/MooVC/Collections/Generic/DictionaryExtensions.Snapshot.cs
+++ b/src/MooVC/Collections/Generic/DictionaryExtensions.Snapshot.cs
@@ -2,6 +2,11 @@
 
 using System.Collections.Generic;
 
+/// <summary>
+/// Provides extensions relating to IDictionary{TKey, TValue}.
+/// </summary>
+/// <typeparam name="TKey">Specifies the type of keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">Specifies the type of values in the dictionary.</typeparam>
 public static partial class DictionaryExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/DictionaryExtensions.Snapshot.cs
+++ b/src/MooVC/Collections/Generic/DictionaryExtensions.Snapshot.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 
 /// <summary>
-/// Provides extensions relating to IDictionary{TKey, TValue}.
+/// Provides extensions relating to <see cref="IDictionary{TKey, TValue}"/>.
 /// </summary>
 /// <typeparam name="TKey">Specifies the type of keys in the dictionary.</typeparam>
 /// <typeparam name="TValue">Specifies the type of values in the dictionary.</typeparam>
@@ -11,7 +11,6 @@ public static partial class DictionaryExtensions
 {
     /// <summary>
     /// Populates a new dictionary instance with the contents of the <paramref name="source"/> dictionary.
-    /// enumeration.
     /// </summary>
     /// <typeparam name="TKey">Specifies the type of keys in the dictionary.</typeparam>
     /// <typeparam name="TValue">Specifies the type of values in the dictionary.</typeparam>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Aggregate.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Aggregate.cs
@@ -3,6 +3,10 @@
 using System.Collections.Generic;
 using System.Linq;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Aggregate.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Aggregate.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Combine.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Combine.cs
@@ -3,6 +3,10 @@
 using System.Collections.Generic;
 using System.Linq;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Combine.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Combine.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -15,7 +15,8 @@ public static partial class EnumerableExtensions
     /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
     /// <param name="source">The enumeration to which the <paramref name="instance"/> is to be apended.</param>
     /// <param name="instance">The instance to be apended to the <paramref name="source"/> enumeration.</param>
-    /// <returns>An enumerable containing the contents of <paramref name="source"/> with <paramref name="instance"/> appended. <br /><br />
+    /// <returns>
+    /// An enumerable containing the contents of <paramref name="source"/> with <paramref name="instance"/> appended.
     /// When <paramref name="source"/> is null, an enumeration containing the <paramref name="instance"/> element is returned.
     /// </returns>
     public static IEnumerable<T> Combine<T>(this IEnumerable<T>? source, T instance)
@@ -34,11 +35,14 @@ public static partial class EnumerableExtensions
     /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
     /// <param name="source">The enumeration to which the <paramref name="instances"/> are to be apended.</param>
     /// <param name="instances">The enumeration to be apended to the <paramref name="source"/> enumeration.</param>
-    /// <returns>An enumerable containing the contents of <paramref name="source"/> with the elements of <paramref name="instances"/> appended.
-    /// <br /><br />When <paramref name="source"/> is null and <paramref name="instances"/> is null, an empty enumeration is returned. <br />
+    /// <returns>
+    /// An enumerable containing the contents of <paramref name="source"/> with the elements of <paramref name="instances"/> appended.
+    /// When <paramref name="source"/> is null and <paramref name="instances"/> is null, an empty enumeration is returned.
     /// When <paramref name="source"/> is null and <paramref name="instances"/> is set, the <paramref name="instances"/> enumeration reference is
-    /// returned. <br /> When <paramref name="instances"/> is null and <paramref name="source"/> is set, the <paramref name="source"/> enumeration
-    /// reference is returned.</returns>
+    /// returned.
+    /// When <paramref name="instances"/> is null and <paramref name="source"/> is set, the <paramref name="source"/> enumeration reference
+    /// is returned.
+    /// </returns>
     public static IEnumerable<T> Combine<T>(this IEnumerable<T>? source, IEnumerable<T>? instances)
     {
         if (source is null)

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.For.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.For.cs
@@ -23,7 +23,7 @@ public static partial class EnumerableExtensions
     /// The action to be called for each element of the enumeration, with a zero-index value indicating the position of the element
     /// in the enueration.
     /// </param>
-    /// <exception cref="ArgumentNullException">The <paramref name="action"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="action"/> is <see langword="null" />.</exception>
     public static void For<T>(this IEnumerable<T>? items, Action<int, T> action)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.For.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.For.cs
@@ -7,6 +7,10 @@ using System.Runtime.InteropServices;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.For.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.For.cs
@@ -8,7 +8,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -19,8 +19,10 @@ public static partial class EnumerableExtensions
     /// </summary>
     /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
     /// <param name="items">The enumeration to be enumerated.</param>
-    /// <param name="action">The action to be called for each element of the enumeration, with a zero-index value indicating the position of the
-    /// element in the enueration.</param>
+    /// <param name="action">
+    /// The action to be called for each element of the enumeration, with a zero-index value indicating the position of the element
+    /// in the enueration.
+    /// </param>
     /// <exception cref="ArgumentNullException">The <paramref name="action"/> is null.</exception>
     public static void For<T>(this IEnumerable<T>? items, Action<int, T> action)
     {

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
@@ -9,7 +9,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -17,8 +17,9 @@ public static partial class EnumerableExtensions
     /// <summary>
     /// Provides Parallel.ForEach-like behavior in the form of a LINQ extension, enumerating the elements of <paramref name="items"/> in parallel
     /// and invoking <paramref name="action"/> for each element encountered.
-    /// <br /><br />The extension guarentees that every element of <paramref name="items"/> will be enumerated, even if one or more elements
-    /// results in an exception being thrown by <paramref name="action"/>.</summary>
+    /// The extension guarentees that every element of <paramref name="items"/> will be enumerated, even if one or more elements results
+    /// in an exception being thrown by <paramref name="action"/>.
+    /// </summary>
     /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
     /// <param name="items">The enumeration to be enumerated.</param>
     /// <param name="action">The action to be called for each element of the enumeration.</param>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
@@ -8,6 +8,10 @@ using System.Threading.Tasks;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAll.cs
@@ -24,7 +24,7 @@ public static partial class EnumerableExtensions
     /// <param name="items">The enumeration to be enumerated.</param>
     /// <param name="action">The action to be called for each element of the enumeration.</param>
     /// <exception cref="AggregateException">One or more elements resulted in an exception being thrown by <paramref name="action"/>.</exception>
-    /// <exception cref="ArgumentNullException">The <paramref name="action"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="action"/> is <see langword="null" />.</exception>
     public static void ForAll<T>(this IEnumerable<T>? items, Action<T> action)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
@@ -21,7 +21,7 @@ public static partial class EnumerableExtensions
     /// <param name="items">The sequence of elements to iterate over.</param>
     /// <param name="operation">The asynchronous operation to execute for each element.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="operation"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="operation"/> is <see langword="null" />.</exception>
     /// <exception cref="AggregateException">At least one of the executed operations threw an exception.</exception>
     public static async Task ForAllAsync<T>(this IEnumerable<T>? items, Func<T, Task> operation)
     {

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
@@ -10,6 +10,19 @@ using static MooVC.Ensure;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Executes an asynchronous operation for each element in an enumerable sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="items"/>.</typeparam>
+    /// <param name="items">The sequence of elements to iterate over.</param>
+    /// <param name="operation">The asynchronous operation to execute for each element.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="operation"/> is null.
+    /// </exception>
+    /// <exception cref="AggregateException">
+    /// At least one of the executed operations threw an exception.
+    /// </exception>
     public static async Task ForAllAsync<T>(this IEnumerable<T>? items, Func<T, Task> operation)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
@@ -8,6 +8,10 @@ using System.Threading.Tasks;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForAllAsync.cs
@@ -9,7 +9,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -21,12 +21,8 @@ public static partial class EnumerableExtensions
     /// <param name="items">The sequence of elements to iterate over.</param>
     /// <param name="operation">The asynchronous operation to execute for each element.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// <paramref name="operation"/> is null.
-    /// </exception>
-    /// <exception cref="AggregateException">
-    /// At least one of the executed operations threw an exception.
-    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="operation"/> is null.</exception>
+    /// <exception cref="AggregateException">At least one of the executed operations threw an exception.</exception>
     public static async Task ForAllAsync<T>(this IEnumerable<T>? items, Func<T, Task> operation)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
@@ -17,7 +17,7 @@ public static partial class EnumerableExtensions
     /// <typeparam name="T">The type of the elements of <paramref name="items"/>.</typeparam>
     /// <param name="items">The sequence of elements to iterate over.</param>
     /// <param name="action">The action to execute for each element.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="action"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null" />.</exception>
     public static void ForEach<T>(this IEnumerable<T>? items, Action<T> action)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
@@ -7,6 +7,15 @@ using static MooVC.Ensure;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Executes a synchronous action for each element in an enumerable sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="items"/>.</typeparam>
+    /// <param name="items">The sequence of elements to iterate over.</param>
+    /// <param name="action">The action to execute for each element.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="action"/> is null.
+    /// </exception>
     public static void ForEach<T>(this IEnumerable<T>? items, Action<T> action)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ForEach.cs
@@ -6,7 +6,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -17,9 +17,7 @@ public static partial class EnumerableExtensions
     /// <typeparam name="T">The type of the elements of <paramref name="items"/>.</typeparam>
     /// <param name="items">The sequence of elements to iterate over.</param>
     /// <param name="action">The action to execute for each element.</param>
-    /// <exception cref="ArgumentNullException">
-    /// <paramref name="action"/> is null.
-    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is null.</exception>
     public static void ForEach<T>(this IEnumerable<T>? items, Action<T> action)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
@@ -21,7 +21,7 @@ public static partial class EnumerableExtensions
     /// <param name="enumeration">The sequence to search for an element that satisfies the condition.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
     /// <returns>The index of the first element in the sequence that satisfies the condition, or -1 if no such element is found.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null" />.</exception>
     public static int IndexOf<T>(this IEnumerable<T>? enumeration, Func<T, bool> predicate)
     {
         if (enumeration is null)

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
@@ -10,6 +10,18 @@ public static partial class EnumerableExtensions
 {
     private const int Default = -1;
 
+    /// <summary>
+    /// Returns the index of the first element in an enumerable sequence that satisfies a specified condition.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="enumeration"/>.</typeparam>
+    /// <param name="enumeration">The sequence to search for an element that satisfies the condition.</param>
+    /// <param name="predicate">A function to test each element for a condition.</param>
+    /// <returns>
+    /// The index of the first element in the sequence that satisfies the condition, or -1 if no such element is found.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="predicate"/> is null.
+    /// </exception>
     public static int IndexOf<T>(this IEnumerable<T>? enumeration, Func<T, bool> predicate)
     {
         if (enumeration is null)
@@ -23,7 +35,6 @@ public static partial class EnumerableExtensions
             .Select((item, index) => new { Index = index, Item = item })
             .Where(item => predicate(item.Item))
             .Select(item => item.Index)
-            .DefaultIfEmpty(Default)
-            .First();
+            .FirstOrDefault(Default);
     }
 }

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
@@ -6,6 +6,10 @@ using System.Linq;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     private const int Default = -1;

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.IndexOf.cs
@@ -7,7 +7,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -20,12 +20,8 @@ public static partial class EnumerableExtensions
     /// <typeparam name="T">The type of the elements of <paramref name="enumeration"/>.</typeparam>
     /// <param name="enumeration">The sequence to search for an element that satisfies the condition.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
-    /// <returns>
-    /// The index of the first element in the sequence that satisfies the condition, or -1 if no such element is found.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">
-    /// <paramref name="predicate"/> is null.
-    /// </exception>
+    /// <returns>The index of the first element in the sequence that satisfies the condition, or -1 if no such element is found.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is null.</exception>
     public static int IndexOf<T>(this IEnumerable<T>? enumeration, Func<T, bool> predicate)
     {
         if (enumeration is null)

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Process.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Process.cs
@@ -7,14 +7,13 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>
-    /// Synchronously processes the elements of an enumerable sequence, returning the results of the transformation function
-    /// applied to each element.
+    /// Synchronously processes the elements of an enumerable sequence, returning the results of the transformation function applied to each element.
     /// </summary>
     /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Process.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Process.cs
@@ -6,10 +6,15 @@ using System.Linq;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>
-    /// Processes the elements of an enumerable sequence, returning the results of the transformation function applied to each element.
+    /// Synchronously processes the elements of an enumerable sequence, returning the results of the transformation function
+    /// applied to each element.
     /// </summary>
     /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
@@ -40,6 +45,15 @@ public static partial class EnumerableExtensions
         return Enumerable.Empty<TResult>();
     }
 
+    /// <summary>
+    /// Synchronously processes the elements of an enumerable sequence, returning the aggregated results of the transformation function
+    /// applied to each element.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <param name="source">The sequence of elements to transform.</param>
+    /// <param name="transform">The function to apply to each element of the sequence.</param>
+    /// <returns>An enumerable sequence containing the results of the transform function applied to each element of the source sequence.</returns>
     public static IEnumerable<TResult> Process<TResult, TSource>(this IEnumerable<TSource>? source, Func<TSource, IEnumerable<TResult>> transform)
         where TSource : notnull
     {

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Process.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Process.cs
@@ -8,6 +8,14 @@ using static MooVC.Ensure;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Processes the elements of an enumerable sequence, returning the results of the transformation function applied to each element.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <param name="source">The sequence of elements to transform.</param>
+    /// <param name="transform">The function to apply to each element of the sequence.</param>
+    /// <returns>An enumerable sequence containing the results of the transform function applied to each element of the source sequence.</returns>
     public static IEnumerable<TResult> Process<TResult, TSource>(this IEnumerable<TSource>? source, Func<TSource, TResult> transform)
         where TSource : notnull
     {

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAll.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAll.cs
@@ -8,7 +8,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAll.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAll.cs
@@ -7,8 +7,21 @@ using System.Linq;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Asyncrhonously processes the elements of an enumerable sequence, returning the results of the transformation function applied
+    /// to each element.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <param name="source">The sequence of elements to transform.</param>
+    /// <param name="transform">The function to apply to each element of the sequence.</param>
+    /// <returns>An enumerable sequence containing the results of the transform function applied to each element of the source sequence.</returns>
     public static IEnumerable<TResult> ProcessAll<TResult, TSource>(this IEnumerable<TSource>? source, Func<TSource, TResult> transform)
         where TSource : notnull
     {
@@ -33,6 +46,15 @@ public static partial class EnumerableExtensions
         return Enumerable.Empty<TResult>();
     }
 
+    /// <summary>
+    /// Asynchronously processes the elements of an enumerable sequence, returning the aggregated results of the transformation function
+    /// applied to each element.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <param name="source">The sequence of elements to transform.</param>
+    /// <param name="transform">The function to apply to each element of the sequence.</param>
+    /// <returns>An enumerable sequence containing the results of the transform function applied to each element of the source sequence.</returns>
     public static IEnumerable<TResult> ProcessAll<TSource, TResult>(this IEnumerable<TSource>? source, Func<TSource, IEnumerable<TResult>> transform)
         where TSource : notnull
     {

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAll.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAll.cs
@@ -50,8 +50,8 @@ public static partial class EnumerableExtensions
     /// Asynchronously processes the elements of an enumerable sequence, returning the aggregated results of the transformation function
     /// applied to each element.
     /// </summary>
-    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
     /// <param name="source">The sequence of elements to transform.</param>
     /// <param name="transform">The function to apply to each element of the sequence.</param>
     /// <returns>An enumerable sequence containing the results of the transform function applied to each element of the source sequence.</returns>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
@@ -57,8 +57,8 @@ public static partial class EnumerableExtensions
     /// Asyncrhonously processes the elements of an enumerable sequence, returning the aggregate results of the transformation function applied
     /// to each element.
     /// </summary>
-    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
     /// <param name="source">The sequence of elements to transform.</param>
     /// <param name="transform">The function to apply to each element of the sequence.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an enumerable sequence containing

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
@@ -8,8 +8,22 @@ using System.Threading.Tasks;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Asyncrhonously processes the elements of an enumerable sequence, returning the results of the transformation function applied
+    /// to each element.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <param name="source">The sequence of elements to transform.</param>
+    /// <param name="transform">The function to apply to each element of the sequence.</param>
+    /// <returns>A task representing the asynchronous operation. The result of the task is an enumerable sequence containing the results
+    /// of the transform function applied to each element of the source sequence.</returns>
     public static async Task<IEnumerable<TResult>> ProcessAllAsync<TResult, TSource>(
         this IEnumerable<TSource>? source,
         Func<TSource, Task<TResult>> transform)
@@ -39,6 +53,16 @@ public static partial class EnumerableExtensions
         return Enumerable.Empty<TResult>();
     }
 
+    /// <summary>
+    /// Asyncrhonously processes the elements of an enumerable sequence, returning the aggregate results of the transformation function applied
+    /// to each element.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <param name="source">The sequence of elements to transform.</param>
+    /// <param name="transform">The function to apply to each element of the sequence.</param>
+    /// <returns>A task representing the asynchronous operation. The result of the task is an enumerable sequence containing the results
+    /// of the transform function applied to each element of the source sequence.</returns>
     public static async Task<IEnumerable<TResult>> ProcessAllAsync<TSource, TResult>(
         this IEnumerable<TSource>? source,
         Func<TSource, Task<IEnumerable<TResult>>> transform)

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
@@ -22,8 +22,8 @@ public static partial class EnumerableExtensions
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
     /// <param name="source">The sequence of elements to transform.</param>
     /// <param name="transform">The function to apply to each element of the sequence.</param>
-    /// <returns>A task representing the asynchronous operation. The result of the task is an enumerable sequence containing the results
-    /// of the transform function applied to each element of the source sequence.</returns>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an enumerable sequence
+    /// containing the results of the transform function applied to each element of the source sequence.</returns>
     public static async Task<IEnumerable<TResult>> ProcessAllAsync<TResult, TSource>(
         this IEnumerable<TSource>? source,
         Func<TSource, Task<TResult>> transform)
@@ -61,8 +61,8 @@ public static partial class EnumerableExtensions
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
     /// <param name="source">The sequence of elements to transform.</param>
     /// <param name="transform">The function to apply to each element of the sequence.</param>
-    /// <returns>A task representing the asynchronous operation. The result of the task is an enumerable sequence containing the results
-    /// of the transform function applied to each element of the source sequence.</returns>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an enumerable sequence containing
+    /// the results of the transform function applied to each element of the source sequence.</returns>
     public static async Task<IEnumerable<TResult>> ProcessAllAsync<TSource, TResult>(
         this IEnumerable<TSource>? source,
         Func<TSource, Task<IEnumerable<TResult>>> transform)

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ProcessAllAsync.cs
@@ -9,7 +9,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -22,8 +22,11 @@ public static partial class EnumerableExtensions
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
     /// <param name="source">The sequence of elements to transform.</param>
     /// <param name="transform">The function to apply to each element of the sequence.</param>
-    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an enumerable sequence
-    /// containing the results of the transform function applied to each element of the source sequence.</returns>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the asynchronous operation.
+    /// The result of the task is an enumerable sequence containing the results of the transform function applied to each element of the
+    /// source sequence.
+    /// </returns>
     public static async Task<IEnumerable<TResult>> ProcessAllAsync<TResult, TSource>(
         this IEnumerable<TSource>? source,
         Func<TSource, Task<TResult>> transform)
@@ -61,8 +64,11 @@ public static partial class EnumerableExtensions
     /// <typeparam name="TResult">The type of the results of the transform function.</typeparam>
     /// <param name="source">The sequence of elements to transform.</param>
     /// <param name="transform">The function to apply to each element of the sequence.</param>
-    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an enumerable sequence containing
-    /// the results of the transform function applied to each element of the source sequence.</returns>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the asynchronous operation.
+    /// The result of the task is an enumerable sequence containing the results of the transform function applied to each element of the
+    /// source sequence.
+    /// </returns>
     public static async Task<IEnumerable<TResult>> ProcessAllAsync<TSource, TResult>(
         this IEnumerable<TSource>? source,
         Func<TSource, Task<IEnumerable<TResult>>> transform)

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Snapshot.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Snapshot.cs
@@ -7,7 +7,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
@@ -17,8 +17,10 @@ public static partial class EnumerableExtensions
     /// </summary>
     /// <typeparam name="T">The type of the elements of <paramref name="enumerable"/>.</typeparam>
     /// <param name="enumerable">The sequence to take a snapshot of.</param>
-    /// <param name="predicate">An optional function to test each element for a condition. If provided, only elements that satisfy the condition
-    /// will be included in the snapshot.</param>
+    /// <param name="predicate">
+    /// An optional function to test each element for a condition.
+    /// If provided, only elements that satisfy the condition will be included in the snapshot.
+    /// </param>
     /// <returns>An array that contains the elements of the snapshot.</returns>
     public static T[] Snapshot<T>(this IEnumerable<T>? enumerable, Func<T, bool>? predicate = default)
     {
@@ -39,8 +41,10 @@ public static partial class EnumerableExtensions
     /// <typeparam name="TKey">The type of the order key.</typeparam>
     /// <param name="enumerable">The sequence to take a snapshot of.</param>
     /// <param name="order">The function to use to extract the key used to order the snapshot.</param>
-    /// <param name="predicate">An optional function to test each element for a condition. If provided, only elements that satisfy the condition
-    /// will be included in the snapshot.</param>
+    /// <param name="predicate">
+    /// An optional function to test each element for a condition.
+    /// If provided, only elements that satisfy the condition will be included in the snapshot.
+    /// </param>
     /// <returns>An array that contains the elements of the snapshot, ordered by the given key.</returns>
     public static T[] Snapshot<T, TKey>(this IEnumerable<T>? enumerable, Func<T, TKey> order, Func<T, bool>? predicate = default)
     {

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Snapshot.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Snapshot.cs
@@ -8,6 +8,14 @@ using static MooVC.Ensure;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Returns a snapshot of an enumerable sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="enumerable"/>.</typeparam>
+    /// <param name="enumerable">The sequence to take a snapshot of.</param>
+    /// <param name="predicate">An optional function to test each element for a condition. If provided, only elements that satisfy the condition
+    /// will be included in the snapshot.</param>
+    /// <returns>An array that contains the elements of the snapshot.</returns>
     public static T[] Snapshot<T>(this IEnumerable<T>? enumerable, Func<T, bool>? predicate = default)
     {
         if (enumerable is { })
@@ -20,6 +28,16 @@ public static partial class EnumerableExtensions
         return Array.Empty<T>();
     }
 
+    /// <summary>
+    /// Returns a snapshot of an enumerable sequence, ordered by the given key.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="enumerable"/>.</typeparam>
+    /// <typeparam name="TKey">The type of the order key.</typeparam>
+    /// <param name="enumerable">The sequence to take a snapshot of.</param>
+    /// <param name="order">The function to use to extract the key used to order the snapshot.</param>
+    /// <param name="predicate">An optional function to test each element for a condition. If provided, only elements that satisfy the condition
+    /// will be included in the snapshot.</param>
+    /// <returns>An array that contains the elements of the snapshot, ordered by the given key.</returns>
     public static T[] Snapshot<T, TKey>(this IEnumerable<T>? enumerable, Func<T, TKey> order, Func<T, bool>? predicate = default)
     {
         _ = IsNotNull(order, message: EnumerableExtensionsSnapshotOrderRequired);

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.Snapshot.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.Snapshot.cs
@@ -6,6 +6,10 @@ using System.Linq;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ToIndex.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ToIndex.cs
@@ -7,14 +7,14 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>
-    /// Creates a dictionary from an enumerable source by applying a selector function to each element of the source. The selector function
-    /// specifies the key for each element of the resulting dictionary.
+    /// Creates a dictionary from an enumerable source by applying a selector function to each element of the source.
+    /// The selector function specifies the key for each element of the resulting dictionary.
     /// </summary>
     /// <typeparam name="TSubject">The type of elements in the source enumerable.</typeparam>
     /// <typeparam name="TValue">The type of value that the selector function returns.</typeparam>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ToIndex.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ToIndex.cs
@@ -8,12 +8,31 @@ using static MooVC.Ensure;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Creates a dictionary from an enumerable source by applying a selector function to each element of the source. The selector function
+    /// specifies the key for each element of the resulting dictionary.
+    /// </summary>
+    /// <typeparam name="TSubject">The type of elements in the source enumerable.</typeparam>
+    /// <typeparam name="TValue">The type of value that the selector function returns.</typeparam>
+    /// <param name="source">The source enumerable.</param>
+    /// <param name="selector">A function that returns the value for each key in the dictionary.</param>
+    /// <returns>A dictionary that contains the keys and values returned by the selector function.</returns>
     public static IDictionary<TSubject, TValue> ToIndex<TSubject, TValue>(this IEnumerable<TSubject>? source, Func<TSubject, TValue> selector)
         where TSubject : notnull
     {
         return source.ToIndex(selector, value => value);
     }
 
+    /// <summary>
+    /// Maps a dictionary to the specified selector and transform functions, returning the resulting dictionary.
+    /// </summary>
+    /// <typeparam name="TSubject">The type of the elements in the input sequence.</typeparam>
+    /// <typeparam name="TTransform">The type of the value returned by the transform function.</typeparam>
+    /// <typeparam name="TValue">The type of the value returned by the selector function.</typeparam>
+    /// <param name="source">The input sequence.</param>
+    /// <param name="selector">A function that maps each element of the input sequence to a value.</param>
+    /// <param name="transform">A function that maps the result of the selector function to a value of the resulting dictionary.</param>
+    /// <returns>A dictionary containing the results of applying the selector and transform functions to the input sequence.</returns>
     public static IDictionary<TSubject, TTransform> ToIndex<TSubject, TTransform, TValue>(
         this IEnumerable<TSubject>? source,
         Func<TSubject, TValue> selector,

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ToIndex.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ToIndex.cs
@@ -6,6 +6,10 @@ using System.Linq;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ToSpan.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ToSpan.cs
@@ -3,6 +3,10 @@ namespace MooVC.Collections.Generic;
 using System;
 using System.Collections.Generic;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ToSpan.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ToSpan.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.ToSpan.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.ToSpan.cs
@@ -5,6 +5,16 @@ using System.Collections.Generic;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Converts an enumerable sequence to a <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="items"/>.</typeparam>
+    /// <param name="items">The sequence of values to convert.</param>
+    /// <returns>A <see cref="ReadOnlySpan{T}"/> that contains the elements from the input sequence.</returns>
+    /// <remarks>
+    /// If <paramref name="items"/> is null or empty, an empty <see cref="ReadOnlySpan{T}"/> is returned.
+    /// Otherwise, the input sequence is first converted to an array, and then the array is wrapped in a <see cref="ReadOnlySpan{T}"/>.
+    /// </remarks>
     public static ReadOnlySpan<T> ToSpan<T>(this IEnumerable<T>? items)
     {
         if (items is { })

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.WhereIf.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.WhereIf.cs
@@ -7,6 +7,10 @@ using System.Linq;
 using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions relating to IEnumerable{T}.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.WhereIf.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.WhereIf.cs
@@ -8,7 +8,7 @@ using static MooVC.Collections.Generic.Resources;
 using static MooVC.Ensure;
 
 /// <summary>
-/// Provides extensions relating to IEnumerable{T}.
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
 /// </summary>
 /// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions

--- a/src/MooVC/Collections/Generic/EnumerableExtensions.WhereIf.cs
+++ b/src/MooVC/Collections/Generic/EnumerableExtensions.WhereIf.cs
@@ -9,6 +9,18 @@ using static MooVC.Ensure;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Filters a sequence of values based on a predicate if a specified condition is true.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="enumeration"/>.</typeparam>
+    /// <param name="enumeration">The sequence of values to filter.</param>
+    /// <param name="isApplicable">A boolean value indicating whether to apply the filter.</param>
+    /// <param name="predicate">A function to test each element for a condition.</param>
+    /// <returns>An <see cref="IEnumerable{T}"/> that contains elements from the input sequence that satisfy the condition.</returns>
+    /// <remarks>
+    /// If <paramref name="enumeration"/> is null and <paramref name="isApplicable"/> is true, an exception is thrown.
+    /// If <paramref name="isApplicable"/> is false, the input sequence is returned unchanged.
+    /// </remarks>
     [return: NotNullIfNotNull("enumeration")]
     public static IEnumerable<T>? WhereIf<T>(this IEnumerable<T>? enumeration, bool isApplicable, Func<T, bool> predicate)
     {
@@ -22,6 +34,18 @@ public static partial class EnumerableExtensions
         return enumeration;
     }
 
+    /// <summary>
+    /// Filters a sequence of values based on a predicate if a specified condition is true.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of <paramref name="enumeration"/>.</typeparam>
+    /// <param name="enumeration">The sequence of values to filter.</param>
+    /// <param name="condition">A function that returns a boolean value indicating whether to apply the filter.</param>
+    /// <param name="predicate">A function to test each element for a condition.</param>
+    /// <returns>An <see cref="IEnumerable{T}"/> that contains elements from the input sequence that satisfy the condition.</returns>
+    /// <remarks>
+    /// If <paramref name="enumeration"/> is null and the result of <paramref name="condition"/> is true, an exception is thrown.
+    /// If the result of <paramref name="condition"/> is false, the input sequence is returned unchanged.
+    /// </remarks>
     [return: NotNullIfNotNull("enumeration")]
     public static IEnumerable<T>? WhereIf<T>(this IEnumerable<T>? enumeration, Func<bool> condition, Func<T, bool> predicate)
     {

--- a/src/MooVC/Collections/Generic/ObjectExtensions.AsArray.cs
+++ b/src/MooVC/Collections/Generic/ObjectExtensions.AsArray.cs
@@ -2,6 +2,12 @@
 
 public static partial class ObjectExtensions
 {
+    /// <summary>
+    /// Returns an array containing the single specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to be returned in the array.</typeparam>
+    /// <param name="value">The value to be returned in the array.</param>
+    /// <returns>An array containing the single specified value.</returns>
     public static T[] AsArray<T>(this T value)
     {
         return new[] { value };

--- a/src/MooVC/Collections/Generic/ObjectExtensions.AsArray.cs
+++ b/src/MooVC/Collections/Generic/ObjectExtensions.AsArray.cs
@@ -1,5 +1,8 @@
 ﻿namespace MooVC.Collections.Generic;
 
+/// <summary>
+/// Provides extensions relating to object.
+/// </summary>
 public static partial class ObjectExtensions
 {
     /// <summary>

--- a/src/MooVC/Collections/Generic/ObjectExtensions.AsEnumerable.cs
+++ b/src/MooVC/Collections/Generic/ObjectExtensions.AsEnumerable.cs
@@ -4,6 +4,12 @@ using System.Collections.Generic;
 
 public static partial class ObjectExtensions
 {
+    /// <summary>
+    /// Returns an enumerable sequence containing the single specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to be returned in the sequence.</typeparam>
+    /// <param name="value">The value to be returned in the sequence.</param>
+    /// <returns>An enumerable sequence containing the single specified value.</returns>
     public static IEnumerable<T> AsEnumerable<T>(this T value)
     {
         yield return value;

--- a/src/MooVC/Collections/Generic/ObjectExtensions.AsEnumerable.cs
+++ b/src/MooVC/Collections/Generic/ObjectExtensions.AsEnumerable.cs
@@ -2,6 +2,9 @@
 
 using System.Collections.Generic;
 
+/// <summary>
+/// Provides extensions relating to object.
+/// </summary>
 public static partial class ObjectExtensions
 {
     /// <summary>

--- a/src/MooVC/Compression/Compressor.cs
+++ b/src/MooVC/Compression/Compressor.cs
@@ -47,7 +47,7 @@ public abstract class Compressor
     /// Asynchronously decompresses a given sequence of bytes.
     /// </summary>
     /// <param name="data">The sequence of bytes to decompress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
     /// decompressed data as a sequence of bytes.
@@ -66,7 +66,7 @@ public abstract class Compressor
     /// Asynchronously decompresses a given stream of data.
     /// </summary>
     /// <param name="source">The stream of data to decompress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
     /// decompressed data as a stream.

--- a/src/MooVC/Compression/Compressor.cs
+++ b/src/MooVC/Compression/Compressor.cs
@@ -18,10 +18,10 @@ public abstract class Compressor
     /// Compresses the specified data asynchronously.
     /// </summary>
     /// <param name="data">The data to compress.</param>
-    /// <param name="cancellationToken">The cancellation token to use for cancelling the operation.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to use for cancelling the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the
-    /// compressed data as a sequence of bytes.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the compressed data as a sequence of bytes.
     /// </returns>
     public async Task<IEnumerable<byte>> CompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
     {
@@ -37,9 +37,10 @@ public abstract class Compressor
     /// When implemented in a derived class, compresses the specified stream asynchronously.
     /// </summary>
     /// <param name="source">The stream to compress.</param>
-    /// <param name="cancellationToken">The cancellation token to use for cancelling the operation.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to use for cancelling the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the compressed stream.
     /// </returns>
     public abstract Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default);
 
@@ -49,8 +50,8 @@ public abstract class Compressor
     /// <param name="data">The sequence of bytes to decompress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
-    /// decompressed data as a sequence of bytes.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation.
+    /// The task result contains the decompressed data as a sequence of bytes.
     /// </returns>
     public async Task<IEnumerable<byte>> DecompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
     {
@@ -68,8 +69,8 @@ public abstract class Compressor
     /// <param name="source">The stream of data to decompress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
-    /// decompressed data as a stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation.
+    /// The task result contains the decompressed data as a stream.
     /// </returns>
     public abstract Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Compression/Compressor.cs
+++ b/src/MooVC/Compression/Compressor.cs
@@ -1,5 +1,6 @@
 ﻿namespace MooVC.Compression;
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,9 +8,21 @@ using System.Threading;
 using System.Threading.Tasks;
 using MooVC.IO;
 
+/// <summary>
+/// Represents an abstract compressor that provides methods for compressing and decompressing streams of data asynchronously.
+/// </summary>
 public abstract class Compressor
     : ICompressor
 {
+    /// <summary>
+    /// Compresses the specified data asynchronously.
+    /// </summary>
+    /// <param name="data">The data to compress.</param>
+    /// <param name="cancellationToken">The cancellation token to use for cancelling the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the
+    /// compressed data as a sequence of bytes.
+    /// </returns>
     public async Task<IEnumerable<byte>> CompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
     {
         using var source = new MemoryStream(data.ToArray());
@@ -20,8 +33,25 @@ public abstract class Compressor
         return compressed.GetBytes();
     }
 
+    /// <summary>
+    /// When implemented in a derived class, compresses the specified stream asynchronously.
+    /// </summary>
+    /// <param name="source">The stream to compress.</param>
+    /// <param name="cancellationToken">The cancellation token to use for cancelling the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed stream.
+    /// </returns>
     public abstract Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously decompresses a given sequence of bytes.
+    /// </summary>
+    /// <param name="data">The sequence of bytes to decompress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
+    /// decompressed data as a sequence of bytes.
+    /// </returns>
     public async Task<IEnumerable<byte>> DecompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
     {
         using var source = new MemoryStream(data.ToArray());
@@ -32,5 +62,14 @@ public abstract class Compressor
         return decompressed.GetBytes();
     }
 
+    /// <summary>
+    /// Asynchronously decompresses a given stream of data.
+    /// </summary>
+    /// <param name="source">The stream of data to decompress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
+    /// decompressed data as a stream.
+    /// </returns>
     public abstract Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Compression/DeflateCompressor.cs
+++ b/src/MooVC/Compression/DeflateCompressor.cs
@@ -7,16 +7,29 @@ using System.Threading.Tasks;
 using static MooVC.Compression.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Represents a class that uses the Deflate algorithm to compress and decompress streams.
+/// </summary>
 public sealed class DeflateCompressor
     : Compressor
 {
     private readonly CompressionLevel level;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeflateCompressor"/> class.
+    /// </summary>
+    /// <param name="level">The <see cref="CompressionLevel"/> to use for compression and decompression.</param>
     public DeflateCompressor(CompressionLevel level = CompressionLevel.SmallestSize)
     {
         this.level = IsDefined(level, message: DeflateCompressorLevelRequired);
     }
 
+    /// <summary>
+    /// Asynchronously compresses the specified stream using the Deflate algorithm.
+    /// </summary>
+    /// <param name="source">The stream to compress.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation, containing the compressed stream as the result.</returns>
     public override async Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default)
     {
         var result = new MemoryStream();
@@ -30,6 +43,13 @@ public sealed class DeflateCompressor
         return result;
     }
 
+    /// <summary>
+    /// Asynchronously decompresses the specified stream using the Deflate algorithm.
+    /// </summary>
+    /// <param name="source">The stream to decompress.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation, containing the decompressed stream
+    /// as the result.</returns>
     public override async Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = null)
     {
         var result = new MemoryStream();

--- a/src/MooVC/Compression/DeflateCompressor.cs
+++ b/src/MooVC/Compression/DeflateCompressor.cs
@@ -48,8 +48,9 @@ public sealed class DeflateCompressor
     /// </summary>
     /// <param name="source">The stream to decompress.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-    /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation, containing the decompressed stream
-    /// as the result.</returns>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation, containing the decompressed stream as the result.
+    /// </returns>
     public override async Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = null)
     {
         var result = new MemoryStream();

--- a/src/MooVC/Compression/ICompressor.cs
+++ b/src/MooVC/Compression/ICompressor.cs
@@ -14,7 +14,7 @@ public interface ICompressor
     /// Compresses a sequence of bytes asynchronously.
     /// </summary>
     /// <param name="data">The sequence of bytes to compress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed
     /// data as a sequence of bytes.
@@ -25,7 +25,7 @@ public interface ICompressor
     /// Compresses a stream asynchronously.
     /// </summary>
     /// <param name="source">The stream to compress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed
     /// data as a stream.
@@ -36,7 +36,7 @@ public interface ICompressor
     /// Decompresses a sequence of bytes asynchronously.
     /// </summary>
     /// <param name="data">The sequence of bytes to decompress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the decompressed data
     /// as a sequence of bytes.
@@ -47,7 +47,7 @@ public interface ICompressor
     /// Decompresses a stream asynchronously.
     /// </summary>
     /// <param name="source">The stream to decompress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the decompressed data as a stream.
     /// </returns>

--- a/src/MooVC/Compression/ICompressor.cs
+++ b/src/MooVC/Compression/ICompressor.cs
@@ -16,7 +16,8 @@ public interface ICompressor
     /// <param name="data">The sequence of bytes to compress.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the compressed data as a sequence of bytes.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed
+    /// data as a sequence of bytes.
     /// </returns>
     Task<IEnumerable<byte>> CompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default);
 
@@ -26,7 +27,8 @@ public interface ICompressor
     /// <param name="source">The stream to compress.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the compressed data as a stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed
+    /// data as a stream.
     /// </returns>
     Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default);
 
@@ -36,7 +38,8 @@ public interface ICompressor
     /// <param name="data">The sequence of bytes to decompress.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the decompressed data as a sequence of bytes.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the decompressed data
+    /// as a sequence of bytes.
     /// </returns>
     Task<IEnumerable<byte>> DecompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default);
 
@@ -46,7 +49,7 @@ public interface ICompressor
     /// <param name="source">The stream to decompress.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the decompressed data as a stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the decompressed data as a stream.
     /// </returns>
     Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Compression/ICompressor.cs
+++ b/src/MooVC/Compression/ICompressor.cs
@@ -5,13 +5,48 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents a compressor that can compress and decompress data.
+/// </summary>
 public interface ICompressor
 {
+    /// <summary>
+    /// Compresses a sequence of bytes asynchronously.
+    /// </summary>
+    /// <param name="data">The sequence of bytes to compress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the compressed data as a sequence of bytes.
+    /// </returns>
     Task<IEnumerable<byte>> CompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Compresses a stream asynchronously.
+    /// </summary>
+    /// <param name="source">The stream to compress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the compressed data as a stream.
+    /// </returns>
     Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Decompresses a sequence of bytes asynchronously.
+    /// </summary>
+    /// <param name="data">The sequence of bytes to decompress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the decompressed data as a sequence of bytes.
+    /// </returns>
     Task<IEnumerable<byte>> DecompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Decompresses a stream asynchronously.
+    /// </summary>
+    /// <param name="source">The stream to decompress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the decompressed data as a stream.
+    /// </returns>
     Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Compression/ICompressor.cs
+++ b/src/MooVC/Compression/ICompressor.cs
@@ -16,8 +16,8 @@ public interface ICompressor
     /// <param name="data">The sequence of bytes to compress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed
-    /// data as a sequence of bytes.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the compressed data as a sequence of bytes.
     /// </returns>
     Task<IEnumerable<byte>> CompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default);
 
@@ -27,8 +27,8 @@ public interface ICompressor
     /// <param name="source">The stream to compress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the compressed
-    /// data as a stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the compressed data as a stream.
     /// </returns>
     Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default);
 
@@ -38,8 +38,8 @@ public interface ICompressor
     /// <param name="data">The sequence of bytes to decompress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the decompressed data
-    /// as a sequence of bytes.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the decompressed data as a sequence of bytes.
     /// </returns>
     Task<IEnumerable<byte>> DecompressAsync(IEnumerable<byte> data, CancellationToken? cancellationToken = default);
 
@@ -49,7 +49,8 @@ public interface ICompressor
     /// <param name="source">The stream to decompress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the decompressed data as a stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the decompressed data as a stream.
     /// </returns>
     Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Compression/SynchronousCompressor.cs
+++ b/src/MooVC/Compression/SynchronousCompressor.cs
@@ -4,20 +4,51 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Abstract base class for implementing a synchronous data compressor.
+/// </summary>
 public abstract class SynchronousCompressor
     : Compressor
 {
+    /// <summary>
+    /// Asynchronously compresses a given stream of data.
+    /// </summary>
+    /// <param name="source">The stream of data to compress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous compression operation. The task result contains the
+    /// compressed data as a stream.
+    /// </returns>
     public override Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default)
     {
         return Task.FromResult(PerformCompress(source));
     }
 
+    /// <summary>
+    /// Asynchronously decompresses a given stream of data.
+    /// </summary>
+    /// <param name="source">The stream of data to decompress.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
+    /// decompressed data as a stream.
+    /// </returns>
     public override Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = default)
     {
         return Task.FromResult(PerformDecompress(source));
     }
 
+    /// <summary>
+    /// When implemented in a derived class, performs the compression of the given stream and returns the result as a new stream.
+    /// </summary>
+    /// <param name="source">The stream to compress.</param>
+    /// <returns>The compressed stream.</returns>
     protected abstract Stream PerformCompress(Stream source);
 
+    /// <summary>
+    /// When implemented in a derived class, performs the decompression of the given stream and returns the result as a new stream.
+    /// </summary>
+    /// <param name="source">The stream to decompress.</param>
+    /// <returns>The decompressed stream.</returns>
     protected abstract Stream PerformDecompress(Stream source);
 }

--- a/src/MooVC/Compression/SynchronousCompressor.cs
+++ b/src/MooVC/Compression/SynchronousCompressor.cs
@@ -16,8 +16,8 @@ public abstract class SynchronousCompressor
     /// <param name="source">The stream of data to compress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous compression operation. The task result contains the
-    /// compressed data as a stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous compression operation.
+    /// The task result contains the compressed data as a stream.
     /// </returns>
     public override Task<Stream> CompressAsync(Stream source, CancellationToken? cancellationToken = default)
     {
@@ -30,8 +30,8 @@ public abstract class SynchronousCompressor
     /// <param name="source">The stream of data to decompress.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
-    /// decompressed data as a stream.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation.
+    /// The task result contains the decompressed data as a stream.
     /// </returns>
     public override Task<Stream> DecompressAsync(Stream source, CancellationToken? cancellationToken = default)
     {

--- a/src/MooVC/Compression/SynchronousCompressor.cs
+++ b/src/MooVC/Compression/SynchronousCompressor.cs
@@ -14,7 +14,7 @@ public abstract class SynchronousCompressor
     /// Asynchronously compresses a given stream of data.
     /// </summary>
     /// <param name="source">The stream of data to compress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous compression operation. The task result contains the
     /// compressed data as a stream.
@@ -28,7 +28,7 @@ public abstract class SynchronousCompressor
     /// Asynchronously decompresses a given stream of data.
     /// </summary>
     /// <param name="source">The stream of data to decompress.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous decompression operation. The task result contains the
     /// decompressed data as a stream.

--- a/src/MooVC/DateTimeExtensions.Max.cs
+++ b/src/MooVC/DateTimeExtensions.Max.cs
@@ -4,9 +4,15 @@ using System;
 
 public static partial class DateTimeExtensions
 {
+    /// <summary>
+    /// Returns the maximum of two dates.
+    /// </summary>
+    /// <param name="first">The first date to compare.</param>
+    /// <param name="second">The second date to compare.</param>
+    /// <returns>The later of the two dates.</returns>
     public static DateTime Max(this DateTime first, DateTime second)
     {
-        return first > second
+        return first.Ticks > second.Ticks
             ? first
             : second;
     }

--- a/src/MooVC/DateTimeExtensions.Max.cs
+++ b/src/MooVC/DateTimeExtensions.Max.cs
@@ -2,6 +2,9 @@
 
 using System;
 
+/// <summary>
+/// Provides the Max extension for <see cref="DateTime"/>.
+/// </summary>
 public static partial class DateTimeExtensions
 {
     /// <summary>

--- a/src/MooVC/DateTimeExtensions.Min.cs
+++ b/src/MooVC/DateTimeExtensions.Min.cs
@@ -2,6 +2,9 @@
 
 using System;
 
+/// <summary>
+/// Provides the Min extension for <see cref="DateTime"/>.
+/// </summary>
 public static partial class DateTimeExtensions
 {
     /// <summary>

--- a/src/MooVC/DateTimeExtensions.Min.cs
+++ b/src/MooVC/DateTimeExtensions.Min.cs
@@ -4,9 +4,15 @@ using System;
 
 public static partial class DateTimeExtensions
 {
+    /// <summary>
+    /// Returns the minimum of two dates.
+    /// </summary>
+    /// <param name="first">The first date to compare.</param>
+    /// <param name="second">The second date to compare.</param>
+    /// <returns>The earlier of the two dates.</returns>
     public static DateTime Min(this DateTime first, DateTime second)
     {
-        return first > second
+        return first.Ticks > second.Ticks
             ? second
             : first;
     }

--- a/src/MooVC/DateTimeOffsetExtensions.Max.cs
+++ b/src/MooVC/DateTimeOffsetExtensions.Max.cs
@@ -2,6 +2,9 @@
 
 using System;
 
+/// <summary>
+/// Provides the Max extension for <see cref="DateTimeOffset"/>.
+/// </summary>
 public static partial class DateTimeOffsetExtensions
 {
     /// <summary>

--- a/src/MooVC/DateTimeOffsetExtensions.Max.cs
+++ b/src/MooVC/DateTimeOffsetExtensions.Max.cs
@@ -4,9 +4,15 @@ using System;
 
 public static partial class DateTimeOffsetExtensions
 {
+    /// <summary>
+    /// Returns the maximum of two dates.
+    /// </summary>
+    /// <param name="first">The first date to compare.</param>
+    /// <param name="second">The second date to compare.</param>
+    /// <returns>The later of the two dates.</returns>
     public static DateTimeOffset Max(this DateTimeOffset first, DateTimeOffset second)
     {
-        return first > second
+        return first.Ticks > second.Ticks
             ? first
             : second;
     }

--- a/src/MooVC/DateTimeOffsetExtensions.Min.cs
+++ b/src/MooVC/DateTimeOffsetExtensions.Min.cs
@@ -2,6 +2,9 @@
 
 using System;
 
+/// <summary>
+/// Provides the Min extension for <see cref="DateTimeOffset"/>.
+/// </summary>
 public static partial class DateTimeOffsetExtensions
 {
     /// <summary>

--- a/src/MooVC/DateTimeOffsetExtensions.Min.cs
+++ b/src/MooVC/DateTimeOffsetExtensions.Min.cs
@@ -4,9 +4,15 @@ using System;
 
 public static partial class DateTimeOffsetExtensions
 {
+    /// <summary>
+    /// Returns the minimum of two dates.
+    /// </summary>
+    /// <param name="first">The first date to compare.</param>
+    /// <param name="second">The second date to compare.</param>
+    /// <returns>The earlier of the two dates.</returns>
     public static DateTimeOffset Min(this DateTimeOffset first, DateTimeOffset second)
     {
-        return first > second
+        return first.Ticks > second.Ticks
             ? second
             : first;
     }

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
@@ -61,7 +61,7 @@ public sealed class DiagnosticsEmittedAsyncEventArgs
     }
 
     /// <summary>
-    /// Get the <see cref="Exception" /> that caused the emission of the event, if any.
+    /// Gets the <see cref="Exception" /> that caused the emission of the event, if any.
     /// </summary>
     /// <value>
     /// The <see cref="Exception" /> that caused the emission of the event, if any.

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
@@ -94,7 +94,7 @@ public sealed class DiagnosticsEmittedAsyncEventArgs
 
     /// <summary>
     /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
-    /// of the <see cref="DiagnosticsMessage"/> class.
+    /// of the <see cref="DiagnosticsEmittedAsyncEventArgs"/> class.
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
@@ -8,11 +8,24 @@ using static System.String;
 using static MooVC.Diagnostics.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Represents the event data for the <see cref="IEmitDiagnostics.DiagnosticsEmitted" /> event.
+/// </summary>
 [Serializable]
 public sealed class DiagnosticsEmittedAsyncEventArgs
     : AsyncEventArgs,
       ISerializable
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticsEmittedAsyncEventArgs" /> class.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// An optional <see cref="CancellationToken" /> that can be used to cancel the operation that raised the event.
+    /// </param>
+    /// <param name="cause">An optional <see cref="Exception" /> that caused the emission of the event.</param>
+    /// <param name="impact">An optional perceived <see cref="Impact" /> of the event from the perspective of the source.</param>
+    /// <param name="level">An optional perceived <see cref="Level" /> of the event from the perspective of the source.</param>
+    /// <param name="message">An optional <see cref="DiagnosticsMessage" /> providing a friendly description of the event.</param>
     public DiagnosticsEmittedAsyncEventArgs(
         CancellationToken? cancellationToken = default,
         Exception? cause = default,
@@ -32,6 +45,12 @@ public sealed class DiagnosticsEmittedAsyncEventArgs
         Cause = cause;
     }
 
+    /// <summary>
+    /// Supports deserialization of an instance of the <see cref="DiagnosticsEmittedAsyncEventArgs"/> class
+    /// via the specified <paramref name="info"/> and <paramref name="context"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
     private DiagnosticsEmittedAsyncEventArgs(SerializationInfo info, StreamingContext context)
         : base(default)
     {
@@ -41,14 +60,44 @@ public sealed class DiagnosticsEmittedAsyncEventArgs
         Message = info.TryGetValue(nameof(Message), defaultValue: DiagnosticsMessage.Empty);
     }
 
+    /// <summary>
+    /// Get the <see cref="Exception" /> that caused the emission of the event, if any.
+    /// </summary>
+    /// <value>
+    /// The <see cref="Exception" /> that caused the emission of the event, if any.
+    /// </value>
     public Exception? Cause { get; }
 
+    /// <summary>
+    /// Gets the perceived <see cref="Impact" /> of the event from the perspective of the source.
+    /// </summary>
+    /// <value>
+    /// The perceived <see cref="Impact" /> of the event from the perspective of the source.
+    /// </value>
     public Impact Impact { get; } = Impact.None;
 
+    /// <summary>
+    /// Gets the perceived <see cref="Level" /> of the event from the perspective of the source.
+    /// </summary>
+    /// <value>
+    /// The perceived <see cref="Level" /> of the event from the perspective of the source.
+    /// </value>
     public Level Level { get; } = Level.Trace;
 
+    /// <summary>
+    /// Gets the <see cref="DiagnosticsMessage" /> providing a friendly description of the event.
+    /// </summary>
+    /// <value>
+    /// The <see cref="DiagnosticsMessage" /> providing a friendly description of the event.
+    /// </value>
     public DiagnosticsMessage Message { get; }
 
+    /// <summary>
+    /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
+    /// of the <see cref="DiagnosticsMessage"/> class.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
+    /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         _ = info.TryAddValue(nameof(Cause), Cause);

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventArgs.cs
@@ -51,6 +51,8 @@ public sealed class DiagnosticsEmittedAsyncEventArgs
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
     /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     private DiagnosticsEmittedAsyncEventArgs(SerializationInfo info, StreamingContext context)
         : base(default)
     {
@@ -98,6 +100,8 @@ public sealed class DiagnosticsEmittedAsyncEventArgs
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         _ = info.TryAddValue(nameof(Cause), Cause);

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventHandler.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventHandler.cs
@@ -7,5 +7,5 @@ using System.Threading.Tasks;
 /// </summary>
 /// <param name="sender">The object that raised the event.</param>
 /// <param name="e">An object containing information about the diagnostics.</param>
-/// <returns>A task representing the asynchronous operation.</returns>
+/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 public delegate Task DiagnosticsEmittedAsyncEventHandler(IEmitDiagnostics sender, DiagnosticsEmittedAsyncEventArgs e);

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventHandler.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedAsyncEventHandler.cs
@@ -2,4 +2,10 @@
 
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents the method that will handle the <see cref="IEmitDiagnostics.DiagnosticsEmitted"/> event.
+/// </summary>
+/// <param name="sender">The object that raised the event.</param>
+/// <param name="e">An object containing information about the diagnostics.</param>
+/// <returns>A task representing the asynchronous operation.</returns>
 public delegate Task DiagnosticsEmittedAsyncEventHandler(IEmitDiagnostics sender, DiagnosticsEmittedAsyncEventArgs e);

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedEventArgsExtensions.Throw.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedEventArgsExtensions.Throw.cs
@@ -30,8 +30,10 @@ public static class DiagnosticsEmittedEventArgsExtensions
     /// Throws an <see cref="AggregateException"/> if any emitted diagnostics match the specified <see cref="predicate"/>.
     /// </summary>
     /// <param name="diagnostics">The collection of <see cref="DiagnosticsEmittedAsyncEventArgs"/> objects to evaluate.</param>
-    /// <param name="predicate">A function to test each diagnostics for a condition. Only diagnostics that satisfy the condition will
-    /// be included in the <see cref="AggregateException"/>.</param>
+    /// <param name="predicate">
+    /// A function to test each diagnostics for a condition. Only diagnostics that satisfy the condition will be included in the
+    /// <see cref="AggregateException"/>.
+    /// </param>
     /// <param name="message">An optional message to include in the thrown <see cref="AggregateException"/>.</param>
     /// <exception cref="AggregateException">Thrown if one or more diagnostics satisfy the specified <see cref="predicate"/>.</exception>
     public static void Throw(

--- a/src/MooVC/Diagnostics/DiagnosticsEmittedEventArgsExtensions.Throw.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsEmittedEventArgsExtensions.Throw.cs
@@ -6,8 +6,18 @@ using System.Linq;
 using static MooVC.Diagnostics.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extension methods for the <see cref="DiagnosticsEmittedEventArgs"/> class.
+/// </summary>
 public static class DiagnosticsEmittedEventArgsExtensions
 {
+    /// <summary>
+    /// Throws an <see cref="AggregateException"/> if any emitted diagnostics are equal to or greater in severity to the
+    /// specified <see cref="Level"/>.
+    /// </summary>
+    /// <param name="diagnostics">The collection of <see cref="DiagnosticsEmittedAsyncEventArgs"/> objects to evaluate.</param>
+    /// <param name="level">The minimum <see cref="Level"/> required for a diagnostic to be considered a match.</param>
+    /// <param name="message">An optional message to include in the thrown <see cref="AggregateException"/>.</param>
     public static void Throw(
         this IEnumerable<DiagnosticsEmittedAsyncEventArgs>? diagnostics,
         Level level = Level.Warning,
@@ -16,6 +26,14 @@ public static class DiagnosticsEmittedEventArgsExtensions
         diagnostics.Throw((diagnostic, _) => diagnostic.Level >= level, message: message);
     }
 
+    /// <summary>
+    /// Throws an <see cref="AggregateException"/> if any emitted diagnostics match the specified <see cref="predicate"/>.
+    /// </summary>
+    /// <param name="diagnostics">The collection of <see cref="DiagnosticsEmittedAsyncEventArgs"/> objects to evaluate.</param>
+    /// <param name="predicate">A function to test each diagnostics for a condition. Only diagnostics that satisfy the condition will
+    /// be included in the <see cref="AggregateException"/>.</param>
+    /// <param name="message">An optional message to include in the thrown <see cref="AggregateException"/>.</param>
+    /// <exception cref="AggregateException">Thrown if one or more diagnostics satisfy the specified <see cref="predicate"/>.</exception>
     public static void Throw(
         this IEnumerable<DiagnosticsEmittedAsyncEventArgs>? diagnostics,
         Func<DiagnosticsEmittedAsyncEventArgs, Exception, bool> predicate,

--- a/src/MooVC/Diagnostics/DiagnosticsMessage.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsMessage.cs
@@ -203,8 +203,6 @@ public sealed class DiagnosticsMessage
                        (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
-        info.AddEnumerable(nameof(Arguments), Arguments);
-
         _ = info.TryAddEnumerable(nameof(Arguments), Arguments);
         _ = info.TryAddString(nameof(Description), Description);
     }

--- a/src/MooVC/Diagnostics/DiagnosticsMessage.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsMessage.cs
@@ -14,6 +14,10 @@ using static MooVC.Ensure;
 /// <summary>
 /// Represents a friendly message relating to a diagnostics event.
 /// </summary>
+/// /// <remarks>
+/// This class implements <see cref="ISerializable"/> and <see cref="IEquatable{T}"/> for string.
+/// It also defines several implicit operators for converting between different types.
+/// </remarks>
 [Serializable]
 public sealed class DiagnosticsMessage
     : ISerializable,
@@ -86,13 +90,18 @@ public sealed class DiagnosticsMessage
     public string Description { get; } = string.Empty;
 
     /// <summary>
-    /// Gets the flag which indicates whether or not the current instance is the default instance.
+    /// Gets a value indicating whether or not the current instance is the default instance.
     /// </summary>
     /// <value>
-    /// The flag which indicates whether or not the current instance is the default instance.
+    /// The value indicating whether or not the current instance is the default instance.
     /// </value>
     public bool IsEmpty => this == Empty;
 
+    /// <summary>
+    /// Converts a <see cref="DiagnosticsMessage"/> to an array of objects, using the arguments of the message as its basis.
+    /// </summary>
+    /// <param name="message">The message to be converted.</param>
+    /// <returns>An array of objects representing the arguments in the message.</returns>
     public static implicit operator object[](DiagnosticsMessage? message)
     {
         if (message is null)
@@ -103,6 +112,11 @@ public sealed class DiagnosticsMessage
         return message.Arguments.ToArray();
     }
 
+    /// <summary>
+    /// Converts a string to a <see cref="DiagnosticsMessage"/>.
+    /// </summary>
+    /// <param name="description">The string to be converted.</param>
+    /// <returns>A <see cref="DiagnosticsMessage"/> with the given description and no arguments.</returns>
     public static implicit operator DiagnosticsMessage(string? description)
     {
         if (IsNullOrWhiteSpace(description))
@@ -113,21 +127,41 @@ public sealed class DiagnosticsMessage
         return new DiagnosticsMessage(description);
     }
 
+    /// <summary>
+    /// Converts a tuple of a string and an object to a <see cref="DiagnosticsMessage"/>.
+    /// </summary>
+    /// <param name="message">The tuple to be converted. The string represents the description, and the object represents the first argument.</param>
+    /// <returns>A <see cref="DiagnosticsMessage"/> with the given description and the given argument.</returns>
     public static implicit operator DiagnosticsMessage((string Description, object Argument1) message)
     {
         return (message.Description, new[] { message.Argument1 });
     }
 
+    /// <summary>
+    /// Converts a tuple of a string and two objects to a <see cref="DiagnosticsMessage"/>.
+    /// </summary>
+    /// <param name="message">The tuple to be converted. The string represents the description, and the objects represent the arguments.</param>
+    /// <returns>A <see cref="DiagnosticsMessage"/> with the given description and the given arguments.</returns>
     public static implicit operator DiagnosticsMessage((string Description, object Argument1, object Argument2) message)
     {
         return (message.Description, new[] { message.Argument1, message.Argument2 });
     }
 
+    /// <summary>
+    /// Converts a tuple of a string and three objects to a <see cref="DiagnosticsMessage"/>.
+    /// </summary>
+    /// <param name="message">The tuple to be converted. The string represents the description, and the objects represent the arguments.</param>
+    /// <returns>A <see cref="DiagnosticsMessage"/> with the given description and the given arguments.</returns>
     public static implicit operator DiagnosticsMessage((string Description, object Argument1, object Argument2, object Argument3) message)
     {
         return (message.Description, new[] { message.Argument1, message.Argument2, message.Argument3 });
     }
 
+    /// <summary>
+    /// Converts a tuple of a string and an array of objects to a <see cref="DiagnosticsMessage"/>.
+    /// </summary>
+    /// <param name="message">The tuple to be converted. The string represents the description, and the objects represent the arguments.</param>
+    /// <returns>A <see cref="DiagnosticsMessage"/> with the given description and the given arguments.</returns>
     public static implicit operator DiagnosticsMessage((string Description, object[] Arguments) message)
     {
         if (IsNullOrWhiteSpace(message.Description) && message.Arguments.IsEmpty())
@@ -138,6 +172,11 @@ public sealed class DiagnosticsMessage
         return new DiagnosticsMessage(message.Description, message.Arguments);
     }
 
+    /// <summary>
+    /// Converts a <see cref="DiagnosticsMessage"/> to a string.
+    /// </summary>
+    /// <param name="message">The message to be converted.</param>
+    /// <returns>A string representation of the rendered message.</returns>
     public static implicit operator string(DiagnosticsMessage? message)
     {
         if (message is null)
@@ -148,16 +187,33 @@ public sealed class DiagnosticsMessage
         return message.ToString();
     }
 
+    /// <summary>
+    /// Determines if a <see cref="DiagnosticsMessage"/> is equal to a string.
+    /// </summary>
+    /// <param name="message">The message to be compared.</param>
+    /// <param name="value">The string to be compared.</param>
+    /// <returns><c>true</c> if the rendered message is equal to the string; <c>false</c> otherwise.</returns>
     public static bool operator ==(DiagnosticsMessage message, string? value)
     {
         return message.Equals(value);
     }
 
+    /// <summary>
+    /// Determines if a <see cref="DiagnosticsMessage"/> is not equal to a string.
+    /// </summary>
+    /// <param name="message">The message to be compared.</param>
+    /// <param name="value">The string to be compared.</param>
+    /// <returns><c>true</c> if the rendered message is not equal to the string; <c>false</c> otherwise.</returns>
     public static bool operator !=(DiagnosticsMessage message, string? value)
     {
         return !message.Equals(value);
     }
 
+    /// <summary>
+    /// Determines if this instance is equal to another object.
+    /// </summary>
+    /// <param name="other">The object to be compared.</param>
+    /// <returns><c>true</c> if the object is equal to this instance; <c>false</c> otherwise.</returns>
     public override bool Equals(object? other)
     {
         if (other is string @string)
@@ -173,6 +229,11 @@ public sealed class DiagnosticsMessage
         return false;
     }
 
+    /// <summary>
+    /// Determines if this instance is equal to another string.
+    /// </summary>
+    /// <param name="other">The string to be compared.</param>
+    /// <returns><c>true</c> if the stirng is equal to this rendered instance; <c>false</c> otherwise.</returns>
     public bool Equals(string? other)
     {
         if (other is null)

--- a/src/MooVC/Diagnostics/DiagnosticsMessage.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsMessage.cs
@@ -31,7 +31,7 @@ public sealed class DiagnosticsMessage
     /// </summary>
     /// <param name="description">The friendly description of the event.</param>
     /// <param name="arguments">The arguments relating to the friendly description of the event.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="description"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="description"/> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">The <paramref name="description"/> is whitespace.</exception>
     public DiagnosticsMessage(string description, params object[] arguments)
         : this()

--- a/src/MooVC/Diagnostics/DiagnosticsMessage.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsMessage.cs
@@ -26,6 +26,12 @@ public sealed class DiagnosticsMessage
         Arguments = arguments.Snapshot();
     }
 
+    /// <summary>
+    /// Supports deserialization of an instance of the <see cref="DiagnosticsMessage"/> class
+    /// via the specified <paramref name="info"/> and <paramref name="context"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
     private DiagnosticsMessage(SerializationInfo info, StreamingContext context)
         : this()
     {
@@ -144,6 +150,12 @@ public sealed class DiagnosticsMessage
             .GetHashCode();
     }
 
+    /// <summary>
+    /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
+    /// of the <see cref="DiagnosticsMessage"/> class.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
+    /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         _ = info.TryAddEnumerable(nameof(Arguments), Arguments);

--- a/src/MooVC/Diagnostics/DiagnosticsMessage.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsMessage.cs
@@ -11,6 +11,9 @@ using static System.String;
 using static MooVC.Diagnostics.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Represents a friendly message relating to a diagnostics event.
+/// </summary>
 [Serializable]
 public sealed class DiagnosticsMessage
     : ISerializable,
@@ -19,6 +22,13 @@ public sealed class DiagnosticsMessage
     private static readonly Lazy<DiagnosticsMessage> empty = new(() => new DiagnosticsMessage());
     private readonly Lazy<string> @string;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticsMessage"/> class.
+    /// </summary>
+    /// <param name="description">The friendly description of the event.</param>
+    /// <param name="arguments">The arguments relating to the friendly description of the event.</param>
+    /// <exception cref="ArgumentNullException">The <paramref name="description"/> is null.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="description"/> is whitespace.</exception>
     public DiagnosticsMessage(string description, params object[] arguments)
         : this()
     {
@@ -32,6 +42,8 @@ public sealed class DiagnosticsMessage
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
     /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     private DiagnosticsMessage(SerializationInfo info, StreamingContext context)
         : this()
     {
@@ -41,17 +53,44 @@ public sealed class DiagnosticsMessage
         @string = new(GetString);
     }
 
+    /// <summary>
+    /// Initializes a default instance of the <see cref="DiagnosticsMessage"/> class.
+    /// </summary>
     private DiagnosticsMessage()
     {
         @string = new(GetString);
     }
 
+    /// <summary>
+    /// Gets the default instance of the <see cref="DiagnosticsMessage"/> class.
+    /// </summary>
+    /// <value>
+    /// The default instance of the <see cref="DiagnosticsMessage"/> class.
+    /// </value>
     public static DiagnosticsMessage Empty => empty.Value;
 
+    /// <summary>
+    /// Gets the arguments relating to the friendly description of the event.
+    /// </summary>
+    /// <value>
+    /// The arguments relating to the friendly description of the event.
+    /// </value>
     public IEnumerable<object> Arguments { get; } = Enumerable.Empty<object>();
 
+    /// <summary>
+    /// Gets the friendly description of the event.
+    /// </summary>
+    /// <value>
+    /// The friendly description of the event.
+    /// </value>
     public string Description { get; } = string.Empty;
 
+    /// <summary>
+    /// Gets the flag which indicates whether or not the current instance is the default instance.
+    /// </summary>
+    /// <value>
+    /// The flag which indicates whether or not the current instance is the default instance.
+    /// </value>
     public bool IsEmpty => this == Empty;
 
     public static implicit operator object[](DiagnosticsMessage? message)
@@ -144,6 +183,10 @@ public sealed class DiagnosticsMessage
         return ToString() == other;
     }
 
+    /// <summary>
+    /// Gets the hash code associated with the instance of <see cref="DiagnosticsMessage"/>.
+    /// </summary>
+    /// <returns>The hash code associated with the instance of <see cref="DiagnosticsMessage"/>.</returns>
     public override int GetHashCode()
     {
         return ToString()
@@ -156,17 +199,29 @@ public sealed class DiagnosticsMessage
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
+        info.AddEnumerable(nameof(Arguments), Arguments);
+
         _ = info.TryAddEnumerable(nameof(Arguments), Arguments);
         _ = info.TryAddString(nameof(Description), Description);
     }
 
+    /// <summary>
+    /// Gets the friendly description of the event formatted with the arguments provided, if any.
+    /// </summary>
+    /// <returns>The friendly description of the event formatted with the arguments provided, if any.</returns>
     public override string ToString()
     {
         return @string.Value;
     }
 
+    /// <summary>
+    /// Formats the friendly description of the event with the arguments provided, if any.
+    /// </summary>
+    /// <returns>The friendly description of the event formatted with the arguments provided, if any.</returns>
     private string GetString()
     {
         if (Arguments.Any())

--- a/src/MooVC/Diagnostics/DiagnosticsProxy.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsProxy.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents a default implementation of the <see cref="IDiagnosticsProxy"/> interface, used for emitting diagnostics messages.
+/// </summary>
 public sealed class DiagnosticsProxy
     : IDiagnosticsProxy
 {
@@ -20,15 +23,33 @@ public sealed class DiagnosticsProxy
 
     private readonly IDictionary<Impact, Level> defaults;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticsProxy"/> class with the specified default impact-level mappings.
+    /// </summary>
+    /// <param name="defaults">The default impact-level mappings to use. If not provided, a standard set of mappings will be used.</param>
     public DiagnosticsProxy(IDictionary<Impact, Level>? defaults = default)
     {
         this.defaults = defaults ?? standard;
     }
 
+    /// <summary>
+    /// An event that is raised when an diagnostic related occurance is encountered.
+    /// </summary>
     public event DiagnosticsEmittedAsyncEventHandler? DiagnosticsEmitted;
 
+    /// <summary>
+    /// Gets the default <see cref="DiagnosticsProxy"/> instance.
+    /// </summary>
+    /// <value>
+    /// The default <see cref="DiagnosticsProxy"/> instance.
+    /// </value>
     public static DiagnosticsProxy Default => @default.Value;
 
+    /// <summary>
+    /// Gets the diagnostic level assigned by the proxy based on the perceived impact.
+    /// </summary>
+    /// <param name="impact">The perceived <see cref="Impact" /> of the event.</param>
+    /// <returns>The diagnostic level assigned by the proxy based on the perceived impact.</returns>
     public Level this[Impact impact]
     {
         get
@@ -42,6 +63,19 @@ public sealed class DiagnosticsProxy
         }
     }
 
+    /// <summary>
+    /// Emits a diagnostic event asynchronously if the proxy deems it appropriate.
+    /// </summary>
+    /// <param name="source">The object emitting the event for the purpose of diagnostics.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <param name="cause">The <see cref="Exception" /> that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="impact">The perceived <see cref="Impact" /> of the event from the perspective of the <paramref name="source"/>.</param>
+    /// <param name="level">The perceived <see cref="Level" /> of the event from the perspective of the <paramref name="source"/>.</param>
+    /// <param name="message">A <see cref="DiagnosticsMessage" />, providing a friendly description of the event, if any.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the asynchronous operation.
+    /// The result of the task is an object containing information about the emitted diagnostic message, or null if the message was not emitted.
+    /// </returns>
     public async Task<DiagnosticsEmittedAsyncEventArgs?> TryEmitAsync(
         IEmitDiagnostics source,
         CancellationToken? cancellationToken = default,

--- a/src/MooVC/Diagnostics/DiagnosticsRelay.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelay.cs
@@ -6,20 +6,47 @@ using System.Threading.Tasks;
 using static MooVC.Diagnostics.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Represents an object that can receive and relay diagnostic events on behalf of another object.
+/// </summary>
 public sealed class DiagnosticsRelay
     : IDiagnosticsRelay
 {
     private readonly IDiagnosticsProxy diagnostics;
     private readonly IEmitDiagnostics source;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticsRelay"/> class.
+    /// </summary>
+    /// <param name="source">The source that will be associated with the events emitted by the relay.</param>
+    /// <param name="diagnostics">
+    /// The proxy that determines if diagnostics are to be emitted, with the default configuration used if not provided.
+    /// </param>
+    /// <exception cref="ArgumentNullException">The <paramref name="source"/> is null.</exception>
     public DiagnosticsRelay(IEmitDiagnostics source, IDiagnosticsProxy? diagnostics = default)
     {
         this.source = IsNotNull(source, message: DiagnosticsEmitterSourceRequired);
         this.diagnostics = diagnostics ?? DiagnosticsProxy.Default;
     }
 
+    /// <summary>
+    /// An event that is raised when a relevant diagnostic related occurance is encountered.
+    /// </summary>
     public event DiagnosticsEmittedAsyncEventHandler? DiagnosticsEmitted;
 
+    /// <summary>
+    /// Emits a diagnostic event asynchronously if the event is deemed relevant by the configuration associated with the proxy.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <param name="cause">The <see cref="Exception" /> that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="impact">
+    /// The perceived <see cref="Impact" /> of the event from the perspective of the source for which this relay is acting.
+    /// </param>
+    /// <param name="level">
+    /// The perceived <see cref="Level" /> of the event from the perspective of the source for which this relay is acting.
+    /// </param>
+    /// <param name="message">An optional <see cref="DiagnosticsMessage" />, providing a friendly description of the event.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task EmitAsync(
         CancellationToken? cancellationToken = default,
         Exception? cause = default,

--- a/src/MooVC/Diagnostics/DiagnosticsRelay.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelay.cs
@@ -22,7 +22,7 @@ public sealed class DiagnosticsRelay
     /// <param name="diagnostics">
     /// The proxy that determines if diagnostics are to be emitted, with the default configuration used if not provided.
     /// </param>
-    /// <exception cref="ArgumentNullException">The <paramref name="source"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="source"/> is <see langword="null" />.</exception>
     public DiagnosticsRelay(IEmitDiagnostics source, IDiagnosticsProxy? diagnostics = default)
     {
         this.source = IsNotNull(source, message: DiagnosticsEmitterSourceRequired);

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Critical.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Critical.cs
@@ -3,8 +3,17 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Provides extensions to support emission of critical diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Emits a critical diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Critical(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         await diagnostics
@@ -12,6 +21,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a critical diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Critical(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,
@@ -23,6 +39,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a critical diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Critical(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         await diagnostics
@@ -30,6 +53,14 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a critical diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Critical(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.CriticalAsync.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.CriticalAsync.cs
@@ -4,23 +4,58 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides extensions to support asynchronous emission of critical diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Asynchronously emits a critical diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task CriticalAsync(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         return diagnostics.CriticalAsync(CancellationToken.None, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a critical diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task CriticalAsync(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         return diagnostics.CriticalAsync(cancellationToken, default, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a critical diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task CriticalAsync(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         return diagnostics.CriticalAsync(CancellationToken.None, cause, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a critical diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task CriticalAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Debug.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Debug.cs
@@ -3,8 +3,17 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Provides extensions to support emission of debug diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Emits a debug diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Debug(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         await diagnostics
@@ -12,6 +21,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a debug diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Debug(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         await diagnostics
@@ -19,6 +35,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a debug diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Debug(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         await diagnostics
@@ -26,6 +49,14 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a debug diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Debug(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.DebugAsync.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.DebugAsync.cs
@@ -4,23 +4,58 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides extensions to support asynchronous emission of debug diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Asynchronously emits a debug diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task DebugAsync(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         return diagnostics.DebugAsync(CancellationToken.None, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a debug diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task DebugAsync(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         return diagnostics.DebugAsync(cancellationToken, default, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a debug diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task DebugAsync(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         return diagnostics.DebugAsync(CancellationToken.None, cause, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a debug diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task DebugAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Error.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Error.cs
@@ -3,8 +3,17 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Provides extensions to support emission of error diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Emits an error diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Error(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         await diagnostics
@@ -12,6 +21,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits an error diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Error(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         await diagnostics
@@ -19,6 +35,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits an error diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Error(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         await diagnostics
@@ -26,6 +49,14 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits an error diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Error(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.ErrorAsync.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.ErrorAsync.cs
@@ -4,23 +4,58 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides extensions to support asynchronous emission of error diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Asynchronously emits an error diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task ErrorAsync(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         return diagnostics.ErrorAsync(CancellationToken.None, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits an error diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task ErrorAsync(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         return diagnostics.ErrorAsync(cancellationToken, default, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits an error diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task ErrorAsync(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         return diagnostics.ErrorAsync(CancellationToken.None, cause, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits an error diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task ErrorAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Information.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Information.cs
@@ -3,8 +3,17 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Provides extensions to support emission of information diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Emits an information diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Information(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         await diagnostics
@@ -12,6 +21,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits an information diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Information(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,
@@ -23,6 +39,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits an information diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Information(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         await diagnostics
@@ -30,6 +53,14 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits an information diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Information(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.InformationAsync.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.InformationAsync.cs
@@ -4,13 +4,31 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides extensions to support asynchronous emission of information diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Asynchronously emits an information diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task InformationAsync(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         return diagnostics.InformationAsync(CancellationToken.None, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits an information diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task InformationAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,
@@ -20,11 +38,28 @@ public static partial class DiagnosticsRelayExtensions
         return diagnostics.InformationAsync(cancellationToken, default, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits an information diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task InformationAsync(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         return diagnostics.InformationAsync(CancellationToken.None, cause, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits an information diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task InformationAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Trace.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Trace.cs
@@ -3,8 +3,17 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Provides extensions to support emission of trace diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Emits a trace diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Trace(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         await diagnostics
@@ -12,6 +21,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a trace diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Trace(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         await diagnostics
@@ -19,6 +35,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a trace diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Trace(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         await diagnostics
@@ -26,6 +49,14 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a trace diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Trace(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.TraceAsync.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.TraceAsync.cs
@@ -4,23 +4,58 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides extensions to support asynchronous emission of trace diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Asynchronously emits a trace diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task TraceAsync(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         return diagnostics.TraceAsync(CancellationToken.None, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a trace diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task TraceAsync(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         return diagnostics.TraceAsync(cancellationToken, default, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a trace diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task TraceAsync(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         return diagnostics.TraceAsync(CancellationToken.None, cause, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a trace diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task TraceAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.TryEmitAsync.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.TryEmitAsync.cs
@@ -4,8 +4,25 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides extensions to support asynchronous emission of diagnostics events via an optional instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Asynchronously emits a diagnostic event if <paramref name="diagnostics"/> is not null, otherwise no action is taken.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <param name="cause">The <see cref="Exception" /> that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="impact">
+    /// The perceived <see cref="Impact" /> of the event from the perspective of the source for which this relay is acting.
+    /// </param>
+    /// <param name="level">
+    /// The perceived <see cref="Level" /> of the event from the perspective of the source for which this relay is acting.
+    /// </param>
+    /// <param name="message">An optional <see cref="DiagnosticsMessage" />, providing a friendly description of the event.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task TryEmitAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken = default,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Warning.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.Warning.cs
@@ -3,8 +3,17 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Provides extensions to support emission of warning diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Emits a warning diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Warning(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         await diagnostics
@@ -12,6 +21,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a warning diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Warning(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         await diagnostics
@@ -19,6 +35,13 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a warning diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Warning(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         await diagnostics
@@ -26,6 +49,14 @@ public static partial class DiagnosticsRelayExtensions
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Emits a warning diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
     public static async void Warning(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.WarningAsync.cs
+++ b/src/MooVC/Diagnostics/DiagnosticsRelayExtensions.WarningAsync.cs
@@ -4,23 +4,58 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides extensions to support asynchronous emission of warning diagnostics events via an instance of <see cref="IDiagnosticsRelay"/>.
+/// </summary>
 public static partial class DiagnosticsRelayExtensions
 {
+    /// <summary>
+    /// Asynchronously emits a warning diagnostic event with the specified message.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task WarningAsync(this IDiagnosticsRelay? diagnostics, string message, params object[] args)
     {
         return diagnostics.WarningAsync(CancellationToken.None, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a warning diagnostic event with the specified message and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task WarningAsync(this IDiagnosticsRelay? diagnostics, CancellationToken? cancellationToken, string message, params object[] args)
     {
         return diagnostics.WarningAsync(cancellationToken, default, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a warning diagnostic event with the specified message and cause.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task WarningAsync(this IDiagnosticsRelay? diagnostics, Exception? cause, string message, params object[] args)
     {
         return diagnostics.WarningAsync(CancellationToken.None, cause, message, args);
     }
 
+    /// <summary>
+    /// Asynchronously emits a warning diagnostic event with the specified message, cause, and cancellation token.
+    /// </summary>
+    /// <param name="diagnostics">The <see cref="IDiagnosticsRelay"/> to use to emit the diagnostic event.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the emission operation.</param>
+    /// <param name="cause">The cause of the diagnostic event.</param>
+    /// <param name="message">The message associated with the diagnostic event.</param>
+    /// <param name="args">The arguments of the message (if any).</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static Task WarningAsync(
         this IDiagnosticsRelay? diagnostics,
         CancellationToken? cancellationToken,

--- a/src/MooVC/Diagnostics/EmitDiagnosticsExtensions.InvokeAsync.cs
+++ b/src/MooVC/Diagnostics/EmitDiagnosticsExtensions.InvokeAsync.cs
@@ -21,7 +21,7 @@ public static partial class EmitDiagnosticsExtensions
     /// <typeparam name="T">The type of the elements in the input sequence.</typeparam>
     /// <param name="sources">The input sequence.</param>
     /// <param name="action">An asynchronous action to be performed on each element of the input sequence.</param>
-    /// <exception cref="ArgumentNullException">Thrown if the action is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the action is <see langword="null" />.</exception>
     /// <returns>A collection containing the emitted diagnostics.</returns>
     public static async Task<IEnumerable<DiagnosticsEmittedAsyncEventArgs>> InvokeAsync<T>(this IEnumerable<T>? sources, Func<T, Task> action)
         where T : IEmitDiagnostics

--- a/src/MooVC/Diagnostics/EmitDiagnosticsExtensions.InvokeAsync.cs
+++ b/src/MooVC/Diagnostics/EmitDiagnosticsExtensions.InvokeAsync.cs
@@ -9,6 +9,10 @@ using MooVC.Collections.Generic;
 using static MooVC.Diagnostics.Resources;
 using static MooVC.Ensure;
 
+/// <summary>
+/// Provides extensions to support capture of diagnostics events from source of type <see cref="IEnumerable{T}"/>.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration that implement <see cref="IEmitDiagnostics"/>.</typeparam>
 public static partial class EmitDiagnosticsExtensions
 {
     /// <summary>

--- a/src/MooVC/Diagnostics/EmitDiagnosticsExtensions.InvokeAsync.cs
+++ b/src/MooVC/Diagnostics/EmitDiagnosticsExtensions.InvokeAsync.cs
@@ -11,6 +11,14 @@ using static MooVC.Ensure;
 
 public static partial class EmitDiagnosticsExtensions
 {
+    /// <summary>
+    /// Invokes the specified asynchronous action on each element of a sequence of sources, and returns the emitted diagnostics.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the input sequence.</typeparam>
+    /// <param name="sources">The input sequence.</param>
+    /// <param name="action">An asynchronous action to be performed on each element of the input sequence.</param>
+    /// <exception cref="ArgumentNullException">Thrown if the action is null.</exception>
+    /// <returns>A collection containing the emitted diagnostics.</returns>
     public static async Task<IEnumerable<DiagnosticsEmittedAsyncEventArgs>> InvokeAsync<T>(this IEnumerable<T>? sources, Func<T, Task> action)
         where T : IEmitDiagnostics
     {

--- a/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
+++ b/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
@@ -26,8 +26,8 @@ public interface IDiagnosticsProxy
     /// <param name="impact">The perceived impact of the event from the perspective of the <paramref name="source"/>.</param>
     /// <param name="level">The perceived level of the event from the perspective of the <paramref name="source"/>.</param>
     /// <param name="message">A friendly description of the event, if any.</param>
-    /// <returns>A task representing the asynchronous operation. The result of the task is an object containing information about the
-    /// emitted diagnostic message, or null if the message was not emitted.</returns>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an object containing
+    /// information about the emitted diagnostic message, or null if the message was not emitted.</returns>
     Task<DiagnosticsEmittedAsyncEventArgs?> TryEmitAsync(
         IEmitDiagnostics source,
         CancellationToken? cancellationToken = default,

--- a/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
+++ b/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
@@ -26,8 +26,10 @@ public interface IDiagnosticsProxy
     /// <param name="impact">The perceived <see cref="Impact" /> of the event from the perspective of the <paramref name="source"/>.</param>
     /// <param name="level">The perceived <see cref="Level" /> of the event from the perspective of the <paramref name="source"/>.</param>
     /// <param name="message">A <see cref="DiagnosticsMessage" />, providing a friendly description of the event, if any.</param>
-    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an object containing
-    /// information about the emitted diagnostic message, or null if the message was not emitted.</returns>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the asynchronous operation.
+    /// The result of the task is an object containing information about the emitted diagnostic message, or null if the message was not emitted.
+    /// </returns>
     Task<DiagnosticsEmittedAsyncEventArgs?> TryEmitAsync(
         IEmitDiagnostics source,
         CancellationToken? cancellationToken = default,

--- a/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
+++ b/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
@@ -4,11 +4,30 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents a proxy for emitting diagnostics messages.
+/// </summary>
 public interface IDiagnosticsProxy
     : IEmitDiagnostics
 {
+    /// <summary>
+    /// Gets the diagnostic level assigned by the proxy based on the perceived impact.
+    /// </summary>
+    /// <param name="impact">The perceived impact of the event.</param>
+    /// <returns>The diagnostic level assigned by the proxy based on the perceived impact.</returns>
     Level this[Impact impact] { get; }
 
+    /// <summary>
+    /// Emits a diagnostic event asynchronously if the proxy deems it appropriate.
+    /// </summary>
+    /// <param name="source">The object emitting the event for the purpose of diagnostics.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cause">The exception that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="impact">The perceived impact of the event from the perspective of the <paramref name="source"/>.</param>
+    /// <param name="level">The perceived level of the event from the perspective of the <paramref name="source"/>.</param>
+    /// <param name="message">A friendly description of the event, if any.</param>
+    /// <returns>A task representing the asynchronous operation. The result of the task is an object containing information about the
+    /// emitted diagnostic message, or null if the message was not emitted.</returns>
     Task<DiagnosticsEmittedAsyncEventArgs?> TryEmitAsync(
         IEmitDiagnostics source,
         CancellationToken? cancellationToken = default,

--- a/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
+++ b/src/MooVC/Diagnostics/IDiagnosticsProxy.cs
@@ -13,7 +13,7 @@ public interface IDiagnosticsProxy
     /// <summary>
     /// Gets the diagnostic level assigned by the proxy based on the perceived impact.
     /// </summary>
-    /// <param name="impact">The perceived impact of the event.</param>
+    /// <param name="impact">The perceived <see cref="Impact" /> of the event.</param>
     /// <returns>The diagnostic level assigned by the proxy based on the perceived impact.</returns>
     Level this[Impact impact] { get; }
 
@@ -21,11 +21,11 @@ public interface IDiagnosticsProxy
     /// Emits a diagnostic event asynchronously if the proxy deems it appropriate.
     /// </summary>
     /// <param name="source">The object emitting the event for the purpose of diagnostics.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-    /// <param name="cause">The exception that caused the diagnostic event to be emitted, if any.</param>
-    /// <param name="impact">The perceived impact of the event from the perspective of the <paramref name="source"/>.</param>
-    /// <param name="level">The perceived level of the event from the perspective of the <paramref name="source"/>.</param>
-    /// <param name="message">A friendly description of the event, if any.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <param name="cause">The <see cref="Exception" /> that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="impact">The perceived <see cref="Impact" /> of the event from the perspective of the <paramref name="source"/>.</param>
+    /// <param name="level">The perceived <see cref="Level" /> of the event from the perspective of the <paramref name="source"/>.</param>
+    /// <param name="message">A <see cref="DiagnosticsMessage" />, providing a friendly description of the event, if any.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The result of the task is an object containing
     /// information about the emitted diagnostic message, or null if the message was not emitted.</returns>
     Task<DiagnosticsEmittedAsyncEventArgs?> TryEmitAsync(

--- a/src/MooVC/Diagnostics/IDiagnosticsRelay.cs
+++ b/src/MooVC/Diagnostics/IDiagnosticsRelay.cs
@@ -18,7 +18,7 @@ public interface IDiagnosticsRelay
     /// <param name="impact">The perceived impact of the event from the perspective of the source for which this relay is acting.</param>
     /// <param name="level">The perceived level of the event from the perspective of the source for which this relay is acting.</param>
     /// <param name="message">A friendly description of the event, if any.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     Task EmitAsync(
         CancellationToken? cancellationToken = default,
         Exception? cause = default,

--- a/src/MooVC/Diagnostics/IDiagnosticsRelay.cs
+++ b/src/MooVC/Diagnostics/IDiagnosticsRelay.cs
@@ -13,11 +13,15 @@ public interface IDiagnosticsRelay
     /// <summary>
     /// Emits a diagnostic event asynchronously.
     /// </summary>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-    /// <param name="cause">The exception that caused the diagnostic event to be emitted, if any.</param>
-    /// <param name="impact">The perceived impact of the event from the perspective of the source for which this relay is acting.</param>
-    /// <param name="level">The perceived level of the event from the perspective of the source for which this relay is acting.</param>
-    /// <param name="message">A friendly description of the event, if any.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <param name="cause">The <see cref="Exception" /> that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="impact">
+    /// The perceived <see cref="Impact" /> of the event from the perspective of the source for which this relay is acting.
+    /// </param>
+    /// <param name="level">
+    /// The perceived <see cref="Level" /> of the event from the perspective of the source for which this relay is acting.
+    /// </param>
+    /// <param name="message">An optional <see cref="DiagnosticsMessage" />, providing a friendly description of the event.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     Task EmitAsync(
         CancellationToken? cancellationToken = default,

--- a/src/MooVC/Diagnostics/IDiagnosticsRelay.cs
+++ b/src/MooVC/Diagnostics/IDiagnosticsRelay.cs
@@ -4,9 +4,21 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents an object that can receive and relay diagnostic events on behalf of another object.
+/// </summary>
 public interface IDiagnosticsRelay
     : IEmitDiagnostics
 {
+    /// <summary>
+    /// Emits a diagnostic event asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cause">The exception that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="impact">The perceived impact of the event from the perspective of the source for which this relay is acting.</param>
+    /// <param name="level">The perceived level of the event from the perspective of the source for which this relay is acting.</param>
+    /// <param name="message">A friendly description of the event, if any.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task EmitAsync(
         CancellationToken? cancellationToken = default,
         Exception? cause = default,

--- a/src/MooVC/Diagnostics/IEmitDiagnostics.cs
+++ b/src/MooVC/Diagnostics/IEmitDiagnostics.cs
@@ -1,6 +1,12 @@
 ﻿namespace MooVC.Diagnostics;
 
+/// <summary>
+/// Represents an object that can emit diagnostics.
+/// </summary>
 public interface IEmitDiagnostics
 {
+    /// <summary>
+    /// An event that is raised when an diagnostic related occurance is encountered.
+    /// </summary>
     event DiagnosticsEmittedAsyncEventHandler DiagnosticsEmitted;
 }

--- a/src/MooVC/Diagnostics/Impact.cs
+++ b/src/MooVC/Diagnostics/Impact.cs
@@ -1,10 +1,28 @@
 ﻿namespace MooVC.Diagnostics;
 
+/// <summary>
+/// An enumeration of impacts from the perspective of the emitter.
+/// </summary>
 public enum Impact
     : byte
 {
+    /// <summary>
+    /// No impact.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    /// A negligible impact, likely addressed automatically.
+    /// </summary>
     Negligible = 1,
+
+    /// <summary>
+    /// A recoverable impact, likely requiring the originator to retry.
+    /// </summary>
     Recoverable = 2,
+
+    /// <summary>
+    /// An unrecoverable impact, likely requiring alternative action.
+    /// </summary>
     Unrecoverable = 3,
 }

--- a/src/MooVC/Diagnostics/Level.cs
+++ b/src/MooVC/Diagnostics/Level.cs
@@ -1,13 +1,44 @@
 ﻿namespace MooVC.Diagnostics;
 
+/// <summary>
+/// An enumeration of diagnostics levels from the perspective of the emitter.
+/// </summary>
 public enum Level
     : byte
 {
+    /// <summary>
+    /// The event is deemed critical to the operation being performed and is likely impacting in nature.
+    /// </summary>
     Critical = 6,
+
+    /// <summary>
+    /// The event is deemed debug to the operation being performed and is likely informational for development purposes.
+    /// </summary>
     Debug = 2,
+
+    /// <summary>
+    /// The event is deemed an error to the operation being performed and is likely impacting in nature.
+    /// </summary>
     Error = 5,
+
+    /// <summary>
+    /// The event is deemed irrelevant to the operation being performed and is likely useless to any listener.
+    /// </summary>
     Ignore = 0,
+
+    /// <summary>
+    /// The event is deemed debug to the operation being performed and is likely informational for diagnostics purposes.
+    /// </summary>
     Information = 3,
+
+    /// <summary>
+    /// The event is deemed trace to the operation being performed and is likely informational for development purposes.
+    /// </summary>
     Trace = 1,
+
+    /// <summary>
+    /// The event is deemed warning to the operation being performed and is likely informational for diagnostics purposes or may neccessitate
+    /// development or operational action be taken in the future to address.
+    /// </summary>
     Warning = 4,
 }

--- a/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
+++ b/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
@@ -6,6 +6,20 @@ using System.Dynamic;
 
 public static class ExpandoObjectExtensions
 {
+    /// <summary>
+    /// Clones the given ExpandoObject.
+    /// If the original object is null and defaultIfNull is true, a default ExpandoObject is returned.
+    /// If defaultIfNull is false and the original object is null, an ArgumentNullException is thrown.
+    /// </summary>
+    /// <param name="original">The original ExpandoObject to clone.</param>
+    /// <param name="defaultIfNull">
+    /// Whether to return a default ExpandoObject if the original object is null.
+    /// If this is set to false and the original object is null, an ArgumentNullException is thrown.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if defaultIfNull is false and the original object is null.
+    /// </exception>
+    /// <returns>A clone of the original ExpandoObject.</returns>
     public static ExpandoObject Clone(this ExpandoObject? orignal, bool defaultIfNull = true)
     {
         var clone = new ExpandoObject();

--- a/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
+++ b/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
@@ -4,6 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 
+/// <summary>
+/// Provides extensions relating to ExpandoObject.
+/// </summary>
 public static class ExpandoObjectExtensions
 {
     /// <summary>
@@ -20,15 +23,15 @@ public static class ExpandoObjectExtensions
     /// Thrown if defaultIfNull is false and the original object is null.
     /// </exception>
     /// <returns>A clone of the original ExpandoObject.</returns>
-    public static ExpandoObject Clone(this ExpandoObject? orignal, bool defaultIfNull = true)
+    public static ExpandoObject Clone(this ExpandoObject? original, bool defaultIfNull = true)
     {
         var clone = new ExpandoObject();
 
-        if (orignal is { })
+        if (original is { })
         {
             var target = (IDictionary<string, object?>)clone;
 
-            foreach (KeyValuePair<string, object?> value in orignal)
+            foreach (KeyValuePair<string, object?> value in original)
             {
                 if (value.Value is ExpandoObject child)
                 {
@@ -42,7 +45,7 @@ public static class ExpandoObjectExtensions
         }
         else if (!defaultIfNull)
         {
-            throw new ArgumentNullException(nameof(orignal));
+            throw new ArgumentNullException(nameof(original));
         }
 
         return clone;

--- a/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
+++ b/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
@@ -16,10 +16,10 @@ public static class ExpandoObjectExtensions
     /// </summary>
     /// <param name="original">The original ExpandoObject to clone.</param>
     /// <param name="defaultIfNull">
-    /// Whether to return a default ExpandoObject if the original object is null.
+    /// Whether to return a default ExpandoObject if the original object is <see langword="null" />.
     /// If this is set to false and the original object is null, an ArgumentNullException is thrown.
     /// </param>
-    /// <exception cref="ArgumentNullException">Thrown if defaultIfNull is false and the original object is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if defaultIfNull is false and the original object is <see langword="null" />.</exception>
     /// <returns>A clone of the original ExpandoObject.</returns>
     public static ExpandoObject Clone(this ExpandoObject? original, bool defaultIfNull = true)
     {

--- a/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
+++ b/src/MooVC/Dynamic/ExpandoObjectExtensions.Clone.cs
@@ -19,9 +19,7 @@ public static class ExpandoObjectExtensions
     /// Whether to return a default ExpandoObject if the original object is null.
     /// If this is set to false and the original object is null, an ArgumentNullException is thrown.
     /// </param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown if defaultIfNull is false and the original object is null.
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown if defaultIfNull is false and the original object is null.</exception>
     /// <returns>A clone of the original ExpandoObject.</returns>
     public static ExpandoObject Clone(this ExpandoObject? original, bool defaultIfNull = true)
     {

--- a/src/MooVC/Ensure.InRange.cs
+++ b/src/MooVC/Ensure.InRange.cs
@@ -3,8 +3,29 @@
 using System;
 using System.Runtime.CompilerServices;
 
+/// <summary>
+/// Provides methods to support validation.
+/// </summary>
 public static partial class Ensure
 {
+    /// <summary>
+    /// Validates that a given argument is within a specified range.
+    /// If the argument is outside of the range, returns a default value or throws an exception.
+    /// </summary>
+    /// <typeparam name="T">The type of the argument. Must be a struct and implement IComparable{T}.</typeparam>
+    /// <param name="argument">The argument to be validated.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">The default value to be returned if the argument is outside of the range. This parameter is optional.</param>
+    /// <param name="end">The end of the range. The argument must be less than or equal to this value. This parameter is optional.</param>
+    /// <param name="message">An optional message to be included in the exception if one is thrown. This parameter is optional.</param>
+    /// <param name="start">The start of the range. The argument must be greater than or equal to this value. This parameter is optional.</param>
+    /// <returns>The original argument if it is within the specified range, or the default value if provided.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if the argument is outside of the specified range and no default value is provided.
+    /// </exception>
     public static T InRange<T>(
         T argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,
@@ -27,12 +48,30 @@ public static partial class Ensure
         return argument;
     }
 
+    /// <summary>
+    /// Validates that a given nullable argument is within a specified range.
+    /// If the argument is outside of the range, returns a default value or throws an exception.
+    /// </summary>
+    /// <typeparam name="T">The type of the argument. Must be a struct and implement IComparable{T}.</typeparam>
+    /// <param name="argument">The nullable argument to be validated.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">The default value to be returned if the argument is outside of the range. This parameter is optional.</param>
+    /// <param name="end">The end of the range. The argument must be less than or equal to this value. This parameter is optional.</param>
+    /// <param name="message">An optional message to be included in the exception if one is thrown. This parameter is optional.</param>
+    /// <param name="start">The start of the range. The argument must be greater than or equal to this value. This parameter is optional.</param>
+    /// <returns>The original argument if it is within the specified range, or the default value if provided.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if the argument is outside of the specified range and no default value is provided.
+    /// </exception>
     public static T InRange<T>(
         T? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,
         T? @default = default,
-        string? message = default,
         T? end = default,
+        string? message = default,
         T? start = default)
        where T : struct, IComparable<T>
     {

--- a/src/MooVC/Ensure.IsDefined.cs
+++ b/src/MooVC/Ensure.IsDefined.cs
@@ -3,8 +3,36 @@
 using System;
 using System.Runtime.CompilerServices;
 
+/// <summary>
+/// Provides methods to support validation.
+/// </summary>
 public static partial class Ensure
 {
+    /// <summary>
+    /// Validates that the given value is defined as a member of the specified enumeration.
+    /// </summary>
+    /// <typeparam name="T">The type of the enumeration.</typeparam>
+    /// <param name="argument">The value to validate.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">
+    /// The default value to return if the argument is invalid.
+    /// This value is optional.
+    /// If not provided, an exception will be thrown if the argument is invalid.
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception if the argument is invalid.
+    /// This value is optional.
+    /// If not provided, a default message will be used.
+    /// </param>
+    /// <returns>
+    /// The given value if it is defined as a member of the specified enumeration, or <paramref name="default"/> if provided.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the argument is not defined as a member of the specified enumeration and no default value was provided.
+    /// </exception>
     public static T IsDefined<T>(
         T? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,
@@ -22,6 +50,31 @@ public static partial class Ensure
         return IsDefined(actual, argumentName: argumentName, @default: @default, message: message);
     }
 
+    /// <summary>
+    /// Validates that the given nullable value is defined as a member of the specified enumeration.
+    /// </summary>
+    /// <typeparam name="T">The type of the enumeration.</typeparam>
+    /// <param name="argument">The nullable value to validate.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">
+    /// The default value to return if the argument is invalid.
+    /// This value is optional.
+    /// If not provided, an exception will be thrown if the argument is invalid.
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception if the argument is invalid.
+    /// This value is optional.
+    /// If not provided, a default message will be used.
+    /// </param>
+    /// <returns>
+    /// The given value if it is defined as a member of the specified enumeration, or <paramref name="default"/> if provided.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the argument is not defined as a member of the specified enumeration and no default value was provided.
+    /// </exception>
     public static T IsDefined<T>(
         T argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,

--- a/src/MooVC/Ensure.IsNotEmpty.cs
+++ b/src/MooVC/Ensure.IsNotEmpty.cs
@@ -6,8 +6,23 @@ using System.Runtime.CompilerServices;
 using MooVC.Collections.Generic;
 using MooVC.Linq;
 
+/// <summary>
+/// Provides methods to support validation.
+/// </summary>
 public static partial class Ensure
 {
+    /// <summary>
+    /// Validates that the given <see cref="Guid"/> value is not empty.
+    /// </summary>
+    /// <param name="argument">The value to be validated.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">The default value to be returned if the validation fails. This value is optional.</param>
+    /// <param name="message">The error message to be used in the exception if the validation fails. This value is optional.</param>
+    /// <returns>The given <see cref="Guid"/> value if it is not empty, or the default value if provided and the validation fails.</returns>
+    /// <exception cref="ArgumentException">Thrown if the given <see cref="Guid"/> value is empty and no default value is provided.</exception>
     public static Guid IsNotEmpty(
         Guid? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,
@@ -17,6 +32,18 @@ public static partial class Ensure
         return Satisfies(argument, value => value != Guid.Empty, argumentName: argumentName, @default: @default, message: message);
     }
 
+    /// <summary>
+    /// Validates that the given <see cref="TimeSpan"/> value is not empty.
+    /// </summary>
+    /// <param name="argument">The value to be validated.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">The default value to be returned if the validation fails. This value is optional.</param>
+    /// <param name="message">The error message to be used in the exception if the validation fails. This value is optional.</param>
+    /// <returns>The given <see cref="TimeSpan"/> value if it is not empty, or the default value if provided and the validation fails.</returns>
+    /// <exception cref="ArgumentException">Thrown if the given <see cref="TimeSpan"/> value is empty and no default value is provided.</exception>
     public static TimeSpan IsNotEmpty(
         TimeSpan? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,
@@ -31,6 +58,35 @@ public static partial class Ensure
             message: message);
     }
 
+    /// <summary>
+    /// Validates that the given sequence of elements is not empty.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the sequence.</typeparam>
+    /// <param name="argument">The sequence of elements to validate.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">
+    /// The default value to return if the argument is invalid.
+    /// This value is optional.
+    /// If not provided, an exception will be thrown if the argument is invalid.
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception if the argument is invalid.
+    /// This value is optional.
+    /// If not provided, a default message will be used.
+    /// </param>
+    /// <param name="predicate">
+    /// A predicate to apply to each element in the sequence to determine if it should be included.
+    /// This value is optional. If not provided, the default predicate will include all elements that are not null.
+    /// </param>
+    /// <returns>
+    /// The given sequence of elements if it is not empty, or <paramref name="default"/> if provided.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the argument is empty and no default value was provided.
+    /// </exception>
     public static T[] IsNotEmpty<T>(
         IEnumerable<T>? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,

--- a/src/MooVC/Ensure.IsNotNull.cs
+++ b/src/MooVC/Ensure.IsNotNull.cs
@@ -18,7 +18,7 @@ public static partial class Ensure
     /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
     /// </param>
     /// <param name="default">
-    /// The default value to return if the argument is null.
+    /// The default value to return if the argument is <see langword="null" />.
     /// If this is not specified, an exception will be thrown instead.
     /// </param>
     /// <param name="message">
@@ -61,7 +61,7 @@ public static partial class Ensure
     /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
     /// </param>
     /// <param name="default">
-    /// The default value to return if the argument is null.
+    /// The default value to return if the argument is <see langword="null" />.
     /// If this is not specified, an exception will be thrown instead.
     /// </param>
     /// <param name="message">

--- a/src/MooVC/Ensure.IsNotNull.cs
+++ b/src/MooVC/Ensure.IsNotNull.cs
@@ -3,8 +3,34 @@
 using System;
 using System.Runtime.CompilerServices;
 
+/// <summary>
+/// Provides methods to support validation.
+/// </summary>
 public static partial class Ensure
 {
+    /// <summary>
+    /// Ensures that the specified nullable value type argument is not null.
+    /// </summary>
+    /// <typeparam name="T">The type of the nullable value.</typeparam>
+    /// <param name="argument">The nullable value type argument to check.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">
+    /// The default value to return if the argument is null.
+    /// If this is not specified, an exception will be thrown instead.
+    /// </param>
+    /// <param name="message">
+    /// An optional message to include in the exception that is thrown if the argument is null and no default value has been specified.
+    /// </param>
+    /// <returns>
+    /// The original nullable value type argument, if it is not null.
+    /// Otherwise, the default value (if specified) or an exception is thrown.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The original nullable value type argument is null and no default value has been specified.
+    /// </exception>
     public static T IsNotNull<T>(
         T? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,
@@ -25,6 +51,29 @@ public static partial class Ensure
         return argument.Value;
     }
 
+    /// <summary>
+    /// Ensures that the specified nullable reference type argument is not null.
+    /// </summary>
+    /// <typeparam name="T">The type of the nullable reference.</typeparam>
+    /// <param name="argument">The nullable reference type argument to check.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">
+    /// The default value to return if the argument is null.
+    /// If this is not specified, an exception will be thrown instead.
+    /// </param>
+    /// <param name="message">
+    /// An optional message to include in the exception that is thrown if the argument is null and no default value has been specified.
+    /// </param>
+    /// <returns>
+    /// The original nullable reference type argument, if it is not null.
+    /// Otherwise, the default value (if specified) or an exception is thrown.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The original nullable reference type argument is null and no default value has been specified.
+    /// </exception>
     public static T IsNotNull<T>(
         T? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,

--- a/src/MooVC/Ensure.IsNotNullOrWhiteSpace.cs
+++ b/src/MooVC/Ensure.IsNotNullOrWhiteSpace.cs
@@ -4,8 +4,33 @@ using System;
 using System.Runtime.CompilerServices;
 using static System.String;
 
+/// <summary>
+/// Provides methods to support validation.
+/// </summary>
 public static partial class Ensure
 {
+    /// <summary>
+    /// Ensures that the specified string argument is not null or whitespace.
+    /// </summary>
+    /// <param name="argument">The string argument to check.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <param name="default">
+    /// The default value to return if the argument is null or whitespace.
+    /// If this is not specified, an exception will be thrown instead.
+    /// </param>
+    /// <param name="message">
+    /// An optional message to include in the exception that is thrown if the argument is null or whitespace and no default value has been specified.
+    /// </param>
+    /// <returns>
+    /// The original string argument, if it is not null or whitespace.
+    /// Otherwise, the default value (if specified) or an exception is thrown.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The argument is null or whitespace and no default value has been specified.
+    /// </exception>
     public static string IsNotNullOrWhiteSpace(
         string? argument,
         [CallerArgumentExpression("argument")] string? argumentName = default,

--- a/src/MooVC/Ensure.Satisfies.cs
+++ b/src/MooVC/Ensure.Satisfies.cs
@@ -5,6 +5,22 @@ using System.Runtime.CompilerServices;
 
 public static partial class Ensure
 {
+    /// <summary>
+    /// Returns the given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified,
+    /// or throws an <see cref="ArgumentException"/> if the default value is not specified.
+    /// </summary>
+    /// <typeparam name="T">The type of the argument to check.</typeparam>
+    /// <param name="argument">The argument to check.</param>
+    /// <param name="predicate">The predicate to evaluate the argument against.</param>
+    /// <param name="argumentName">The name of the argument, provided by the caller.</param>
+    /// <param name="default">The default value to return if the argument is not <c>null</c>.</param>
+    /// <param name="message">The error message to use if the argument does not satisfy the predicate and no default value is specified.</param>
+    /// <returns>
+    /// The given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// The given argument does not satisfy the specified predicate and no default value is specified.
+    /// </exception>
     public static T Satisfies<T>(
         T? argument,
         Func<T, bool> predicate,
@@ -33,6 +49,22 @@ public static partial class Ensure
         return actual;
     }
 
+    /// <summary>
+    /// Returns the given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified,
+    /// or throws an <see cref="ArgumentException"/> if the default value is not specified.
+    /// </summary>
+    /// <typeparam name="T">The type of the argument to check.</typeparam>
+    /// <param name="argument">The argument to check.</param>
+    /// <param name="predicate">The predicate to evaluate the argument against.</param>
+    /// <param name="argumentName">The name of the argument, provided by the caller.</param>
+    /// <param name="default">The default value to return if the argument is not <c>null</c>.</param>
+    /// <param name="message">The error message to use if the argument does not satisfy the predicate and no default value is specified.</param>
+    /// <returns>
+    /// The given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// The given argument does not satisfy the specified predicate and no default value is specified.
+    /// </exception>
     public static T Satisfies<T>(
         T? argument,
         Func<T, bool> predicate,

--- a/src/MooVC/Ensure.Satisfies.cs
+++ b/src/MooVC/Ensure.Satisfies.cs
@@ -3,6 +3,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
+/// <summary>
+/// Provides methods to support validation.
+/// </summary>
 public static partial class Ensure
 {
     /// <summary>
@@ -12,7 +15,10 @@ public static partial class Ensure
     /// <typeparam name="T">The type of the argument to check.</typeparam>
     /// <param name="argument">The argument to check.</param>
     /// <param name="predicate">The predicate to evaluate the argument against.</param>
-    /// <param name="argumentName">The name of the argument, provided by the caller.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
     /// <param name="default">The default value to return if the argument is not null.</param>
     /// <param name="message">The error message to use if the argument does not satisfy the predicate and no default value is specified.</param>
     /// <returns>
@@ -56,7 +62,10 @@ public static partial class Ensure
     /// <typeparam name="T">The type of the argument to check.</typeparam>
     /// <param name="argument">The argument to check.</param>
     /// <param name="predicate">The predicate to evaluate the argument against.</param>
-    /// <param name="argumentName">The name of the argument, provided by the caller.</param>
+    /// <param name="argumentName">
+    /// The name of the argument, which will be used in the exception message if the validation fails.
+    /// This value is optional and can be provided automatically by the caller via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
     /// <param name="default">The default value to return if the argument is not null.</param>
     /// <param name="message">The error message to use if the argument does not satisfy the predicate and no default value is specified.</param>
     /// <returns>

--- a/src/MooVC/Ensure.Satisfies.cs
+++ b/src/MooVC/Ensure.Satisfies.cs
@@ -6,17 +6,17 @@ using System.Runtime.CompilerServices;
 public static partial class Ensure
 {
     /// <summary>
-    /// Returns the given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified,
+    /// Returns the given argument if it satisfies the specified predicate, or the default value if it is not null and if specified,
     /// or throws an <see cref="ArgumentException"/> if the default value is not specified.
     /// </summary>
     /// <typeparam name="T">The type of the argument to check.</typeparam>
     /// <param name="argument">The argument to check.</param>
     /// <param name="predicate">The predicate to evaluate the argument against.</param>
     /// <param name="argumentName">The name of the argument, provided by the caller.</param>
-    /// <param name="default">The default value to return if the argument is not <c>null</c>.</param>
+    /// <param name="default">The default value to return if the argument is not null.</param>
     /// <param name="message">The error message to use if the argument does not satisfy the predicate and no default value is specified.</param>
     /// <returns>
-    /// The given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified.
+    /// The given argument if it satisfies the specified predicate, or the default value if it is not null and if specified.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// The given argument does not satisfy the specified predicate and no default value is specified.
@@ -50,17 +50,17 @@ public static partial class Ensure
     }
 
     /// <summary>
-    /// Returns the given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified,
+    /// Returns the given argument if it satisfies the specified predicate, or the default value if it is not null and if specified,
     /// or throws an <see cref="ArgumentException"/> if the default value is not specified.
     /// </summary>
     /// <typeparam name="T">The type of the argument to check.</typeparam>
     /// <param name="argument">The argument to check.</param>
     /// <param name="predicate">The predicate to evaluate the argument against.</param>
     /// <param name="argumentName">The name of the argument, provided by the caller.</param>
-    /// <param name="default">The default value to return if the argument is not <c>null</c>.</param>
+    /// <param name="default">The default value to return if the argument is not null.</param>
     /// <param name="message">The error message to use if the argument does not satisfy the predicate and no default value is specified.</param>
     /// <returns>
-    /// The given argument if it satisfies the specified predicate, or the default value if it is not <c>null</c> and if specified.
+    /// The given argument if it satisfies the specified predicate, or the default value if it is not null and if specified.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// The given argument does not satisfy the specified predicate and no default value is specified.

--- a/src/MooVC/ExceptionExtensions.Explode.cs
+++ b/src/MooVC/ExceptionExtensions.Explode.cs
@@ -7,13 +7,28 @@ using static MooVC.Resources;
 
 public static class ExceptionExtensions
 {
+    /// <summary>
+    /// Performs an action on the given exception and any of its inner exceptions,
+    /// recursively.
+    /// </summary>
+    /// <param name="exception">The exception to perform the action on.</param>
+    /// <param name="handler">The action to perform on the given exception.</param>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="handler"/> parameter is <c>null</c>.
+    /// </exception>
     public static void Explode(this Exception? exception, Action<Exception> handler)
     {
         _ = IsNotNull(handler, message: ExceptionExtensionsExplodeHandlerRequired);
 
-        exception?.PerformExplode(handler);
+        exception.PerformExplode(handler);
     }
 
+    /// <summary>
+    /// Performs an action on the given exception and any of its inner exceptions,
+    /// recursively.
+    /// </summary>
+    /// <param name="exception">The exception to perform the action on.</param>
+    /// <param name="handler">The action to perform on the given exception.</param>
     private static void PerformExplode(this Exception? exception, Action<Exception> handler)
     {
         if (exception is { })

--- a/src/MooVC/ExceptionExtensions.Explode.cs
+++ b/src/MooVC/ExceptionExtensions.Explode.cs
@@ -5,6 +5,9 @@ using MooVC.Collections.Generic;
 using static MooVC.Ensure;
 using static MooVC.Resources;
 
+/// <summary>
+/// Provides extensions relating to Exception.
+/// </summary>
 public static class ExceptionExtensions
 {
     /// <summary>
@@ -14,7 +17,7 @@ public static class ExceptionExtensions
     /// <param name="exception">The exception to perform the action on.</param>
     /// <param name="handler">The action to perform on the given exception.</param>
     /// <exception cref="ArgumentNullException">
-    /// The <paramref name="handler"/> parameter is <c>null</c>.
+    /// The <paramref name="handler"/> parameter is null.
     /// </exception>
     public static void Explode(this Exception? exception, Action<Exception> handler)
     {

--- a/src/MooVC/ExceptionExtensions.Explode.cs
+++ b/src/MooVC/ExceptionExtensions.Explode.cs
@@ -15,7 +15,7 @@ public static class ExceptionExtensions
     /// </summary>
     /// <param name="exception">The <see cref="Exception"/> to perform the action on.</param>
     /// <param name="handler">The <see cref="Action{T}"/> to perform on the given exception.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="handler"/> parameter is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="handler"/> parameter is <see langword="null" />.</exception>
     public static void Explode(this Exception? exception, Action<Exception> handler)
     {
         _ = IsNotNull(handler, message: ExceptionExtensionsExplodeHandlerRequired);

--- a/src/MooVC/ExceptionExtensions.Explode.cs
+++ b/src/MooVC/ExceptionExtensions.Explode.cs
@@ -6,19 +6,16 @@ using static MooVC.Ensure;
 using static MooVC.Resources;
 
 /// <summary>
-/// Provides extensions relating to Exception.
+/// Provides extensions relating to <see cref="Exception"/>.
 /// </summary>
 public static class ExceptionExtensions
 {
     /// <summary>
-    /// Performs an action on the given exception and any of its inner exceptions,
-    /// recursively.
+    /// Performs an action on the given <see cref="Exception"/> and any of its inner exceptions, recursively.
     /// </summary>
-    /// <param name="exception">The exception to perform the action on.</param>
-    /// <param name="handler">The action to perform on the given exception.</param>
-    /// <exception cref="ArgumentNullException">
-    /// The <paramref name="handler"/> parameter is null.
-    /// </exception>
+    /// <param name="exception">The <see cref="Exception"/> to perform the action on.</param>
+    /// <param name="handler">The <see cref="Action{T}"/> to perform on the given exception.</param>
+    /// <exception cref="ArgumentNullException">The <paramref name="handler"/> parameter is null.</exception>
     public static void Explode(this Exception? exception, Action<Exception> handler)
     {
         _ = IsNotNull(handler, message: ExceptionExtensionsExplodeHandlerRequired);
@@ -27,11 +24,10 @@ public static class ExceptionExtensions
     }
 
     /// <summary>
-    /// Performs an action on the given exception and any of its inner exceptions,
-    /// recursively.
+    /// Performs an action on the given <see cref="Exception"/> and any of its inner exceptions, recursively.
     /// </summary>
-    /// <param name="exception">The exception to perform the action on.</param>
-    /// <param name="handler">The action to perform on the given exception.</param>
+    /// <param name="exception">The <see cref="Exception"/> to perform the action on.</param>
+    /// <param name="handler">The <see cref="Action{T}"/> to perform on the given exception.</param>
     private static void PerformExplode(this Exception? exception, Action<Exception> handler)
     {
         if (exception is { })

--- a/src/MooVC/GlobalSuppressions.cs
+++ b/src/MooVC/GlobalSuppressions.cs
@@ -6,3 +6,10 @@
     Justification = "The suggested approach is less readable.",
     Scope = "member",
     Target = "~M:MooVC.Collections.Generic.EnumerableExtensions.IndexOf``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})~System.Int32")]
+
+[assembly: SuppressMessage(
+    "Design",
+    "CA1005:Avoid excessive parameters on generic types",
+    Justification = "The problem the class solves precludes any reduction in the number of generic parameters.",
+    Scope = "type",
+    Target = "~T:MooVC.Persistence.MappedStore`3")]

--- a/src/MooVC/GlobalSuppressions.cs
+++ b/src/MooVC/GlobalSuppressions.cs
@@ -13,3 +13,17 @@
     Justification = "The problem the class solves precludes any reduction in the number of generic parameters.",
     Scope = "type",
     Target = "~T:MooVC.Persistence.MappedStore`3")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.DocumentationRules",
+    "SA1600:Elements should be documented",
+    Justification = "Obsolete feature, slated for removal in v8 - Not worth documentating.",
+    Scope = "type",
+    Target = "~T:MooVC.Serialization.SerializationInfoExtensions")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.DocumentationRules",
+    "SA1601:Partial elements should be documented",
+    Justification = "Obsolete feature, slated for removal in v8 - Not worth documentating.",
+    Scope = "type",
+    Target = "~T:MooVC.Serialization.SerializationInfoExtensions")]

--- a/src/MooVC/GlobalSuppressions.cs
+++ b/src/MooVC/GlobalSuppressions.cs
@@ -27,3 +27,17 @@
     Justification = "Obsolete feature, slated for removal in v8 - Not worth documentating.",
     Scope = "type",
     Target = "~T:MooVC.Serialization.SerializationInfoExtensions")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.DocumentationRules",
+    "SA1600:Elements should be documented",
+    Justification = "Obsolete feature, slated for removal in v8 - Not worth documentating.",
+    Scope = "type",
+    Target = "~T:MooVC.Serialization.SerializationInfoEnumeratorExtensions")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.DocumentationRules",
+    "SA1601:Partial elements should be documented",
+    Justification = "Obsolete feature, slated for removal in v8 - Not worth documentating.",
+    Scope = "type",
+    Target = "~T:MooVC.Serialization.SerializationInfoEnumeratorExtensions")]

--- a/src/MooVC/IO/StreamExtensions.GetBytes.cs
+++ b/src/MooVC/IO/StreamExtensions.GetBytes.cs
@@ -1,6 +1,5 @@
 ﻿namespace MooVC.IO;
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 

--- a/src/MooVC/IO/StreamExtensions.GetBytes.cs
+++ b/src/MooVC/IO/StreamExtensions.GetBytes.cs
@@ -3,6 +3,9 @@
 using System.Collections.Generic;
 using System.IO;
 
+/// <summary>
+/// Provides extensions relating to <see cref="Stream"/>.
+/// </summary>
 public static partial class StreamExtensions
 {
     /// <summary>

--- a/src/MooVC/IO/StreamExtensions.GetBytes.cs
+++ b/src/MooVC/IO/StreamExtensions.GetBytes.cs
@@ -1,10 +1,16 @@
 ﻿namespace MooVC.IO;
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
 public static partial class StreamExtensions
 {
+    /// <summary>
+    /// Reads the bytes from a stream and returns them as an enumerable sequence of bytes.
+    /// </summary>
+    /// <param name="source">The stream to read from.</param>
+    /// <returns>An enumerable sequence of bytes representing the data in the source stream.</returns>
     public static IEnumerable<byte> GetBytes(this Stream source)
     {
         using var target = new MemoryStream();

--- a/src/MooVC/Linq/EnumerableExtensions.IsEmpty.cs
+++ b/src/MooVC/Linq/EnumerableExtensions.IsEmpty.cs
@@ -6,8 +6,24 @@ using System.Linq;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Determines whether an enumerable sequence is empty or not.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the enumerable sequence.</typeparam>
+    /// <param name="source">The enumerable sequence to check for emptiness.</param>
+    /// <returns>True if the enumerable sequence is empty, or false if it is not.</returns>
     public static bool IsEmpty<T>([NotNullWhen(false)] this IEnumerable<T>? source)
     {
-        return source is null || !source.Any();
+        if (source is null)
+        {
+            return true;
+        }
+
+        if (source.TryGetNonEnumeratedCount(out int count))
+        {
+            return count == 0;
+        }
+
+        return !source.Any();
     }
 }

--- a/src/MooVC/Linq/EnumerableExtensions.IsEmpty.cs
+++ b/src/MooVC/Linq/EnumerableExtensions.IsEmpty.cs
@@ -4,6 +4,10 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
+/// <summary>
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Linq/EnumerableExtensions.SafeAny.cs
+++ b/src/MooVC/Linq/EnumerableExtensions.SafeAny.cs
@@ -7,11 +7,25 @@ using System.Linq;
 
 public static partial class EnumerableExtensions
 {
+    /// <summary>
+    /// Determines whether an enumerable sequence is not empty.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the enumerable sequence.</typeparam>
+    /// <param name="source">The enumerable sequence to check for emptiness.</param>
+    /// <returns>True if the enumerable sequence is not empty, or false if it is empty or null.</returns>
     public static bool SafeAny<T>([NotNullWhen(true)] this IEnumerable<T>? source)
     {
         return source is { } && source.Any();
     }
 
+    /// <summary>
+    /// Determines whether any elements of an enumerable sequence satisfy a condition.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the enumerable sequence.</typeparam>
+    /// <param name="source">The enumerable sequence to check for elements that satisfy the condition.</param>
+    /// <param name="predicate">A function to test each element for a condition.</param>
+    /// <returns>True if any elements in the enumerable sequence satisfy the condition, or false if none of the elements do or
+    /// the sequence is empty or null.</returns>
     public static bool SafeAny<T>([NotNullWhen(true)] this IEnumerable<T>? source, Func<T, bool> predicate)
     {
         return source is { } && source.Any(predicate);

--- a/src/MooVC/Linq/EnumerableExtensions.SafeAny.cs
+++ b/src/MooVC/Linq/EnumerableExtensions.SafeAny.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
+/// <summary>
+/// Provides extensions relating to <see cref="IEnumerable{T}"/>.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the enumeration.</typeparam>
 public static partial class EnumerableExtensions
 {
     /// <summary>

--- a/src/MooVC/Linq/EnumerableExtensions.SafeAny.cs
+++ b/src/MooVC/Linq/EnumerableExtensions.SafeAny.cs
@@ -24,8 +24,9 @@ public static partial class EnumerableExtensions
     /// <typeparam name="T">The type of the elements in the enumerable sequence.</typeparam>
     /// <param name="source">The enumerable sequence to check for elements that satisfy the condition.</param>
     /// <param name="predicate">A function to test each element for a condition.</param>
-    /// <returns>True if any elements in the enumerable sequence satisfy the condition, or false if none of the elements do or
-    /// the sequence is empty or null.</returns>
+    /// <returns>
+    /// True if any elements in the enumerable sequence satisfy the condition, or false if none of the elements do or the sequence is empty or null.
+    /// </returns>
     public static bool SafeAny<T>([NotNullWhen(true)] this IEnumerable<T>? source, Func<T, bool> predicate)
     {
         return source is { } && source.Any(predicate);

--- a/src/MooVC/Linq/PagedResult.cs
+++ b/src/MooVC/Linq/PagedResult.cs
@@ -49,6 +49,12 @@ public sealed class PagedResult<T>
         count = new(CalculateCount);
     }
 
+    /// <summary>
+    /// Supports deserialization of an instance of the <see cref="PagedResult{T}"/> class
+    /// via the specified <paramref name="info"/> and <paramref name="context"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
     private PagedResult(SerializationInfo info, StreamingContext context)
     {
         Request = info.TryGetValue(nameof(Request), defaultValue: Paging.Default);
@@ -97,6 +103,12 @@ public sealed class PagedResult<T>
         return Values.GetEnumerator();
     }
 
+    /// <summary>
+    /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
+    /// of the <see cref="PagedResult{T}"/> class.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
+    /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         _ = info.TryAddValue(nameof(Request), Request, defaultValue: Paging.Default);

--- a/src/MooVC/Linq/PagedResult.cs
+++ b/src/MooVC/Linq/PagedResult.cs
@@ -55,6 +55,8 @@ public sealed class PagedResult<T>
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
     /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     private PagedResult(SerializationInfo info, StreamingContext context)
     {
         Request = info.TryGetValue(nameof(Request), defaultValue: Paging.Default);
@@ -109,6 +111,8 @@ public sealed class PagedResult<T>
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         _ = info.TryAddValue(nameof(Request), Request, defaultValue: Paging.Default);

--- a/src/MooVC/Linq/PagedResult.cs
+++ b/src/MooVC/Linq/PagedResult.cs
@@ -9,37 +9,92 @@ using MooVC.Serialization;
 using static MooVC.Ensure;
 using static MooVC.Linq.Resources;
 
+/// <summary>
+/// Represents the result of a request to page a sequence of type <see cref="T"/>.
+/// </summary>
+/// <typeparam name="T">The type of the elements paged.</typeparam>
 [Serializable]
 public sealed class PagedResult<T>
     : ISerializable
 {
     private readonly Lazy<ulong> count;
 
+    /// <summary>
+    /// Initializes a new, empty instance, of the <see cref="PagedResult{T}"/> class.
+    /// </summary>
+    /// <param name="request">The request that was used to page the sequence.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> is <see langword="null" />.
+    /// </exception>
     public PagedResult(Paging request)
         : this(request, () => 0, Enumerable.Empty<T>())
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PagedResult{T}"/> class with the values paged from the sequence.
+    /// </summary>
+    /// <param name="request">The request that was used to page the sequence.</param>
+    /// <param name="values">The paged sequence of elements.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> is <see langword="null" />.
+    /// </exception>
     public PagedResult(Paging request, IEnumerable<T> values)
         : this(request, () => (ulong)values.LongCount(), values)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PagedResult{T}"/> class with the values paged from the sequence.
+    /// </summary>
+    /// <param name="request">The request that was used to page the sequence.</param>
+    /// <param name="total">The total number of elements in the sequence.</param>
+    /// <param name="values">The paged sequence of elements.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> is <see langword="null" />.
+    /// </exception>
     public PagedResult(Paging request, int total, IEnumerable<T> values)
         : this(request, () => (ulong)total, values)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PagedResult{T}"/> class with the values paged from the sequence.
+    /// </summary>
+    /// <param name="request">The request that was used to page the sequence.</param>
+    /// <param name="total">The total number of elements in the sequence.</param>
+    /// <param name="values">The paged sequence of elements.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> is <see langword="null" />.
+    /// </exception>
     public PagedResult(Paging request, long total, IEnumerable<T> values)
         : this(request, () => (ulong)total, values)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PagedResult{T}"/> class with the values paged from the sequence.
+    /// </summary>
+    /// <param name="request">The request that was used to page the sequence.</param>
+    /// <param name="total">The total number of elements in the sequence.</param>
+    /// <param name="values">The paged sequence of elements.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> is <see langword="null" />.
+    /// </exception>
     public PagedResult(Paging request, ulong total, IEnumerable<T> values)
         : this(request, () => total, values)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PagedResult{T}"/> class with the values paged from the sequence.
+    /// </summary>
+    /// <param name="request">The request that was used to page the sequence.</param>
+    /// <param name="total">A function that provides the total number of elements in the sequence.</param>
+    /// <param name="values">The paged sequence of elements.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="request"/> is <see langword="null" />.
+    /// </exception>
     private PagedResult(Paging request, Func<ulong> total, IEnumerable<T> values)
     {
         Request = IsNotNull(request, message: PagedResultRequestRequired);
@@ -66,20 +121,69 @@ public sealed class PagedResult<T>
         count = new(CalculateCount);
     }
 
+    /// <summary>
+    /// Gets the number of elements in this result.
+    /// </summary>
+    /// <value>
+    /// The number of elements in this result.
+    /// </value>
     public ulong Count => count.Value;
 
+    /// <summary>
+    /// Gets a value indicating whether this result has any elements.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if there are any results; otherwise, <c>false</c>.
+    /// </value>
     public bool HasResults => Count > 0;
 
+    /// <summary>
+    /// Gets a value indicating whether this result has no elements.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if there are no results; otherwise, <c>false</c>.
+    /// </value>
     public bool IsEmpty => Count == 0;
 
+    /// <summary>
+    /// Gets the request that was used to generate this result.
+    /// </summary>
+    /// <value>
+    /// The request that was used to generate this result.
+    /// </value>
     public Paging Request { get; }
 
+    /// <summary>
+    /// Gets the total number of elements in the sequence.
+    /// </summary>
+    /// <value>
+    /// The total number of elements in the sequence.
+    /// </value>
     public ulong Total { get; }
 
+    /// <summary>
+    /// Gets the paged sequence of elements.
+    /// </summary>
+    /// <value>
+    /// The paged sequence of elements.
+    /// </value>
     public IEnumerable<T> Values { get; }
 
+    /// <summary>
+    /// Gets the element at the specified index in the result set.
+    /// </summary>
+    /// <param name="index">The zero-based index of the element to get.</param>
+    /// <returns>The element at the specified index in the result set.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is outside the bounds of the <paramref name="Values" /> sequence.
+    /// </exception>
     public T this[int index] => Values.ElementAt(index);
 
+    /// <summary>
+    /// Implicitly converts the specified <paramref name="result"/> to an array of <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="result">The result to convert.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
     public static implicit operator T[](PagedResult<T>? result)
     {
         if (result is null)
@@ -90,6 +194,11 @@ public sealed class PagedResult<T>
         return result.Values.ToArray();
     }
 
+    /// <summary>
+    /// Implicitly converts the specified <paramref name="result"/> to a ulong representing the <paramref name="Count"/> of elements returned.
+    /// </summary>
+    /// <param name="result">The result to convert.</param>
+    /// <returns>The count of elements stored within the <paramref name="result"/>.</returns>
     public static implicit operator ulong(PagedResult<T>? result)
     {
         if (result is null)
@@ -100,6 +209,10 @@ public sealed class PagedResult<T>
         return result.Count;
     }
 
+    /// <summary>
+    /// Returns an enumerator that iterates through the elements in the result set.
+    /// </summary>
+    /// <returns>An enumerator for the elements in the result set.</returns>
     public IEnumerator<T> GetEnumerator()
     {
         return Values.GetEnumerator();

--- a/src/MooVC/Linq/Paging.cs
+++ b/src/MooVC/Linq/Paging.cs
@@ -6,17 +6,37 @@ using System.Runtime.Serialization;
 using MooVC.Serialization;
 using static System.Math;
 
+/// <summary>
+/// Represents paging information used to control the amount of data returned from a sequence or query.
+/// </summary>
 [Serializable]
 public class Paging
     : ISerializable
 {
+    /// <summary>
+    /// The default number of items per page.
+    /// </summary>
     public const ushort DefaultSize = 10;
+
+    /// <summary>
+    /// The index assigned to the first page of a sequence.
+    /// </summary>
     public const ushort FirstPage = 1;
+
+    /// <summary>
+    /// The minimum number of items per page.
+    /// </summary>
     public const ushort MinimumSize = 1;
+
     private static readonly Lazy<Paging> @default = new(() => new Paging());
     private static readonly Lazy<Paging> none = new(() => new Paging(size: ushort.MaxValue));
     private static readonly Lazy<Paging> one = new(() => new Paging(size: 1));
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Paging"/> class.
+    /// </summary>
+    /// <param name="page">The page number to retrieve.</param>
+    /// <param name="size">The number of items per page.</param>
     public Paging(ushort page = FirstPage, ushort size = DefaultSize)
     {
         Page = Max(page, FirstPage);
@@ -37,27 +57,86 @@ public class Paging
         Size = info.GetValue<ushort>(nameof(Size));
     }
 
+    /// <summary>
+    /// Gets the default <see cref="Paging"/> instance.
+    /// </summary>
+    /// <value>
+    /// The default <see cref="Paging"/> instance, which uses the <see cref="FirstPage"/> and <see cref="DefaultSize"/> values.
+    /// </value>
     public static Paging Default => @default.Value;
 
+    /// <summary>
+    /// Gets the <see cref="Paging"/> instance that indicates that no paging be applied.
+    /// </summary>
+    /// <value>
+    /// The <see cref="Paging"/> instance that indicates that no paging be applied.
+    /// </value>
     public static Paging None => none.Value;
 
+    /// <summary>
+    /// Gets the <see cref="Paging"/> instance that indicates that only one value be returned from the top of the sequence.
+    /// </summary>
+    /// <value>
+    /// The <see cref="Paging"/> instance that indicates that only one value be returned from the top of the sequence.
+    /// </value>
     public static Paging One => one.Value;
 
+    /// <summary>
+    /// Gets a value indicating whether this instance is the default instance.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the instance is the default instance; otherwise, <c>false</c>.
+    /// </value>
     public bool IsDefault => this == Default;
 
+    /// <summary>
+    /// Gets a value indicating whether this instance is the none instance.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the instance is the none instance; otherwise, <c>false</c>.
+    /// </value>
     public bool IsNone => this == None;
 
+    /// <summary>
+    /// Gets the requested page number, starting from <see cref="FirstPage"/>.
+    /// </summary>
+    /// <value>
+    /// The requested page number.
+    /// </value>
     public ushort Page { get; } = FirstPage;
 
+    /// <summary>
+    /// Gets the size associated with a page.
+    /// </summary>
+    /// <value>
+    /// The size associated with a page.
+    /// </value>
     public ushort Size { get; } = DefaultSize;
 
+    /// <summary>
+    /// Gets the number of entries in the sequence to be skipped to read the beginning of the desired page.
+    /// </summary>
+    /// <value>
+    /// The number of entries in the sequence to be skipped to read the beginning of the desired page.
+    /// </value>
     public int Skip => (Page - FirstPage) * Size;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="ushort"/> value to a <see cref="Paging"/> instance that requests the first page of a sequence with
+    /// a <see cref="Size"/> matching the value specified or <see cref="MinimumSize"/> if a zero value is provided.
+    /// </summary>
+    /// <param name="size">The size associated with a page.</param>
+    /// <returns>A new <see cref="Paging"/> instance that requests the first page of a sequence sized at the value specified.</returns>
     public static implicit operator Paging(ushort size)
     {
         return (FirstPage, size);
     }
 
+    /// <summary>
+    /// Implicitly converts a tuple of <see cref="ushort"/> values to a <see cref="Paging"/> instance.
+    /// </summary>
+    /// <param name="paging">A tuple containing the page number and number of items per page.</param>
+    /// <returns>A new <see cref="Paging"/> instance with the specified page number and number of items per page.</returns>
     public static implicit operator Paging((ushort Page, ushort Size) paging)
     {
         Paging? result = default;
@@ -76,6 +155,12 @@ public class Paging
         return result ?? new Paging(page: paging.Page, size: paging.Size);
     }
 
+    /// <summary>
+    /// Applies the paging information to the specified <paramref name="queryable"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of element in the queryable.</typeparam>
+    /// <param name="queryable">The queryable to which the paging is to be applied.</param>
+    /// <returns>A new <see cref="IQueryable{T}"/> with the paging information applied.</returns>
     public virtual IQueryable<T> Apply<T>(IQueryable<T> queryable)
     {
         if (IsNone)
@@ -100,6 +185,12 @@ public class Paging
         info.AddValue(nameof(Size), Size);
     }
 
+    /// <summary>
+    /// Returns a new <see cref="Paging"/> instance representing the next page in the sequence or query.
+    /// </summary>
+    /// <returns>
+    /// A new <see cref="Paging"/> instance representing the next page in the sequence or query.
+    /// </returns>
     public virtual Paging Next()
     {
         if (Page == ushort.MaxValue)
@@ -110,6 +201,12 @@ public class Paging
         return new Paging(page: (ushort)(Page + 1), size: Size);
     }
 
+    /// <summary>
+    /// Returns a new <see cref="Paging"/> instance representing the previous page in the sequence or query.
+    /// </summary>
+    /// <returns>
+    /// A new <see cref="Paging"/> instance representing the previous page in the sequence or query.
+    /// </returns>
     public virtual Paging Previous()
     {
         if (Page == FirstPage)

--- a/src/MooVC/Linq/Paging.cs
+++ b/src/MooVC/Linq/Paging.cs
@@ -23,6 +23,12 @@ public class Paging
         Size = Max(size, MinimumSize);
     }
 
+    /// <summary>
+    /// Supports deserialization of an instance of the <see cref="Paging"/> class
+    /// via the specified <paramref name="info"/> and <paramref name="context"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
     protected Paging(SerializationInfo info, StreamingContext context)
     {
         Page = info.GetValue<ushort>(nameof(Page));
@@ -78,6 +84,12 @@ public class Paging
         return queryable.Skip(Skip).Take(Size);
     }
 
+    /// <summary>
+    /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
+    /// of the <see cref="Paging"/> class.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
+    /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
     public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         info.AddValue(nameof(Page), Page);

--- a/src/MooVC/Linq/Paging.cs
+++ b/src/MooVC/Linq/Paging.cs
@@ -29,6 +29,8 @@ public class Paging
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
     /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     protected Paging(SerializationInfo info, StreamingContext context)
     {
         Page = info.GetValue<ushort>(nameof(Page));
@@ -90,6 +92,8 @@ public class Paging
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         info.AddValue(nameof(Page), Page);

--- a/src/MooVC/Linq/QueryableExtensions.Page.cs
+++ b/src/MooVC/Linq/QueryableExtensions.Page.cs
@@ -3,6 +3,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
+/// <summary>
+/// Provides extensions relating to <see cref="IQueryable{T}"/>.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the sequence.</typeparam>
 public static partial class QueryableExtensions
 {
     /// <summary>

--- a/src/MooVC/Linq/QueryableExtensions.Page.cs
+++ b/src/MooVC/Linq/QueryableExtensions.Page.cs
@@ -5,6 +5,15 @@ using System.Linq;
 
 public static partial class QueryableExtensions
 {
+    /// <summary>
+    /// Applies paging to an IQueryable sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the IQueryable sequence.</typeparam>
+    /// <param name="queryable">The IQueryable sequence to apply paging to.</param>
+    /// <param name="paging">The paging parameters to apply to the IQueryable sequence.</param>
+    /// <returns>
+    /// The original IQueryable sequence with paging applied, or null if the original IQueryable was null.
+    /// </returns>
     [return: NotNullIfNotNull("queryable")]
     public static IQueryable<T>? Page<T>(this IQueryable<T>? queryable, Paging? paging)
     {

--- a/src/MooVC/Linq/QueryableExtensions.ToResult.cs
+++ b/src/MooVC/Linq/QueryableExtensions.ToResult.cs
@@ -5,6 +5,15 @@ using System.Linq;
 
 public static partial class QueryableExtensions
 {
+    /// <summary>
+    /// Applies paging to an IQueryable sequence to produce a paged result.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the IQueryable sequence.</typeparam>
+    /// <param name="queryable">The IQueryable sequence to which paging is to be applied.</param>
+    /// <param name="paging">The paging parameters to apply to the IQueryable sequence.</param>
+    /// <returns>
+    /// A paged result that contains the elements of the IQueryable sequence, with paging applied and metadata about the total number of
+    /// elements and the applied paging parameters.</returns>
     public static PagedResult<T> ToResult<T>(this IQueryable<T>? queryable, Paging? paging)
     {
         ulong total = 0;

--- a/src/MooVC/Linq/QueryableExtensions.ToResult.cs
+++ b/src/MooVC/Linq/QueryableExtensions.ToResult.cs
@@ -13,7 +13,8 @@ public static partial class QueryableExtensions
     /// <param name="paging">The paging parameters to apply to the IQueryable sequence.</param>
     /// <returns>
     /// A paged result that contains the elements of the IQueryable sequence, with paging applied and metadata about the total number of
-    /// elements and the applied paging parameters.</returns>
+    /// elements and the applied paging parameters.
+    /// </returns>
     public static PagedResult<T> ToResult<T>(this IQueryable<T>? queryable, Paging? paging)
     {
         ulong total = 0;

--- a/src/MooVC/Linq/QueryableExtensions.ToResult.cs
+++ b/src/MooVC/Linq/QueryableExtensions.ToResult.cs
@@ -3,6 +3,10 @@
 using System;
 using System.Linq;
 
+/// <summary>
+/// Provides extensions relating to <see cref="IQueryable{T}"/>.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the sequence.</typeparam>
 public static partial class QueryableExtensions
 {
     /// <summary>

--- a/src/MooVC/MulticastDelegateExtensions.EnsureParameters.cs
+++ b/src/MooVC/MulticastDelegateExtensions.EnsureParameters.cs
@@ -5,8 +5,20 @@ using System.Reflection;
 using static System.String;
 using static MooVC.Resources;
 
+/// <summary>
+/// Provides methods to support event propagation.
+/// </summary>
 public static partial class MulticastDelegateExtensions
 {
+    /// <summary>
+    /// Ensures that a multicast delegate matches the expected signature for a derivation of the AsyncEventHandler.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender from which the event has originated.</typeparam>
+    /// <typeparam name="TArgs">The type of the event arguments.</typeparam>
+    /// <param name="method">The method definition for the multicast delegate.</param>
+    /// <exception cref="NotSupportedException">
+    /// The multicast delegate does not match the expected signature for an AsyncEventHandler.
+    /// </exception>
     private static void EnsureParameters<TSender, TArgs>(MethodInfo method)
         where TSender : class
         where TArgs : EventArgs

--- a/src/MooVC/MulticastDelegateExtensions.InvokeAsync.cs
+++ b/src/MooVC/MulticastDelegateExtensions.InvokeAsync.cs
@@ -6,8 +6,21 @@ using System.Threading.Tasks;
 using MooVC.Collections.Generic;
 using static MooVC.Resources;
 
+/// <summary>
+/// Provides methods to support event propagation.
+/// </summary>
 public static partial class MulticastDelegateExtensions
 {
+    /// <summary>
+    /// Invokes a multicast delegate asynchronously.
+    /// The multicast delegate is assumed to be a derivation of the AsyncEventHandler.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender from which the event has originated.</typeparam>
+    /// <typeparam name="TArgs">The type of the event arguments.</typeparam>
+    /// <param name="handler">The multicast delegate that holds the list of subscribers for the event.</param>
+    /// <param name="sender">The sender of the event.</param>
+    /// <param name="e">The event arguments.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static async Task InvokeAsync<TSender, TArgs>(this MulticastDelegate? handler, TSender? sender, TArgs e)
         where TSender : class
         where TArgs : AsyncEventArgs

--- a/src/MooVC/MulticastDelegateExtensions.PassiveInvoke.cs
+++ b/src/MooVC/MulticastDelegateExtensions.PassiveInvoke.cs
@@ -5,8 +5,20 @@ using System.Reflection;
 using MooVC.Collections.Generic;
 using static MooVC.Resources;
 
+/// <summary>
+/// Provides methods to support event propagation.
+/// </summary>
 public static partial class MulticastDelegateExtensions
 {
+    /// <summary>
+    /// Invokes a multicast delegate synchronously, with the option to handle any failures that may occur without throwing an exception.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender from which the event has originated.</typeparam>
+    /// <typeparam name="TArgs">The type of the event arguments.</typeparam>
+    /// <param name="handler">The multicast delegate that holds the list of subscribers for the event.</param>
+    /// <param name="sender">The sender of the event.</param>
+    /// <param name="e">The event arguments.</param>
+    /// <param name="onFailure">A delegate to be executed if any of the handlers throws an exception.</param>
     public static void PassiveInvoke<TSender, TArgs>(
         this MulticastDelegate? handler,
         TSender? sender,

--- a/src/MooVC/MulticastDelegateExtensions.PassiveInvokeAsync.cs
+++ b/src/MooVC/MulticastDelegateExtensions.PassiveInvokeAsync.cs
@@ -3,8 +3,22 @@
 using System;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides methods to support event propagation.
+/// </summary>
 public static partial class MulticastDelegateExtensions
 {
+    /// <summary>
+    /// Invokes a multicast delegate asynchronously, with the option to handle any failures that may occur without throwing an exception.
+    /// The multicast delegate is assumed to be a derivation of the AsyncEventHandler.
+    /// </summary>
+    /// <typeparam name="TSender">The type of the sender from which the event has originated.</typeparam>
+    /// <typeparam name="TArgs">The type of the event arguments.</typeparam>
+    /// <param name="handler">The multicast delegate that holds the list of subscribers for the event.</param>
+    /// <param name="sender">The sender of the event.</param>
+    /// <param name="e">The event arguments.</param>
+    /// <param name="onFailure">A delegate to be executed if any of the handlers throws an exception.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static async Task PassiveInvokeAsync<TSender, TArgs>(
         this MulticastDelegate? handler,
         TSender? sender,

--- a/src/MooVC/Persistence/IEventStore.cs
+++ b/src/MooVC/Persistence/IEventStore.cs
@@ -16,46 +16,35 @@ public interface IEventStore<T, TIndex>
     /// <summary>
     /// Asynchronously retrieves the event with the specified <paramref name="index"/> from the event store.
     /// </summary>
-    /// <param name="index">
-    /// The index of the event to retrieve.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="index">The index of the event to retrieve.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the event with the specified
-    /// <paramref name="index"/>, or null if no such event exists.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the event with the specified <paramref name="index"/>, or null if no such event exists.
     /// </returns>
     Task<T?> GetAsync(TIndex index, CancellationToken? cancellationToken = default);
 
     /// <summary>
     /// Asynchronously inserts the specified <paramref name="event"/> into the event store.
     /// </summary>
-    /// <param name="event">
-    /// The event to insert.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="event">The event to insert.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the index of the newly inserted event.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the index of the newly inserted event.
     /// </returns>
     Task<TIndex> InsertAsync(T @event, CancellationToken? cancellationToken = default);
 
     /// <summary>
     /// Asynchronously retrieves events starting from after the specified <paramref name="lastIndex"/> and totalling
-    /// no more than <paramref name="numberToRead"/>.</summary>
-    /// <param name="lastIndex">
-    /// The index of the previous event read from the stream.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
-    /// <param name="numberToRead">
-    /// The number of events to read from the stream following <paramref name="lastIndex"/>.
-    /// </param>
+    /// no more than <paramref name="numberToRead"/>.
+    /// </summary>
+    /// <param name="lastIndex">The index of the previous event read from the stream.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <param name="numberToRead">The number of events to read from the stream following <paramref name="lastIndex"/>.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the list of matching events.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the list of matching events.
     /// </returns>
     Task<IEnumerable<T>> ReadAsync(TIndex lastIndex, CancellationToken? cancellationToken = default, ushort numberToRead = Paging.DefaultSize);
 }

--- a/src/MooVC/Persistence/IEventStore.cs
+++ b/src/MooVC/Persistence/IEventStore.cs
@@ -23,7 +23,7 @@ public interface IEventStore<T, TIndex>
     /// An optional cancellation token that can be used to cancel the operation.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the event with the specified
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the event with the specified
     /// <paramref name="index"/>, or null if no such event exists.
     /// </returns>
     Task<T?> GetAsync(TIndex index, CancellationToken? cancellationToken = default);
@@ -38,7 +38,7 @@ public interface IEventStore<T, TIndex>
     /// An optional cancellation token that can be used to cancel the operation.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the index of the newly inserted event.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the index of the newly inserted event.
     /// </returns>
     Task<TIndex> InsertAsync(T @event, CancellationToken? cancellationToken = default);
 
@@ -55,7 +55,7 @@ public interface IEventStore<T, TIndex>
     /// The number of events to read from the stream following <paramref name="lastIndex"/>.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the list of matching events.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The task result contains the list of matching events.
     /// </returns>
     Task<IEnumerable<T>> ReadAsync(TIndex lastIndex, CancellationToken? cancellationToken = default, ushort numberToRead = Paging.DefaultSize);
 }

--- a/src/MooVC/Persistence/IEventStore.cs
+++ b/src/MooVC/Persistence/IEventStore.cs
@@ -5,12 +5,57 @@ using System.Threading;
 using System.Threading.Tasks;
 using MooVC.Linq;
 
+/// <summary>
+/// Represents a storage location for a stream of indexed events.
+/// </summary>
+/// <typeparam name="T">The type of the events within the stream.</typeparam>
+/// <typeparam name="TIndex">The type of index for the events.</typeparam>
 public interface IEventStore<T, TIndex>
     where T : class
 {
+    /// <summary>
+    /// Asynchronously retrieves the event with the specified <paramref name="index"/> from the event store.
+    /// </summary>
+    /// <param name="index">
+    /// The index of the event to retrieve.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the event with the specified
+    /// <paramref name="index"/>, or null if no such event exists.
+    /// </returns>
     Task<T?> GetAsync(TIndex index, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously inserts the specified <paramref name="event"/> into the event store.
+    /// </summary>
+    /// <param name="event">
+    /// The event to insert.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the index of the newly inserted event.
+    /// </returns>
     Task<TIndex> InsertAsync(T @event, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously retrieves events starting from after the specified <paramref name="lastIndex"/> and totalling
+    /// no more than <paramref name="numberToRead"/>.</summary>
+    /// <param name="lastIndex">
+    /// The index of the previous event read from the stream.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <param name="numberToRead">
+    /// The number of events to read from the stream following <paramref name="lastIndex"/>.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the list of matching events.
+    /// </returns>
     Task<IEnumerable<T>> ReadAsync(TIndex lastIndex, CancellationToken? cancellationToken = default, ushort numberToRead = Paging.DefaultSize);
 }

--- a/src/MooVC/Persistence/IStore.cs
+++ b/src/MooVC/Persistence/IStore.cs
@@ -15,11 +15,10 @@ public interface IStore<T, TKey>
     /// Asynchronously creates a new item in the store.
     /// </summary>
     /// <param name="item">The item to create.</param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task"/> that represents the asynchronous operation. The task result contains the key of the newly created item.
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains the key of the newly created item.
     /// </returns>
     Task<TKey> CreateAsync(T item, CancellationToken? cancellationToken = default);
 
@@ -27,9 +26,7 @@ public interface IStore<T, TKey>
     /// Asynchronously deletes an item from the store.
     /// </summary>
     /// <param name="item">The item to delete.</param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     Task DeleteAsync(T item, CancellationToken? cancellationToken = default);
 
@@ -37,9 +34,7 @@ public interface IStore<T, TKey>
     /// Asynchronously deletes an item from the store.
     /// </summary>
     /// <param name="key">The key that identifies the item to delete.</param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     Task DeleteAsync(TKey key, CancellationToken? cancellationToken = default);
 
@@ -47,24 +42,21 @@ public interface IStore<T, TKey>
     /// Asynchronously retrieves an item from the store.
     /// </summary>
     /// <param name="key">The key that identifies the item to retrieve.</param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task"/> that represents the asynchronous operation. The task result contains the item with the specified
-    /// <paramref name="key"/>, or null if no such item exists.
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains the item with the specified <paramref name="key"/>, or null if no such item exists.
     /// </returns>
     Task<T?> GetAsync(TKey key, CancellationToken? cancellationToken = default);
 
     /// <summary>
     /// Asynchronously retrieves item from the store, and optionally applies <paramref name="paging"/>.
     /// </summary>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <param name="paging">Optional paging instructions to be applied to the results.</param>
     /// <returns>
-    /// A <see cref="Task"/> that represents the asynchronous operation. The task result contains paging instructions for the matching items.
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains paging instructions for the matching items.
     /// </returns>
     Task<PagedResult<T>> GetAsync(CancellationToken? cancellationToken = default, Paging? paging = default);
 
@@ -72,9 +64,7 @@ public interface IStore<T, TKey>
     /// Asynchronously updates an existing item within the store.
     /// </summary>
     /// <param name="item">The item to update.</param>
-    /// <param name="cancellationToken">
-    /// An optional cancellation token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     Task UpdateAsync(T item, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Persistence/IStore.cs
+++ b/src/MooVC/Persistence/IStore.cs
@@ -4,17 +4,78 @@ using System.Threading;
 using System.Threading.Tasks;
 using MooVC.Linq;
 
+/// <summary>
+/// Represents a generic store for persisted items.
+/// </summary>
+/// <typeparam name="T">The type of the items in the store.</typeparam>
+/// <typeparam name="TKey">The type of the keys used to identify items in the store.</typeparam>
 public interface IStore<T, TKey>
 {
+    /// <summary>
+    /// Asynchronously creates a new item in the store.
+    /// </summary>
+    /// <param name="item">The item to create.</param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result
+    /// contains the key of the newly created item.
+    /// </returns>
     Task<TKey> CreateAsync(T item, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously deletes an item from the store.
+    /// </summary>
+    /// <param name="item">The item to delete.</param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task DeleteAsync(T item, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously deletes an item from the store.
+    /// </summary>
+    /// <param name="key">The key that identifies the item to delete.</param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task DeleteAsync(TKey key, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously retrieves an item from the store.
+    /// </summary>
+    /// <param name="key">The key that identifies the item to retrieve.</param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the item with the specified
+    /// <paramref name="key"/>, or null if no such item exists.
+    /// </returns>
     Task<T?> GetAsync(TKey key, CancellationToken? cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously retrieves item from the store, and optionally applies <paramref name="paging"/>.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <param name="paging">Optional paging instructions to be applied to the results.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains paging instructions for the matching items.
+    /// </returns>
     Task<PagedResult<T>> GetAsync(CancellationToken? cancellationToken = default, Paging? paging = default);
 
+    /// <summary>
+    /// Asynchronously updates an existing item within the store.
+    /// </summary>
+    /// <param name="item">The item to update.</param>
+    /// <param name="cancellationToken">
+    /// An optional cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task UpdateAsync(T item, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Persistence/IStore.cs
+++ b/src/MooVC/Persistence/IStore.cs
@@ -19,8 +19,7 @@ public interface IStore<T, TKey>
     /// An optional cancellation token that can be used to cancel the operation.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result
-    /// contains the key of the newly created item.
+    /// A <see cref="Task"/> that represents the asynchronous operation. The task result contains the key of the newly created item.
     /// </returns>
     Task<TKey> CreateAsync(T item, CancellationToken? cancellationToken = default);
 
@@ -31,7 +30,7 @@ public interface IStore<T, TKey>
     /// <param name="cancellationToken">
     /// An optional cancellation token that can be used to cancel the operation.
     /// </param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     Task DeleteAsync(T item, CancellationToken? cancellationToken = default);
 
     /// <summary>
@@ -41,7 +40,7 @@ public interface IStore<T, TKey>
     /// <param name="cancellationToken">
     /// An optional cancellation token that can be used to cancel the operation.
     /// </param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     Task DeleteAsync(TKey key, CancellationToken? cancellationToken = default);
 
     /// <summary>
@@ -52,7 +51,7 @@ public interface IStore<T, TKey>
     /// An optional cancellation token that can be used to cancel the operation.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the item with the specified
+    /// A <see cref="Task"/> that represents the asynchronous operation. The task result contains the item with the specified
     /// <paramref name="key"/>, or null if no such item exists.
     /// </returns>
     Task<T?> GetAsync(TKey key, CancellationToken? cancellationToken = default);
@@ -65,7 +64,7 @@ public interface IStore<T, TKey>
     /// </param>
     /// <param name="paging">Optional paging instructions to be applied to the results.</param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains paging instructions for the matching items.
+    /// A <see cref="Task"/> that represents the asynchronous operation. The task result contains paging instructions for the matching items.
     /// </returns>
     Task<PagedResult<T>> GetAsync(CancellationToken? cancellationToken = default, Paging? paging = default);
 
@@ -76,6 +75,6 @@ public interface IStore<T, TKey>
     /// <param name="cancellationToken">
     /// An optional cancellation token that can be used to cancel the operation.
     /// </param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     Task UpdateAsync(T item, CancellationToken? cancellationToken = default);
 }

--- a/src/MooVC/Persistence/IStore.cs
+++ b/src/MooVC/Persistence/IStore.cs
@@ -50,7 +50,7 @@ public interface IStore<T, TKey>
     Task<T?> GetAsync(TKey key, CancellationToken? cancellationToken = default);
 
     /// <summary>
-    /// Asynchronously retrieves item from the store, and optionally applies <paramref name="paging"/>.
+    /// Asynchronously retrieves items from the store, and optionally applies <paramref name="paging"/>.
     /// </summary>
     /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <param name="paging">Optional paging instructions to be applied to the results.</param>

--- a/src/MooVC/Persistence/MappedStore.cs
+++ b/src/MooVC/Persistence/MappedStore.cs
@@ -27,11 +27,11 @@ public sealed class MappedStore<T, TOutterKey, TInnerKey>
     /// <param name="outterMapping">A function that maps an item and an internal key to an external key.</param>
     /// <param name="store">The store to wrap.</param>
     /// <exception cref="ArgumentNullException">
-    /// <paramref name="innerMapping"/> is null.
+    /// <paramref name="innerMapping"/> is <see langword="null" />.
     /// <para>-or-</para>
-    /// <paramref name="outterMapping"/> is null.
+    /// <paramref name="outterMapping"/> is <see langword="null" />.
     /// <para>-or-</para>
-    /// <paramref name="store"/> is null.
+    /// <paramref name="store"/> is <see langword="null" />.
     /// </exception>
     public MappedStore(Func<TOutterKey, TInnerKey> innerMapping, Func<T, TInnerKey, TOutterKey> outterMapping, IStore<T, TInnerKey> store)
     {

--- a/src/MooVC/Persistence/MappedStore.cs
+++ b/src/MooVC/Persistence/MappedStore.cs
@@ -7,6 +7,12 @@ using MooVC.Linq;
 using static MooVC.Ensure;
 using static MooVC.Persistence.Resources;
 
+/// <summary>
+/// Serves as an adapter, allowing for access to a resource via an alternative key than that applied by the implementing.
+/// </summary>
+/// <typeparam name="T">The type of the items in the store.</typeparam>
+/// <typeparam name="TOutterKey">The type of the keys used to identify items in the store from an external perspective.</typeparam>
+/// <typeparam name="TInnerKey">The type of the keys used to identify items in the store from an internal perspective.</typeparam>
 public sealed class MappedStore<T, TOutterKey, TInnerKey>
     : IStore<T, TOutterKey>
 {
@@ -14,6 +20,19 @@ public sealed class MappedStore<T, TOutterKey, TInnerKey>
     private readonly Func<T, TInnerKey, TOutterKey> outterMapping;
     private readonly IStore<T, TInnerKey> store;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MappedStore{T, TOutterKey, TInnerKey}"/> class.
+    /// </summary>
+    /// <param name="innerMapping">A function that maps an external key to an internal key.</param>
+    /// <param name="outterMapping">A function that maps an item and an internal key to an external key.</param>
+    /// <param name="store">The store to wrap.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="innerMapping"/> is null.
+    /// <para>-or-</para>
+    /// <paramref name="outterMapping"/> is null.
+    /// <para>-or-</para>
+    /// <paramref name="store"/> is null.
+    /// </exception>
     public MappedStore(Func<TOutterKey, TInnerKey> innerMapping, Func<T, TInnerKey, TOutterKey> outterMapping, IStore<T, TInnerKey> store)
     {
         this.innerMapping = IsNotNull(innerMapping, message: MappedStoreInnerMappingRequired);
@@ -21,6 +40,15 @@ public sealed class MappedStore<T, TOutterKey, TInnerKey>
         this.store = IsNotNull(store, message: MappedStoreStoreRequired);
     }
 
+    /// <summary>
+    /// Asynchronously creates a new item in the store and maps the internal key supplied to the expected external key.
+    /// </summary>
+    /// <param name="item">The item to create.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains the mapped key of the newly created item.
+    /// </returns>
     public async Task<TOutterKey> CreateAsync(T item, CancellationToken? cancellationToken = default)
     {
         TInnerKey innerKey = await store
@@ -30,11 +58,23 @@ public sealed class MappedStore<T, TOutterKey, TInnerKey>
         return outterMapping(item, innerKey);
     }
 
+    /// <summary>
+    /// Asynchronously deletes an item from the store.
+    /// </summary>
+    /// <param name="item">The item to delete.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     public Task DeleteAsync(T item, CancellationToken? cancellationToken = default)
     {
         return store.DeleteAsync(item, cancellationToken: cancellationToken);
     }
 
+    /// <summary>
+    /// Asynchronously deletes an item from the store.
+    /// </summary>
+    /// <param name="outterKey">The external key that identifies the item to delete.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     public Task DeleteAsync(TOutterKey outterKey, CancellationToken? cancellationToken = default)
     {
         TInnerKey innerKey = innerMapping(outterKey);
@@ -42,6 +82,15 @@ public sealed class MappedStore<T, TOutterKey, TInnerKey>
         return store.DeleteAsync(innerKey, cancellationToken: cancellationToken);
     }
 
+    /// <summary>
+    /// Asynchronously retrieves an item from the store.
+    /// </summary>
+    /// <param name="outterKey">The external key that identifies the item to retrieve.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains the item with the specified <paramref name="outterKey"/>, or null if no such item exists.
+    /// </returns>
     public Task<T?> GetAsync(TOutterKey outterKey, CancellationToken? cancellationToken = default)
     {
         TInnerKey innerKey = innerMapping(outterKey);
@@ -49,11 +98,26 @@ public sealed class MappedStore<T, TOutterKey, TInnerKey>
         return store.GetAsync(innerKey, cancellationToken: cancellationToken);
     }
 
+    /// <summary>
+    /// Asynchronously retrieves item from the store, and optionally applies <paramref name="paging"/>.
+    /// </summary>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <param name="paging">Optional paging instructions to be applied to the results.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains paging instructions for the matching items.
+    /// </returns>
     public Task<PagedResult<T>> GetAsync(CancellationToken? cancellationToken = default, Paging? paging = default)
     {
         return store.GetAsync(cancellationToken: cancellationToken, paging: paging);
     }
 
+    /// <summary>
+    /// Asynchronously updates an existing item within the store.
+    /// </summary>
+    /// <param name="item">The item to update.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     public Task UpdateAsync(T item, CancellationToken? cancellationToken = default)
     {
         return store.UpdateAsync(item, cancellationToken: cancellationToken);

--- a/src/MooVC/Persistence/SynchronousEventStore.cs
+++ b/src/MooVC/Persistence/SynchronousEventStore.cs
@@ -4,28 +4,79 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Facilitates synchronous implementation of a storage location for a stream of indexed events.
+/// </summary>
+/// <typeparam name="T">The type of the events within the stream.</typeparam>
+/// <typeparam name="TIndex">The type of index for the events.</typeparam>
 public abstract class SynchronousEventStore<T, TIndex>
     : IEventStore<T, TIndex>
     where T : class
 {
+    /// <summary>
+    /// Asynchronously retrieves the event with the specified <paramref name="index"/> from the event store.
+    /// </summary>
+    /// <param name="index">The index of the event to retrieve.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the event with the specified <paramref name="index"/>, or null if no such event exists.
+    /// </returns>
     public virtual Task<T?> GetAsync(TIndex index, CancellationToken? cancellationToken = default)
     {
         return Task.FromResult(PerformGet(index));
     }
 
+    /// <summary>
+    /// Asynchronously inserts the specified <paramref name="event"/> into the event store.
+    /// </summary>
+    /// <param name="event">The event to insert.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the index of the newly inserted event.
+    /// </returns>
     public virtual Task<TIndex> InsertAsync(T @event, CancellationToken? cancellationToken = default)
     {
         return Task.FromResult(PerformInsert(@event));
     }
 
+    /// <summary>
+    /// Asynchronously retrieves events starting from after the specified <paramref name="lastIndex"/> and totalling
+    /// no more than <paramref name="numberToRead"/>.
+    /// </summary>
+    /// <param name="lastIndex">The index of the previous event read from the stream.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <param name="numberToRead">The number of events to read from the stream following <paramref name="lastIndex"/>.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The task result contains the list of matching events.
+    /// </returns>
     public virtual Task<IEnumerable<T>> ReadAsync(TIndex lastIndex, CancellationToken? cancellationToken = default, ushort numberToRead = 10)
     {
         return Task.FromResult(PerformRead(lastIndex, numberToRead: numberToRead));
     }
 
-    protected abstract TIndex PerformInsert(T @event);
-
+    /// <summary>
+    /// Facilitates synchronous implementation of event retrieval with the specified <paramref name="index"/> from the event store.
+    /// </summary>
+    /// <param name="index">The index of the event to retrieve.</param>
+    /// <returns>The event with the specified <paramref name="index"/>, or null if no such event exists.</returns>
     protected abstract T? PerformGet(TIndex index);
 
+    /// <summary>
+    /// Facilitates synchronous implementation of event insertion into the event store.
+    /// </summary>
+    /// <param name="event">The event to insert.</param>
+    /// <returns>The index of the newly inserted event.</returns>
+    protected abstract TIndex PerformInsert(T @event);
+
+    /// <summary>
+    /// Facilitates synchronous implementation event retrieval starting from after the specified
+    /// <paramref name="lastIndex"/> and totalling no more than <paramref name="numberToRead"/>.
+    /// </summary>
+    /// <param name="lastIndex">The index of the previous event read from the stream.</param>
+    /// <param name="numberToRead">The number of events to read from the stream following <paramref name="lastIndex"/>.</param>
+    /// <returns>The list of matching events.</returns>
     protected abstract IEnumerable<T> PerformRead(TIndex lastIndex, ushort numberToRead = 10);
 }

--- a/src/MooVC/Persistence/SynchronousStore.cs
+++ b/src/MooVC/Persistence/SynchronousStore.cs
@@ -4,14 +4,34 @@ using System.Threading;
 using System.Threading.Tasks;
 using MooVC.Linq;
 
+/// <summary>
+/// Facilitates synchronous implementation of a generic store for persisted items.
+/// </summary>
+/// <typeparam name="T">The type of the items in the store.</typeparam>
+/// <typeparam name="TKey">The type of the keys used to identify items in the store.</typeparam>
 public abstract class SynchronousStore<T, TKey>
     : IStore<T, TKey>
 {
+    /// <summary>
+    /// Asynchronously creates a new item in the store.
+    /// </summary>
+    /// <param name="item">The item to create.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains the key of the newly created item.
+    /// </returns>
     public virtual async Task<TKey> CreateAsync(T item, CancellationToken? cancellationToken = default)
     {
         return await Task.FromResult(PerformCreate(item));
     }
 
+    /// <summary>
+    /// Asynchronously deletes an item from the store.
+    /// </summary>
+    /// <param name="item">The item to delete.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     public virtual Task DeleteAsync(T item, CancellationToken? cancellationToken = default)
     {
         PerformDelete(item);
@@ -19,6 +39,12 @@ public abstract class SynchronousStore<T, TKey>
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Asynchronously deletes an item from the store.
+    /// </summary>
+    /// <param name="key">The key that identifies the item to delete.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     public virtual Task DeleteAsync(TKey key, CancellationToken? cancellationToken = default)
     {
         PerformDelete(key);
@@ -26,16 +52,40 @@ public abstract class SynchronousStore<T, TKey>
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Asynchronously retrieves an item from the store.
+    /// </summary>
+    /// <param name="key">The key that identifies the item to retrieve.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains the item with the specified <paramref name="key"/>, or null if no such item exists.
+    /// </returns>
     public virtual Task<T?> GetAsync(TKey key, CancellationToken? cancellationToken = default)
     {
         return Task.FromResult(PerformGet(key));
     }
 
+    /// <summary>
+    /// Asynchronously retrieves items from the store, and optionally applies <paramref name="paging"/>.
+    /// </summary>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <param name="paging">Optional paging instructions to be applied to the results.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that represents the asynchronous operation.
+    /// The task result contains paging instructions for the matching items.
+    /// </returns>
     public virtual Task<PagedResult<T>> GetAsync(CancellationToken? cancellationToken = default, Paging? paging = default)
     {
         return Task.FromResult(PerformGet(paging: paging));
     }
 
+    /// <summary>
+    /// Asynchronously updates an existing item within the store.
+    /// </summary>
+    /// <param name="item">The item to update.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     public virtual Task UpdateAsync(T item, CancellationToken? cancellationToken = default)
     {
         PerformUpdate(item);
@@ -43,15 +93,42 @@ public abstract class SynchronousStore<T, TKey>
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Facilitates synchronous implementation of item creation in the store.
+    /// </summary>
+    /// <param name="item">The item to create.</param>
+    /// <returns>The key of the newly created item.</returns>
     protected abstract TKey PerformCreate(T item);
 
+    /// <summary>
+    /// Facilitates synchronous implementation of item deletion from the store.
+    /// </summary>
+    /// <param name="item">The item to delete.</param>
     protected abstract void PerformDelete(T item);
 
+    /// <summary>
+    /// Facilitates synchronous implementation of item deletion from the store.
+    /// </summary>
+    /// <param name="key">The key that identifies the item to delete.</param>
     protected abstract void PerformDelete(TKey key);
 
+    /// <summary>
+    /// Facilitates synchronous implementation of item retrieval from the store.
+    /// </summary>
+    /// <param name="key">The key that identifies the item to retrieve.</param>
+    /// <returns>The item with the specified <paramref name="key"/>, or null if no such item exists.</returns>
     protected abstract T? PerformGet(TKey key);
 
+    /// <summary>
+    /// Facilitates synchronous implementation items retrieval from the store, and optionally applies <paramref name="paging"/>.
+    /// </summary>
+    /// <param name="paging">Optional paging instructions to be applied to the results.</param>
+    /// <returns>Paging instructions for the matching items.</returns>
     protected abstract PagedResult<T> PerformGet(Paging? paging = default);
 
+    /// <summary>
+    /// Facilitates synchronous implementation of an update to an existing item within the store.
+    /// </summary>
+    /// <param name="item">The item to update.</param>
     protected abstract void PerformUpdate(T item);
 }

--- a/src/MooVC/Processing/IProcessor.cs
+++ b/src/MooVC/Processing/IProcessor.cs
@@ -27,15 +27,15 @@ public interface IProcessor
     /// Tries to start the processor asynchronously.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-    /// <returns>A task representing the asynchronous operation. The result of the task is a boolean value indicating whether the attempt to
-    /// start the processor was successful.</returns>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation. The result of the task is a boolean value
+    /// indicating whether the attempt to start the processor was successful.</returns>
     Task<bool> TryStartAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Tries to stop the processor asynchronously.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-    /// <returns>A task representing the asynchronous operation. The result of the task is a boolean value indicating whether the attempt to
-    /// stop the processor was successful.</returns>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation. The result of the task is a boolean value
+    /// indicating whether the attempt to stop the processor was successful.</returns>
     Task<bool> TryStopAsync(CancellationToken cancellationToken);
 }

--- a/src/MooVC/Processing/IProcessor.cs
+++ b/src/MooVC/Processing/IProcessor.cs
@@ -18,6 +18,9 @@ public interface IProcessor
     /// <summary>
     /// Gets the current state of the processor.
     /// </summary>
+    /// <value>
+    /// The current state of the processor.
+    /// </value>
     ProcessorState State { get; }
 
     /// <summary>

--- a/src/MooVC/Processing/IProcessor.cs
+++ b/src/MooVC/Processing/IProcessor.cs
@@ -26,7 +26,7 @@ public interface IProcessor
     /// <summary>
     /// Tries to start the processor asynchronously.
     /// </summary>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation. The result of the task is a boolean value
     /// indicating whether the attempt to start the processor was successful.</returns>
     Task<bool> TryStartAsync(CancellationToken cancellationToken);
@@ -34,7 +34,7 @@ public interface IProcessor
     /// <summary>
     /// Tries to stop the processor asynchronously.
     /// </summary>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation. The result of the task is a boolean value
     /// indicating whether the attempt to stop the processor was successful.</returns>
     Task<bool> TryStopAsync(CancellationToken cancellationToken);

--- a/src/MooVC/Processing/IProcessor.cs
+++ b/src/MooVC/Processing/IProcessor.cs
@@ -4,14 +4,35 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Represents a long running process.
+/// </summary>
 public interface IProcessor
     : IHostedService
 {
+    /// <summary>
+    /// An event that is raised when the state of the processor changes.
+    /// </summary>
     event ProcessorStateChangedAsyncEventHandler StateChanged;
 
+    /// <summary>
+    /// Gets the current state of the processor.
+    /// </summary>
     ProcessorState State { get; }
 
+    /// <summary>
+    /// Tries to start the processor asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation. The result of the task is a boolean value indicating whether the attempt to
+    /// start the processor was successful.</returns>
     Task<bool> TryStartAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Tries to stop the processor asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation. The result of the task is a boolean value indicating whether the attempt to
+    /// stop the processor was successful.</returns>
     Task<bool> TryStopAsync(CancellationToken cancellationToken);
 }

--- a/src/MooVC/Processing/IProcessor.cs
+++ b/src/MooVC/Processing/IProcessor.cs
@@ -27,15 +27,19 @@ public interface IProcessor
     /// Tries to start the processor asynchronously.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation. The result of the task is a boolean value
-    /// indicating whether the attempt to start the processor was successful.</returns>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation.
+    /// The result of the task is a boolean value indicating whether the attempt to start the processor was successful.
+    /// </returns>
     Task<bool> TryStartAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Tries to stop the processor asynchronously.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation. The result of the task is a boolean value
-    /// indicating whether the attempt to stop the processor was successful.</returns>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation.
+    /// The result of the task is a boolean value indicating whether the attempt to stop the processor was successful.
+    /// </returns>
     Task<bool> TryStopAsync(CancellationToken cancellationToken);
 }

--- a/src/MooVC/Processing/ProcessorState.cs
+++ b/src/MooVC/Processing/ProcessorState.cs
@@ -1,10 +1,32 @@
 ﻿namespace MooVC.Processing;
 
+/// <summary>
+/// Represents the state of a processor.
+/// </summary>
 public enum ProcessorState
 {
+    /// <summary>
+    /// The state is unknown, likely as a result of an unexpected and unrecoverable failure.
+    /// </summary>
     Unknown,
+
+    /// <summary>
+    /// The processor has started and is performing its intended role.
+    /// </summary>
     Started,
+
+    /// <summary>
+    /// The processor is starting and is not yet performing its intended role.
+    /// </summary>
     Starting,
+
+    /// <summary>
+    /// The processor has stopped and is no longer performing its intended role.
+    /// </summary>
     Stopped,
+
+    /// <summary>
+    /// The processor is stopping and may be currently performing its intended role.
+    /// </summary>
     Stopping,
 }

--- a/src/MooVC/Processing/ProcessorStateChangedAsyncEventArgs.cs
+++ b/src/MooVC/Processing/ProcessorStateChangedAsyncEventArgs.cs
@@ -5,11 +5,21 @@ using System.Runtime.Serialization;
 using System.Threading;
 using MooVC.Serialization;
 
+/// <summary>
+/// Represents the event data for the <see cref="IProcessor.StateChanged" /> event.
+/// </summary>
 [Serializable]
 public sealed class ProcessorStateChangedAsyncEventArgs
     : AsyncEventArgs,
       ISerializable
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProcessorStateChangedAsyncEventArgs" /> class.
+    /// </summary>
+    /// <param name="state">The state of the processor at the time the event was raised.</param>
+    /// <param name="cancellationToken">
+    /// An optional <see cref="CancellationToken" /> that can be used to cancel the operation that raised the event.
+    /// </param>
     public ProcessorStateChangedAsyncEventArgs(ProcessorState state, CancellationToken? cancellationToken = default)
         : base(cancellationToken: cancellationToken)
     {
@@ -29,6 +39,12 @@ public sealed class ProcessorStateChangedAsyncEventArgs
         State = info.GetValue<ProcessorState>(nameof(State));
     }
 
+    /// <summary>
+    /// Gets the state of the processor at the time the event was raised.
+    /// </summary>
+    /// <value>
+    /// The state of the processor at the time the event was raised.
+    /// </value>
     public ProcessorState State { get; }
 
     /// <summary>

--- a/src/MooVC/Processing/ProcessorStateChangedAsyncEventArgs.cs
+++ b/src/MooVC/Processing/ProcessorStateChangedAsyncEventArgs.cs
@@ -22,6 +22,8 @@ public sealed class ProcessorStateChangedAsyncEventArgs
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
     /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     private ProcessorStateChangedAsyncEventArgs(SerializationInfo info, StreamingContext context)
     {
         State = info.GetValue<ProcessorState>(nameof(State));
@@ -35,6 +37,8 @@ public sealed class ProcessorStateChangedAsyncEventArgs
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         info.AddValue(nameof(State), State);

--- a/src/MooVC/Processing/ProcessorStateChangedAsyncEventArgs.cs
+++ b/src/MooVC/Processing/ProcessorStateChangedAsyncEventArgs.cs
@@ -16,6 +16,12 @@ public sealed class ProcessorStateChangedAsyncEventArgs
         State = state;
     }
 
+    /// <summary>
+    /// Supports deserialization of an instance of the <see cref="ProcessorStateChangedAsyncEventArgs"/> class
+    /// via the specified <paramref name="info"/> and <paramref name="context"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
     private ProcessorStateChangedAsyncEventArgs(SerializationInfo info, StreamingContext context)
     {
         State = info.GetValue<ProcessorState>(nameof(State));
@@ -23,6 +29,12 @@ public sealed class ProcessorStateChangedAsyncEventArgs
 
     public ProcessorState State { get; }
 
+    /// <summary>
+    /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
+    /// of the <see cref="ProcessorStateChangedAsyncEventArgs"/> class.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
+    /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         info.AddValue(nameof(State), State);

--- a/src/MooVC/Processing/ProcessorStateChangedAsyncEventHandler.cs
+++ b/src/MooVC/Processing/ProcessorStateChangedAsyncEventHandler.cs
@@ -2,4 +2,10 @@
 
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents the method that will handle the <see cref="IProcessor.StateChanged"/> event.
+/// </summary>
+/// <param name="sender">The <see cref="IProcessor"/> that raised the event.</param>
+/// <param name="e">An instance of <see cref="ProcessorStateChangedAsyncEventArgs"/> containing information about the state change.</param>
+/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 public delegate Task ProcessorStateChangedAsyncEventHandler(IProcessor sender, ProcessorStateChangedAsyncEventArgs e);

--- a/src/MooVC/Processing/StartOperationInvalidException.cs
+++ b/src/MooVC/Processing/StartOperationInvalidException.cs
@@ -21,6 +21,8 @@ public sealed class StartOperationInvalidException
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
     /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     private StartOperationInvalidException(SerializationInfo info, StreamingContext context)
     {
         State = info.GetValue<ProcessorState>(nameof(State));
@@ -34,6 +36,8 @@ public sealed class StartOperationInvalidException
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         base.GetObjectData(info, context);

--- a/src/MooVC/Processing/StartOperationInvalidException.cs
+++ b/src/MooVC/Processing/StartOperationInvalidException.cs
@@ -5,10 +5,17 @@ using System.Runtime.Serialization;
 using MooVC.Serialization;
 using static MooVC.Processing.Resources;
 
+/// <summary>
+/// Encapsulates information relating to a failed attempt to start an instance of <see cref="IProcessor"/>.
+/// </summary>
 [Serializable]
 public sealed class StartOperationInvalidException
     : InvalidOperationException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StartOperationInvalidException" /> class.
+    /// </summary>
+    /// <param name="state">The state of the processor was in at the time the request to start was made.</param>
     public StartOperationInvalidException(ProcessorState state)
         : base(StartOperationInvalidExceptionMessage)
     {
@@ -28,6 +35,12 @@ public sealed class StartOperationInvalidException
         State = info.GetValue<ProcessorState>(nameof(State));
     }
 
+    /// <summary>
+    /// Gets the state of the processor was in at the time the request to start was made.
+    /// </summary>
+    /// <value>
+    /// The state of the processor was in at the time the request to start was made.
+    /// </value>
     public ProcessorState State { get; }
 
     /// <summary>

--- a/src/MooVC/Processing/StartOperationInvalidException.cs
+++ b/src/MooVC/Processing/StartOperationInvalidException.cs
@@ -15,6 +15,12 @@ public sealed class StartOperationInvalidException
         State = state;
     }
 
+    /// <summary>
+    /// Supports deserialization of an instance of the <see cref="StartOperationInvalidException"/> class
+    /// via the specified <paramref name="info"/> and <paramref name="context"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
     private StartOperationInvalidException(SerializationInfo info, StreamingContext context)
     {
         State = info.GetValue<ProcessorState>(nameof(State));
@@ -22,6 +28,12 @@ public sealed class StartOperationInvalidException
 
     public ProcessorState State { get; }
 
+    /// <summary>
+    /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
+    /// of the <see cref="StartOperationInvalidException"/> class.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
+    /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         base.GetObjectData(info, context);

--- a/src/MooVC/Processing/StopOperationInvalidException.cs
+++ b/src/MooVC/Processing/StopOperationInvalidException.cs
@@ -5,10 +5,17 @@ using System.Runtime.Serialization;
 using MooVC.Serialization;
 using static MooVC.Processing.Resources;
 
+/// <summary>
+/// Encapsulates information relating to a failed attempt to stop an instance of <see cref="IProcessor"/>.
+/// </summary>
 [Serializable]
 public sealed class StopOperationInvalidException
     : InvalidOperationException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StopOperationInvalidException" /> class.
+    /// </summary>
+    /// <param name="state">The state of the processor was in at the time the request to stop was made.</param>
     public StopOperationInvalidException(ProcessorState state)
         : base(StopOperationInvalidExceptionMessage)
     {
@@ -28,6 +35,12 @@ public sealed class StopOperationInvalidException
         State = info.GetValue<ProcessorState>(nameof(State));
     }
 
+    /// <summary>
+    /// Gets the state of the processor was in at the time the request to stop was made.
+    /// </summary>
+    /// <value>
+    /// The state of the processor was in at the time the request to stop was made.
+    /// </value>
     public ProcessorState State { get; }
 
     /// <summary>

--- a/src/MooVC/Processing/StopOperationInvalidException.cs
+++ b/src/MooVC/Processing/StopOperationInvalidException.cs
@@ -15,6 +15,12 @@ public sealed class StopOperationInvalidException
         State = state;
     }
 
+    /// <summary>
+    /// Supports deserialization of an instance of the <see cref="StopOperationInvalidException"/> class
+    /// via the specified <paramref name="info"/> and <paramref name="context"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
     private StopOperationInvalidException(SerializationInfo info, StreamingContext context)
     {
         State = info.GetValue<ProcessorState>(nameof(State));
@@ -22,6 +28,12 @@ public sealed class StopOperationInvalidException
 
     public ProcessorState State { get; }
 
+    /// <summary>
+    /// Populates the specified <see cref="SerializationInfo"/> object with the data needed to serialize the current instance
+    /// of the <see cref="StopOperationInvalidException"/> class.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
+    /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         base.GetObjectData(info, context);

--- a/src/MooVC/Processing/StopOperationInvalidException.cs
+++ b/src/MooVC/Processing/StopOperationInvalidException.cs
@@ -21,6 +21,8 @@ public sealed class StopOperationInvalidException
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that holds the serialized object data relating to the instance.</param>
     /// <param name="context">The <see cref="StreamingContext"/> object that contains contextual information about the stream.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     private StopOperationInvalidException(SerializationInfo info, StreamingContext context)
     {
         State = info.GetValue<ProcessorState>(nameof(State));
@@ -34,6 +36,8 @@ public sealed class StopOperationInvalidException
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> object that will be populated with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for the serialization operation.</param>
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         base.GetObjectData(info, context);

--- a/src/MooVC/Processing/ThreadSafeHostedService.cs
+++ b/src/MooVC/Processing/ThreadSafeHostedService.cs
@@ -9,22 +9,44 @@ using MooVC.Diagnostics;
 using static MooVC.Ensure;
 using static MooVC.Processing.Resources;
 
+/// <summary>
+/// Allows for the thread-safe start/stop of one or more <see cref="IHostedService"/> implementations.
+/// </summary>
 public sealed class ThreadSafeHostedService
     : ThreadSafeProcessor
 {
     private readonly IEnumerable<IHostedService> services;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThreadSafeHostedService"/> class.
+    /// </summary>
+    /// <param name="services">
+    /// The services to be managed by the <see cref="ThreadSafeHostedService"/>.
+    /// </param>
+    /// <param name="diagnostics">
+    /// The proxy that determines if diagnostics are to be emitted, with the default configuration used if not provided.
+    /// </param>
     public ThreadSafeHostedService(IEnumerable<IHostedService> services, IDiagnosticsProxy? diagnostics = default)
         : base(diagnostics: diagnostics)
     {
         this.services = IsNotEmpty(services, message: ThreadSafeHostedServiceServicesRequired);
     }
 
+    /// <summary>
+    /// Asynchronously starts all <see cref="IHostedService"/> instances managed by the processor.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task PerformStartAsync(CancellationToken cancellationToken)
     {
         return services.ForAllAsync(service => service.StartAsync(cancellationToken));
     }
 
+    /// <summary>
+    /// Asynchronously stops all <see cref="IHostedService"/> instances managed by the processor.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task PerformStopAsync(CancellationToken cancellationToken)
     {
         return services.ForAllAsync(service => service.StopAsync(cancellationToken));

--- a/src/MooVC/Processing/ThreadSafeProcessor.cs
+++ b/src/MooVC/Processing/ThreadSafeProcessor.cs
@@ -3,6 +3,9 @@
 using System.Threading;
 using MooVC.Diagnostics;
 
+/// <summary>
+/// Represents a base implementation for a long running process that provides a thread safe guarentee when starting/stoping.
+/// </summary>
 public abstract class ThreadSafeProcessor
     : Processor
 {
@@ -11,16 +14,34 @@ public abstract class ThreadSafeProcessor
 
     private volatile int flag = StopRequestedFlag;
 
+    /// <summary>
+    /// Facilitates the Initialization of new instance based on the <see cref="ThreadSafeProcessor"/> class.
+    /// </summary>
+    /// <param name="diagnostics">
+    /// The proxy that determines if diagnostics are to be emitted, with the default configuration used if not provided.
+    /// </param>
     protected ThreadSafeProcessor(IDiagnosticsProxy? diagnostics = default)
         : base(diagnostics: diagnostics)
     {
     }
 
+    /// <summary>
+    /// Determines if the process can be started in a thread-safe manner.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the processor can be started, otherwise <c>false</c>.
+    /// </returns>
     protected sealed override bool CanStart()
     {
         return Interlocked.CompareExchange(ref flag, StartRequestedFlag, StopRequestedFlag) == StopRequestedFlag;
     }
 
+    /// <summary>
+    /// Determines if the process can be stopped in a thread-safe manner.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the processor can be stopped, otherwise <c>false</c>.
+    /// </returns>
     protected sealed override bool CanStop()
     {
         return Interlocked.CompareExchange(ref flag, StopRequestedFlag, StartRequestedFlag) == StartRequestedFlag;

--- a/src/MooVC/Processing/TimedJobQueue.cs
+++ b/src/MooVC/Processing/TimedJobQueue.cs
@@ -11,6 +11,10 @@ using MooVC.Diagnostics;
 using static MooVC.Ensure;
 using static MooVC.Processing.Resources;
 
+/// <summary>
+/// Represents a base implementation for a long running thread-safe process that manages a queue of tasks to be performed on a timed basis.
+/// </summary>
+/// <typeparam name="T">The type of job to be processed.</typeparam>
 public abstract class TimedJobQueue<T>
     : IDisposable,
       IEmitDiagnostics
@@ -19,6 +23,11 @@ public abstract class TimedJobQueue<T>
     private readonly TimedProcessor timer;
     private bool isDisposed;
 
+    /// <summary>
+    /// Facilitates initialization of a <see cref="TimedJobQueue{T}"/> using the <paramref name="timer"/> to determine when processing should occur.
+    /// </summary>
+    /// <param name="timer">The timer that determines when jobs in the queue should be processed.</param>
+    /// <remarks>The <paramref name="timer"/> will only be started when a job is enqueued and will be stopped when no jobs remain.</remarks>
     protected TimedJobQueue(TimedProcessor timer)
     {
         this.timer = IsNotNull(timer, message: JobQueueTimerRequired);
@@ -26,10 +35,23 @@ public abstract class TimedJobQueue<T>
         this.timer.Triggered += Timer_Triggered;
     }
 
+    /// <summary>
+    /// An event that is raised when an diagnostic related occurance is encountered.
+    /// </summary>
     public event DiagnosticsEmittedAsyncEventHandler? DiagnosticsEmitted;
 
+    /// <summary>
+    /// Gets a value indicating whether any jobs are queued.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if there are jobs present in the queue, otherwise <c>false</c>.
+    /// </value>
     public bool HasJobsPending => queue.Any();
 
+    /// <summary>
+    /// Adds the specified <paramref name="job"/> to the queue.
+    /// </summary>
+    /// <param name="job">The job to add to the queue for deferred processing.</param>
     public void Enqueue(T job)
     {
         queue.Enqueue(job);
@@ -37,6 +59,9 @@ public abstract class TimedJobQueue<T>
         _ = StartTimerAsync();
     }
 
+    /// <summary>
+    /// Releases all resources used by this instance.
+    /// </summary>
     public void Dispose()
     {
         Dispose(true);
@@ -44,6 +69,13 @@ public abstract class TimedJobQueue<T>
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Releases all resources used by this instance.
+    /// </summary>
+    /// <param name="isDisposing">
+    /// <c>true</c> if this method was called directly or indirectly by a user's code;
+    /// <c>false</c> if this method was called by the runtime from inside the finalizer.
+    /// </param>
     protected virtual void Dispose(bool isDisposing)
     {
         if (!isDisposed)
@@ -59,13 +91,29 @@ public abstract class TimedJobQueue<T>
         }
     }
 
+    /// <summary>
+    /// Emits a diagnostic event.
+    /// </summary>
+    /// <param name="level">The perceived <see cref="Level" /> of the event from the perspective of the <paramref name="source"/>.</param>
+    /// <param name="cause">The <see cref="Exception" /> that caused the diagnostic event to be emitted, if any.</param>
+    /// <param name="message">A friendly description of the event, if any.</param>
     protected virtual void OnDiagnosticsEmitted(Level level, Exception? cause = default, string? message = default)
     {
         _ = DiagnosticsEmitted.PassiveInvokeAsync(this, new DiagnosticsEmittedAsyncEventArgs(cause: cause, level: level, message: message));
     }
 
+    /// <summary>
+    /// Supports the synchronous processing of the jobs specified in <paramref name="jobs"/>.
+    /// </summary>
+    /// <param name="jobs">A list of one or more jobs to be processed.</param>
+    /// <typeparam name="T">The type of job to be processed.</typeparam>
+    /// <returns>A list of jobs to be returned to the queue.</returns>
     protected abstract IEnumerable<T> Process(IEnumerable<T> jobs);
 
+    /// <summary>
+    /// Asynchronous prepares the list of jobs to be processed.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     private async Task ProcessQueueAsync()
     {
         var pending = new List<T>();

--- a/src/MooVC/Processing/TimedProcessor.cs
+++ b/src/MooVC/Processing/TimedProcessor.cs
@@ -7,6 +7,9 @@ using MooVC.Diagnostics;
 using static System.String;
 using static MooVC.Processing.Resources;
 
+/// <summary>
+/// Encapsulates the functionality of <see cref="Timer"/> within the <see cref="IProcessor"/> interface.
+/// </summary>
 public class TimedProcessor
     : ThreadSafeProcessor,
       IDisposable
@@ -16,6 +19,16 @@ public class TimedProcessor
     private readonly Lazy<Timer> timer;
     private bool isDisposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimedProcessor"/> class.
+    /// </summary>
+    /// <param name="delay">The delay between timer callbacks.</param>
+    /// <param name="diagnostics">
+    /// The proxy that determines if diagnostics are to be emitted, with the default configuration used if not provided.
+    /// </param>
+    /// <param name="initial">
+    /// The initial delay before the first timer callback, or <c>null</c> to use the same value as <paramref name="delay"/>.
+    /// </param>
     public TimedProcessor(TimeSpan delay, IDiagnosticsProxy? diagnostics = default, TimeSpan? initial = default)
         : base(diagnostics: diagnostics)
     {
@@ -24,8 +37,14 @@ public class TimedProcessor
         timer = new Lazy<Timer>(() => new Timer(TimerCallbackAsync));
     }
 
+    /// <summary>
+    /// An event that is raised when the time associated with the timer has elapsed.
+    /// </summary>
     public event EventHandler? Triggered;
 
+    /// <summary>
+    /// Releases all resources used by this instance.
+    /// </summary>
     public void Dispose()
     {
         Dispose(true);
@@ -33,6 +52,13 @@ public class TimedProcessor
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Releases all resources used by this instance.
+    /// </summary>
+    /// <param name="isDisposing">
+    /// <c>true</c> if this method was called directly or indirectly by a user's code;
+    /// <c>false</c> if this method was called by the runtime from inside the finalizer.
+    /// </param>
     protected virtual void Dispose(bool isDisposing)
     {
         if (!isDisposed)
@@ -46,6 +72,11 @@ public class TimedProcessor
         }
     }
 
+    /// <summary>
+    /// Starts the timer.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task PerformStartAsync(CancellationToken cancellationToken)
     {
         _ = timer.Value.Change(initial, delay);
@@ -53,6 +84,11 @@ public class TimedProcessor
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Stops the timer.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task PerformStopAsync(CancellationToken cancellationToken)
     {
         _ = timer.Value.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
@@ -60,11 +96,18 @@ public class TimedProcessor
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Facilitates the asynchronously invocation of work to be done when the timer triggers.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected virtual Task PerformTimerCallbackAsync()
     {
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Asynchronously performs the work to be done when the timer triggers.
+    /// </summary>
     private async void TimerCallbackAsync(object? state)
     {
         try

--- a/src/MooVC/Serialization/DefaultCloner.cs
+++ b/src/MooVC/Serialization/DefaultCloner.cs
@@ -6,16 +6,34 @@ using System.Threading.Tasks;
 using static MooVC.Ensure;
 using static MooVC.Serialization.Resources;
 
+/// <summary>
+/// Defines a default implementation of the <see cref="ICloner"/> interface, supporting object cloning via <see cref="ISerializer"/>.
+/// </summary>
 public sealed class DefaultCloner
     : ICloner
 {
     private readonly ISerializer serializer;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultCloner"/> class with the specified <see cref="ISerializer"/>.
+    /// </summary>
+    /// <param name="serializer">The serializer to use for cloning objects.</param>
+    /// <exception cref="ArgumentNullException">The <paramref name="serializer"/> is null.</exception>
     public DefaultCloner(ISerializer serializer)
     {
         this.serializer = IsNotNull(serializer, message: DefaultClonerSerializerRequired);
     }
 
+    /// <summary>
+    /// Asynchronously clones the specified object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to clone.</typeparam>
+    /// <param name="original">The original object to clone.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous clone operation.
+    /// The task result contains the cloned object.
+    /// </returns>
     public async Task<T> CloneAsync<T>(T original, CancellationToken? cancellationToken = default)
         where T : notnull
     {

--- a/src/MooVC/Serialization/DefaultCloner.cs
+++ b/src/MooVC/Serialization/DefaultCloner.cs
@@ -18,7 +18,7 @@ public sealed class DefaultCloner
     /// Initializes a new instance of the <see cref="DefaultCloner"/> class with the specified <see cref="ISerializer"/>.
     /// </summary>
     /// <param name="serializer">The serializer to use for cloning objects.</param>
-    /// <exception cref="ArgumentNullException">The <paramref name="serializer"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="serializer"/> is <see langword="null" />.</exception>
     public DefaultCloner(ISerializer serializer)
     {
         this.serializer = IsNotNull(serializer, message: DefaultClonerSerializerRequired);

--- a/src/MooVC/Serialization/ICloner.cs
+++ b/src/MooVC/Serialization/ICloner.cs
@@ -16,7 +16,7 @@ public interface ICloner
     /// <param name="cancellationToken">
     /// A cancellation token that can be used to cancel the operation.
     /// </param>
-    /// <returns>A task that represents the asynchronous clone operation.</returns>
+    /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous clone operation.</returns>
     Task<T> CloneAsync<T>(T original, CancellationToken? cancellationToken = default)
         where T : notnull;
 }

--- a/src/MooVC/Serialization/ICloner.cs
+++ b/src/MooVC/Serialization/ICloner.cs
@@ -13,9 +13,7 @@ public interface ICloner
     /// </summary>
     /// <typeparam name="T">The type of the object to clone.</typeparam>
     /// <param name="original">The original object to clone.</param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous clone operation.</returns>
     Task<T> CloneAsync<T>(T original, CancellationToken? cancellationToken = default)
         where T : notnull;

--- a/src/MooVC/Serialization/ICloner.cs
+++ b/src/MooVC/Serialization/ICloner.cs
@@ -14,7 +14,7 @@ public interface ICloner
     /// <typeparam name="T">The type of the object to clone.</typeparam>
     /// <param name="original">The original object to clone.</param>
     /// <param name="cancellationToken">
-    /// A cancellation token that can be used to cancel the operation.
+    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
     /// </param>
     /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous clone operation.</returns>
     Task<T> CloneAsync<T>(T original, CancellationToken? cancellationToken = default)

--- a/src/MooVC/Serialization/ICloner.cs
+++ b/src/MooVC/Serialization/ICloner.cs
@@ -3,8 +3,20 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Defines a contract for cloning objects.
+/// </summary>
 public interface ICloner
 {
+    /// <summary>
+    /// Asynchronously clones the specified object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to clone.</typeparam>
+    /// <param name="original">The original object to clone.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>A task that represents the asynchronous clone operation.</returns>
     Task<T> CloneAsync<T>(T original, CancellationToken? cancellationToken = default)
         where T : notnull;
 }

--- a/src/MooVC/Serialization/ICloner.cs
+++ b/src/MooVC/Serialization/ICloner.cs
@@ -14,7 +14,10 @@ public interface ICloner
     /// <typeparam name="T">The type of the object to clone.</typeparam>
     /// <param name="original">The original object to clone.</param>
     /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
-    /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous clone operation.</returns>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous clone operation.
+    /// The task result contains the cloned object.
+    /// </returns>
     Task<T> CloneAsync<T>(T original, CancellationToken? cancellationToken = default)
         where T : notnull;
 }

--- a/src/MooVC/Serialization/ISerializer.cs
+++ b/src/MooVC/Serialization/ISerializer.cs
@@ -19,8 +19,8 @@ public interface ISerializer
     /// A cancellation token that can be used to cancel the operation.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous serialization operation.
-    /// The result of the task is a sequence of bytes representing the serialized object.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is a sequence
+    /// of bytes representing the serialized object.
     /// </returns>
     Task<IEnumerable<byte>> SerializeAsync<T>(T instance, CancellationToken? cancellationToken = default)
         where T : notnull;
@@ -34,7 +34,7 @@ public interface ISerializer
     /// <param name="cancellationToken">
     /// A cancellation token that can be used to cancel the operation.
     /// </param>
-    /// <returns>A task that represents the asynchronous serialization operation.</returns>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous serialization operation.</returns>
     Task SerializeAsync<T>(T instance, Stream target, CancellationToken? cancellationToken = default)
         where T : notnull;
 
@@ -47,8 +47,8 @@ public interface ISerializer
     /// A cancellation token that can be used to cancel the operation.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous serialization operation.
-    /// The result of the task is the instance deserialized from the sequence of bytes that represented the object.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is the
+    /// instance deserialized from the sequence of bytes that represented the object.
     /// </returns>
     Task<T> DeserializeAsync<T>(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
         where T : notnull;
@@ -62,8 +62,8 @@ public interface ISerializer
     /// A cancellation token that can be used to cancel the operation.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous serialization operation.
-    /// The result of the task is the instance deserialized from the stream that represented the object.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is the instance
+    /// deserialized from the stream that represented the object.
     /// </returns>
     Task<T> DeserializeAsync<T>(Stream source, CancellationToken? cancellationToken = default)
         where T : notnull;

--- a/src/MooVC/Serialization/ISerializer.cs
+++ b/src/MooVC/Serialization/ISerializer.cs
@@ -16,7 +16,7 @@ public interface ISerializer
     /// <typeparam name="T">The type of the object to serialize.</typeparam>
     /// <param name="instance">The object to serialize.</param>
     /// <param name="cancellationToken">
-    /// A cancellation token that can be used to cancel the operation.
+    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
     /// </param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is a sequence
@@ -32,7 +32,7 @@ public interface ISerializer
     /// <param name="instance">The object to serialize.</param>
     /// <param name="target">The target stream to which to serialize the object.</param>
     /// <param name="cancellationToken">
-    /// A cancellation token that can be used to cancel the operation.
+    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
     /// </param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous serialization operation.</returns>
     Task SerializeAsync<T>(T instance, Stream target, CancellationToken? cancellationToken = default)
@@ -44,7 +44,7 @@ public interface ISerializer
     /// <typeparam name="T">The type of the object to deserialize.</typeparam>
     /// <param name="data">The sequence of bytes to deserialize.</param>
     /// <param name="cancellationToken">
-    /// A cancellation token that can be used to cancel the operation.
+    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
     /// </param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is the
@@ -59,7 +59,7 @@ public interface ISerializer
     /// <typeparam name="T">The type of the object to deserialize.</typeparam>
     /// <param name="source">The stream from which the object is to be deserialized.</param>
     /// <param name="cancellationToken">
-    /// A cancellation token that can be used to cancel the operation.
+    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
     /// </param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is the instance

--- a/src/MooVC/Serialization/ISerializer.cs
+++ b/src/MooVC/Serialization/ISerializer.cs
@@ -15,12 +15,10 @@ public interface ISerializer
     /// </summary>
     /// <typeparam name="T">The type of the object to serialize.</typeparam>
     /// <param name="instance">The object to serialize.</param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is a sequence
-    /// of bytes representing the serialized object.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation.
+    /// The result of the task is a sequence of bytes representing the serialized object.
     /// </returns>
     Task<IEnumerable<byte>> SerializeAsync<T>(T instance, CancellationToken? cancellationToken = default)
         where T : notnull;
@@ -31,9 +29,7 @@ public interface ISerializer
     /// <typeparam name="T">The type of the object to serialize.</typeparam>
     /// <param name="instance">The object to serialize.</param>
     /// <param name="target">The target stream to which to serialize the object.</param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous serialization operation.</returns>
     Task SerializeAsync<T>(T instance, Stream target, CancellationToken? cancellationToken = default)
         where T : notnull;
@@ -43,12 +39,10 @@ public interface ISerializer
     /// </summary>
     /// <typeparam name="T">The type of the object to deserialize.</typeparam>
     /// <param name="data">The sequence of bytes to deserialize.</param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is the
-    /// instance deserialized from the sequence of bytes that represented the object.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation.
+    /// The result of the task is the instance deserialized from the sequence of bytes that represented the object.
     /// </returns>
     Task<T> DeserializeAsync<T>(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
         where T : notnull;
@@ -58,12 +52,10 @@ public interface ISerializer
     /// </summary>
     /// <typeparam name="T">The type of the object to deserialize.</typeparam>
     /// <param name="source">The stream from which the object is to be deserialized.</param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation. The result of the task is the instance
-    /// deserialized from the stream that represented the object.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation.
+    /// The result of the task is the instance deserialized from the stream that represented the object.
     /// </returns>
     Task<T> DeserializeAsync<T>(Stream source, CancellationToken? cancellationToken = default)
         where T : notnull;

--- a/src/MooVC/Serialization/ISerializer.cs
+++ b/src/MooVC/Serialization/ISerializer.cs
@@ -5,17 +5,66 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Defines a contract for serializing and deserializing objects.
+/// </summary>
 public interface ISerializer
 {
+    /// <summary>
+    /// Asynchronously serializes the specified object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="instance">The object to serialize.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous serialization operation.
+    /// The result of the task is a sequence of bytes representing the serialized object.
+    /// </returns>
     Task<IEnumerable<byte>> SerializeAsync<T>(T instance, CancellationToken? cancellationToken = default)
         where T : notnull;
 
+    /// <summary>
+    /// Asynchronously serializes the specified object to the specified stream.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="instance">The object to serialize.</param>
+    /// <param name="target">The target stream to which to serialize the object.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>A task that represents the asynchronous serialization operation.</returns>
     Task SerializeAsync<T>(T instance, Stream target, CancellationToken? cancellationToken = default)
         where T : notnull;
 
+    /// <summary>
+    /// Asynchronously deserializes a sequence of bytes that represent an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="data">The sequence of bytes to deserialize.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous serialization operation.
+    /// The result of the task is the instance deserialized from the sequence of bytes that represented the object.
+    /// </returns>
     Task<T> DeserializeAsync<T>(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
         where T : notnull;
 
+    /// <summary>
+    /// Asynchronously deserializes a stream that represent an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="source">The stream from which the object is to be deserialized.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous serialization operation.
+    /// The result of the task is the instance deserialized from the stream that represented the object.
+    /// </returns>
     Task<T> DeserializeAsync<T>(Stream source, CancellationToken? cancellationToken = default)
         where T : notnull;
 }

--- a/src/MooVC/Serialization/SerializationInfoEnumeratorExtensions.ToDictionary.cs
+++ b/src/MooVC/Serialization/SerializationInfoEnumeratorExtensions.ToDictionary.cs
@@ -5,6 +5,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoEnumeratorExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static IDictionary<string, object?> ToDictionary(this SerializationInfoEnumerator enumerator)
     {
         var contents = new Dictionary<string, object?>();

--- a/src/MooVC/Serialization/SerializationInfoExtensions.AddEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.AddEnumerable.cs
@@ -6,6 +6,8 @@ using MooVC.Collections.Generic;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddEnumerable<T>(this SerializationInfo info, string name, IEnumerable<T> value)
     {
         info.AddValue(name, value.Snapshot());

--- a/src/MooVC/Serialization/SerializationInfoExtensions.AddInternalEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.AddInternalEnumerable.cs
@@ -5,6 +5,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalEnumerable<T>(this SerializationInfo info, string name, IEnumerable<T> value)
     {
         info.AddEnumerable(FormatName(name), value);

--- a/src/MooVC/Serialization/SerializationInfoExtensions.AddInternalValue.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.AddInternalValue.cs
@@ -5,81 +5,113 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, short value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, char value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, byte value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, bool value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, decimal value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, ulong value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, double value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, uint value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, float value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, sbyte value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, object value, Type type)
     {
         info.AddValue(FormatName(name), value, type);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, object value)
     {
         info.AddValue(FormatName(name), value, value.GetType());
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, long value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, int value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, ushort value)
     {
         info.AddValue(FormatName(name), value);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static void AddInternalValue(this SerializationInfo info, string name, DateTime value)
     {
         info.AddValue(FormatName(name), value);

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetEnumerable.cs
@@ -6,6 +6,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static IEnumerable<T> GetEnumerable<T>(this SerializationInfo info, string name)
     {
         object? value = info.GetValue<T[]>(name);

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalBoolean.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalBoolean.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static bool GetInternalBoolean(this SerializationInfo info, string name)
     {
         return info.GetBoolean(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalByte.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalByte.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static byte GetInternalByte(this SerializationInfo info, string name)
     {
         return info.GetByte(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalChar.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalChar.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static char GetInternalChar(this SerializationInfo info, string name)
     {
         return info.GetChar(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalDateTime.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalDateTime.cs
@@ -5,6 +5,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static DateTime GetInternalDateTime(this SerializationInfo info, string name)
     {
         return info.GetDateTime(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalDecimal.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalDecimal.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static decimal GetInternalDecimal(this SerializationInfo info, string name)
     {
         return info.GetDecimal(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalDouble.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalDouble.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static double GetInternalDouble(this SerializationInfo info, string name)
     {
         return info.GetDouble(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalEnumerable.cs
@@ -5,6 +5,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static IEnumerable<T> GetInternalEnumerable<T>(this SerializationInfo info, string name)
     {
         return info.GetEnumerable<T>(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalInt16.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalInt16.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static short GetInternalInt16(this SerializationInfo info, string name)
     {
         return info.GetInt16(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalInt32.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalInt32.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static int GetInternalInt32(this SerializationInfo info, string name)
     {
         return info.GetInt32(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalInt64.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalInt64.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static long GetInternalInt64(this SerializationInfo info, string name)
     {
         return info.GetInt64(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalSbyte.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalSbyte.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static sbyte GetInternalSbyte(this SerializationInfo info, string name)
     {
         return info.GetSByte(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalSingle.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalSingle.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static float GetInternalSingle(this SerializationInfo info, string name)
     {
         return info.GetSingle(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalString.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalString.cs
@@ -6,11 +6,15 @@ using static System.String;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static string GetInternalString(this SerializationInfo info, string name)
     {
         return info.GetInternalString(name, defaultValue: Empty);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     [return: NotNullIfNotNull("defaultValue")]
     public static string? GetInternalString(this SerializationInfo info, string name, string? defaultValue = default)
     {

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalUInt16.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalUInt16.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static ushort GetInternalUInt16(this SerializationInfo info, string name)
     {
         return info.GetUInt16(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalUInt32.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalUInt32.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static uint GetInternalUInt32(this SerializationInfo info, string name)
     {
         return info.GetUInt32(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalUInt64.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalUInt64.cs
@@ -4,6 +4,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static ulong GetInternalUInt64(this SerializationInfo info, string name)
     {
         return info.GetUInt64(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalValue.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetInternalValue.cs
@@ -5,11 +5,15 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static object? GetInternalValue(this SerializationInfo info, string name, Type type)
     {
         return info.GetValue(FormatName(name), type);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static T GetInternalValue<T>(this SerializationInfo info, string name)
     {
         return info.GetValue<T>(FormatName(name));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.GetValue.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.GetValue.cs
@@ -6,6 +6,8 @@ using static MooVC.Serialization.Resources;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static T GetValue<T>(this SerializationInfo info, string name)
     {
         object? value = info.GetValue(name, typeof(T));

--- a/src/MooVC/Serialization/SerializationInfoExtensions.ToDictionary.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.ToDictionary.cs
@@ -5,6 +5,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static IDictionary<string, object?> ToDictionary(this SerializationInfo info)
     {
         SerializationInfoEnumerator enumerator = info.GetEnumerator();

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryAddEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryAddEnumerable.cs
@@ -8,6 +8,8 @@ using MooVC.Linq;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static bool TryAddEnumerable<T>(
         this SerializationInfo info,
         string name,

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryAddInternalEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryAddInternalEnumerable.cs
@@ -7,6 +7,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static bool TryAddInternalEnumerable<T>(
         this SerializationInfo info,
         string name,

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryAddInternalString.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryAddInternalString.cs
@@ -6,6 +6,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static bool TryAddInternalString(
         this SerializationInfo info,
         string name,

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryAddInternalValue.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryAddInternalValue.cs
@@ -6,6 +6,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static bool TryAddInternalValue<T>(
         this SerializationInfo info,
         string name,

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryAddString.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryAddString.cs
@@ -7,6 +7,8 @@ using static System.String;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static bool TryAddString(
         this SerializationInfo info,
         string name,

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryAddValue.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryAddValue.cs
@@ -6,6 +6,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static bool TryAddValue<T>(
         this SerializationInfo info,
         string name,

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryGetEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryGetEnumerable.cs
@@ -7,11 +7,15 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static IEnumerable<T> TryGetEnumerable<T>(this SerializationInfo info, string name)
     {
         return info.TryGetValue(name, Array.Empty<T>());
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     [return: NotNullIfNotNull("defaultValue")]
     public static IEnumerable<T>? TryGetEnumerable<T>(this SerializationInfo info, string name, IEnumerable<T>? defaultValue)
     {

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryGetInternalEnumerable.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryGetInternalEnumerable.cs
@@ -7,11 +7,15 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static IEnumerable<T> TryGetInternalEnumerable<T>(this SerializationInfo info, string name)
     {
         return info.TryGetInternalEnumerable(name, Array.Empty<T>());
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     [return: NotNullIfNotNull("defaultValue")]
     public static IEnumerable<T>? TryGetInternalEnumerable<T>(this SerializationInfo info, string name, IEnumerable<T>? defaultValue)
     {

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryGetInternalString.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryGetInternalString.cs
@@ -6,11 +6,15 @@ using static System.String;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static string TryGetInternalString(this SerializationInfo info, string name)
     {
         return info.TryGetInternalString(name, Empty);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     [return: NotNullIfNotNull("defaultValue")]
     public static string? TryGetInternalString(this SerializationInfo info, string name, string? defaultValue)
     {

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryGetInternalValue.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryGetInternalValue.cs
@@ -5,6 +5,8 @@ using System.Runtime.Serialization;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     [return: NotNullIfNotNull("defaultValue")]
     public static T? TryGetInternalValue<T>(this SerializationInfo info, string name, T? defaultValue = default)
     {

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryGetString.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryGetString.cs
@@ -6,11 +6,15 @@ using static System.String;
 
 public static partial class SerializationInfoExtensions
 {
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     public static string TryGetString(this SerializationInfo info, string name)
     {
         return info.TryGetString(name, Empty);
     }
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     [return: NotNullIfNotNull("defaultValue")]
     public static string? TryGetString(this SerializationInfo info, string name, string? defaultValue)
     {

--- a/src/MooVC/Serialization/SerializationInfoExtensions.TryGetValue.cs
+++ b/src/MooVC/Serialization/SerializationInfoExtensions.TryGetValue.cs
@@ -18,6 +18,8 @@ public static partial class SerializationInfoExtensions
 
     private static MethodInfo Method => method.Value;
 
+    [Obsolete(@"Slated for removal in v8 as part of Microsoft's BinaryFormatter Obsoletion Strategy.
+                       (see: https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)")]
     [return: NotNullIfNotNull("defaultValue")]
     public static T? TryGetValue<T>(this SerializationInfo info, string name, T? defaultValue = default)
     {

--- a/src/MooVC/Serialization/Serializer.cs
+++ b/src/MooVC/Serialization/Serializer.cs
@@ -7,16 +7,36 @@ using System.Threading;
 using System.Threading.Tasks;
 using MooVC.Compression;
 
+/// <summary>
+/// Provides a default implementation of the <see cref="ISerializer"/> contract for serializing and deserializing objects.
+/// </summary>
 public abstract class Serializer
     : ISerializer
 {
     private readonly ICompressor? compressor;
 
+    /// <summary>
+    /// Facilitates the Initialization of new instance based on the <see cref="Serializer"/> class.
+    /// </summary>
+    /// <param name="compressor">
+    /// The optional <see cref="ICompressor"/> to use to compress/decompress the serialize/deserialized data.
+    /// If no instance is provided, the streams will not be compressed/decompressed.
+    /// </param>
     protected Serializer(ICompressor? compressor = default)
     {
         this.compressor = compressor;
     }
 
+    /// <summary>
+    /// Asynchronously deserializes a sequence of bytes that represent an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="data">The sequence of bytes to deserialize.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation.
+    /// The result of the task is the instance deserialized from the sequence of bytes that represented the object.
+    /// </returns>
     public async Task<T> DeserializeAsync<T>(IEnumerable<byte> data, CancellationToken? cancellationToken = default)
         where T : notnull
     {
@@ -26,6 +46,16 @@ public abstract class Serializer
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Asynchronously decompresses a stream (if provided) and deserializes the result that represent an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="source">The stream from which the object is to be deserialized.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation.
+    /// The result of the task is the instance deserialized from the stream that represented the object.
+    /// </returns>
     public async Task<T> DeserializeAsync<T>(Stream source, CancellationToken? cancellationToken = default)
         where T : notnull
     {
@@ -40,9 +70,17 @@ public abstract class Serializer
             .ConfigureAwait(false);
     }
 
-    public async Task<IEnumerable<byte>> SerializeAsync<T>(
-        T instance,
-        CancellationToken? cancellationToken = default)
+    /// <summary>
+    /// Asynchronously serializes the specified object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="instance">The object to serialize.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous serialization operation.
+    /// The result of the task is a sequence of bytes representing the serialized object.
+    /// </returns>
+    public async Task<IEnumerable<byte>> SerializeAsync<T>(T instance, CancellationToken? cancellationToken = default)
         where T : notnull
     {
         using var target = new MemoryStream();
@@ -53,10 +91,15 @@ public abstract class Serializer
         return target.ToArray();
     }
 
-    public async Task SerializeAsync<T>(
-        T instance,
-        Stream target,
-        CancellationToken? cancellationToken = default)
+    /// <summary>
+    /// Asynchronously serializes the specified object to the specified stream and compresses the result (if provided).
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="instance">The object to serialize.</param>
+    /// <param name="target">The target stream to which to serialize the object.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous serialization operation.</returns>
+    public async Task SerializeAsync<T>(T instance, Stream target, CancellationToken? cancellationToken = default)
         where T : notnull
     {
         using var serialized = new MemoryStream();
@@ -70,6 +113,15 @@ public abstract class Serializer
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Asynchronously compresses the contents of the <paramref name="source"/> stream and writes the compressed data to the
+    /// <paramref name="target"/> stream if a compressor has been provided on construction, otherwise the contents of the <paramref name="source"/>
+    /// stream are simlply copied to the <paramref name="target"/> stream.
+    /// </summary>
+    /// <param name="source">The stream containing the data to be compressed/copied.</param>
+    /// <param name="target">The stream to which the data will be written.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous serialization operation.</returns>
     protected async Task CompressAsync(Stream source, Stream target, CancellationToken? cancellationToken = default)
     {
         cancellationToken = cancellationToken.GetValueOrDefault();
@@ -94,6 +146,15 @@ public abstract class Serializer
         }
     }
 
+    /// <summary>
+    /// Asynchronously decompresses the contents of the <paramref name="source"/> stream and writes the decompressed data to the
+    /// <paramref name="target"/> stream if a compressor has been provided on construction, otherwise the contents of the <paramref name="source"/>
+    /// stream are simlply copied to the <paramref name="target"/> stream.
+    /// </summary>
+    /// <param name="source">The stream containing the data to be decompressed/copied.</param>
+    /// <param name="target">The stream to which the data will be written.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected async Task DecompressAsync(Stream source, Stream target, CancellationToken? cancellationToken = default)
     {
         cancellationToken = cancellationToken.GetValueOrDefault();
@@ -118,9 +179,27 @@ public abstract class Serializer
         }
     }
 
+    /// <summary>
+    /// Facilitates asynchronously implementation of the deserialization of the result that represent an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="source">The stream from which the object is to be deserialized.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous deserialization operation.
+    /// The result of the task is the instance deserialized from the stream that represented the object.
+    /// </returns>
     protected abstract Task<T> PerformDeserializeAsync<T>(Stream source, CancellationToken? cancellationToken = default)
         where T : notnull;
 
+    /// <summary>
+    /// Facilitates asynchronously implementation of the serialization of the specified object to the specified stream.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="instance">The object to serialize.</param>
+    /// <param name="target">The target stream to which to serialize the object.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous serialization operation.</returns>
     protected abstract Task PerformSerializeAsync<T>(T instance, Stream target, CancellationToken? cancellationToken = default)
         where T : notnull;
 }

--- a/src/MooVC/Serialization/SynchronousCloner.cs
+++ b/src/MooVC/Serialization/SynchronousCloner.cs
@@ -3,15 +3,34 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Faciliates implementation of a synchronous implementation of the <see cref="ICloner"/> contract for cloning objects.
+/// </summary>
 public abstract class SynchronousCloner
     : ICloner
 {
+    /// <summary>
+    /// Asynchronously clones the specified object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to clone.</typeparam>
+    /// <param name="original">The original object to clone.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous clone operation.
+    /// The task result contains the cloned object.
+    /// </returns>
     public Task<T> CloneAsync<T>(T original, CancellationToken? cancellationToken = default)
         where T : notnull
     {
         return Task.FromResult(PerformClone(original));
     }
 
+    /// <summary>
+    /// Facilitates synchronously cloning of the specified object.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to clone.</typeparam>
+    /// <param name="original">The original object to clone.</param>
+    /// <returns>The cloned object.</returns>
     protected abstract T PerformClone<T>(T original)
         where T : notnull;
 }

--- a/src/MooVC/Serialization/SynchronousSerializer.cs
+++ b/src/MooVC/Serialization/SynchronousSerializer.cs
@@ -5,19 +5,47 @@ using System.Threading;
 using System.Threading.Tasks;
 using MooVC.Compression;
 
+/// <summary>
+/// Faciliates implementation of a synchronous implementation of the <see cref="ISerializer"/> contract for serializing and deserializing objects.
+/// </summary>
 public abstract class SynchronousSerializer
     : Serializer
 {
+    /// <summary>
+    /// Facilitates the Initialization of new instance based on the <see cref="SynchronousSerializer"/> class.
+    /// </summary>
+    /// <param name="compressor">
+    /// The optional <see cref="ICompressor"/> to use to compress/decompress the serialize/deserialized data.
+    /// If no instance is provided, the streams will not be compressed/decompressed.
+    /// </param>
     protected SynchronousSerializer(ICompressor? compressor = default)
         : base(compressor: compressor)
     {
     }
 
+    /// <summary>
+    /// Asynchronously deserializes of the result that represent an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="source">The stream from which the object is to be deserialized.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous deserialization operation.
+    /// The result of the task is the instance deserialized from the stream that represented the object.
+    /// </returns>
     protected override Task<T> PerformDeserializeAsync<T>(Stream source, CancellationToken? cancellationToken = default)
     {
         return Task.FromResult(PerformDeserialize<T>(source));
     }
 
+    /// <summary>
+    /// Asynchronously serializes of the specified object to the specified stream.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="instance">The object to serialize.</param>
+    /// <param name="target">The target stream to which to serialize the object.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous serialization operation.</returns>
     protected override Task PerformSerializeAsync<T>(T instance, Stream target, CancellationToken? cancellationToken = default)
     {
         PerformSerialize(instance, target);
@@ -25,9 +53,21 @@ public abstract class SynchronousSerializer
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Facilitates synchronous deserialization of the result that represent an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="source">The stream from which the object is to be deserialized.</param>
+    /// <returns>The instance deserialized from the stream that represented the object.</returns>
     protected abstract T PerformDeserialize<T>(Stream source)
         where T : notnull;
 
+    /// <summary>
+    /// Facilitates synchronous serialization of the specified object to the specified stream.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="instance">The object to serialize.</param>
+    /// <param name="target">The target stream to which to serialize the object.</param>
     protected abstract void PerformSerialize<T>(T instance, Stream target)
         where T : notnull;
 }

--- a/src/MooVC/Threading/CoordinationContext.cs
+++ b/src/MooVC/Threading/CoordinationContext.cs
@@ -3,6 +3,10 @@
 using System;
 using System.Threading;
 
+/// <summary>
+/// Represents the context in which coordination has been applied.
+/// </summary>
+/// <typeparam name="T">The type in which the coordination context applies.</typeparam>
 internal sealed class CoordinationContext<T>
     : ICoordinationContext<T>
     where T : notnull
@@ -10,18 +14,44 @@ internal sealed class CoordinationContext<T>
     private readonly SemaphoreSlim semaphore;
     private TimeSpan? disposal;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CoordinationContext{T}"/> class.
+    /// </summary>
+    /// <param name="context">The instance on which coordination has been applied.</param>
+    /// <param name="semaphore">The semaphore used to apply coordination.</param>
     public CoordinationContext(T context, SemaphoreSlim semaphore)
     {
         Context = context;
         this.semaphore = semaphore;
     }
 
+    /// <summary>
+    /// Gets the instance on which coordination has been applied.
+    /// </summary>
+    /// <value>
+    /// The instance on which coordination has been applied.
+    /// </value>
     public T Context { get; }
 
+    /// <summary>
+    /// Gets the duration for which coordination has been applied.
+    /// </summary>
+    /// <value>
+    /// The duration for which coordination has been applied.
+    /// </value>
     public TimeSpan Duration => disposal ?? DateTimeOffset.UtcNow.Subtract(TimeStamp);
 
+    /// <summary>
+    /// Gets the timestamp when the coordination started.
+    /// </summary>
+    /// <value>
+    /// The timestamp when the coordination started.
+    /// </value>
     public DateTimeOffset TimeStamp { get; } = DateTimeOffset.UtcNow;
 
+    /// <summary>
+    /// Releases coordination on the <see cref="Context"/> and sets the final <see cref="Duration"/> for which it was held.
+    /// </summary>
     public void Dispose()
     {
         Dispose(disposing: true);

--- a/src/MooVC/Threading/Coordinator.cs
+++ b/src/MooVC/Threading/Coordinator.cs
@@ -8,22 +8,43 @@ using MooVC.Collections.Generic;
 using static System.String;
 using static MooVC.Threading.Resources;
 
+/// <summary>
+/// Represents a coordinator that manages access to resources based on context specific string, provided via the ToString method for the
+/// <see cref="ICoordinatable{T}"/> implementation of the context instance provided, or via its hashcode.
+/// </summary>
+/// <typeparam name="T">The type to which the context applies.</typeparam>
 public sealed class Coordinator<T>
     : ICoordinator<T>,
       IDisposable
     where T : notnull
 {
-    public const string NumberFormat = "X";
+    private const string NumberFormat = "X";
 
     private readonly ConcurrentDictionary<string, SemaphoreSlim> contexts = new();
     private readonly TimeSpan? @default;
     private bool isDisposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Coordinator{T}"/> class.
+    /// </summary>
+    /// <param name="default">
+    /// The duration to wait for coordination to be granted if no duraiton has been explicitly specified in the context of the request.
+    /// </param>
     public Coordinator(TimeSpan? @default = default)
     {
         this.@default = @default;
     }
 
+    /// <summary>
+    /// Asynchronously applies coordination in the specified context.
+    /// </summary>
+    /// <param name="context">The context in which coordination is to be applied.</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <param name="timeout">A timeout that specifies how long the operation should wait for coordination to be granted.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The result of the task is metadata relating to the mutual exclusive access granted by the coordinator in the specified context.
+    /// </returns>
     public async Task<ICoordinationContext<T>> ApplyAsync(T context, CancellationToken? cancellationToken = default, TimeSpan? timeout = default)
     {
         if (isDisposed)
@@ -50,6 +71,9 @@ public sealed class Coordinator<T>
         return new CoordinationContext<T>(context, semaphore);
     }
 
+    /// <summary>
+    /// Disposes all coordination resources for every context encountered during its lifecycle, including those that are currently being held.
+    /// </summary>
     public void Dispose()
     {
         Dispose(isDisposing: true);

--- a/src/MooVC/Threading/ICoordinatable.cs
+++ b/src/MooVC/Threading/ICoordinatable.cs
@@ -1,7 +1,15 @@
 ﻿namespace MooVC.Threading;
 
+/// <summary>
+/// Represents an object that can direct the context in which it is coordinated.
+/// </summary>
+/// <typeparam name="T">The type of the key used to coordinate objects of this type.</typeparam>
 public interface ICoordinatable<T>
     where T : notnull
 {
+    /// <summary>
+    /// Gets the key that serves as the context in which to coordinate operations on objects of the same type.
+    /// </summary>
+    /// <returns>The key used to coordinate operations on objects of the same type.</returns>
     T GetKey();
 }

--- a/src/MooVC/Threading/ICoordinationContext.cs
+++ b/src/MooVC/Threading/ICoordinationContext.cs
@@ -2,13 +2,26 @@
 
 using System;
 
+/// <summary>
+/// Represents the context in which coordination has been applied.
+/// </summary>
+/// <typeparam name="T">The type in which the coordination context applies.</typeparam>
 public interface ICoordinationContext<T>
     : IDisposable
     where T : notnull
 {
+    /// <summary>
+    /// Gets the instance on which coordination has been applied.
+    /// </summary>
     T Context { get; }
 
+    /// <summary>
+    /// Gets the duration for which coordination has been applied.
+    /// </summary>
     TimeSpan Duration { get; }
 
+    /// <summary>
+    /// Gets the timestamp when the coordination started.
+    /// </summary>
     DateTimeOffset TimeStamp { get; }
 }

--- a/src/MooVC/Threading/ICoordinationContext.cs
+++ b/src/MooVC/Threading/ICoordinationContext.cs
@@ -13,15 +13,24 @@ public interface ICoordinationContext<T>
     /// <summary>
     /// Gets the instance on which coordination has been applied.
     /// </summary>
+    /// <value>
+    /// The instance on which coordination has been applied.
+    /// </value>
     T Context { get; }
 
     /// <summary>
     /// Gets the duration for which coordination has been applied.
     /// </summary>
+    /// <value>
+    /// The duration for which coordination has been applied.
+    /// </value>
     TimeSpan Duration { get; }
 
     /// <summary>
     /// Gets the timestamp when the coordination started.
     /// </summary>
+    /// <value>
+    /// The timestamp when the coordination started.
+    /// </value>
     DateTimeOffset TimeStamp { get; }
 }

--- a/src/MooVC/Threading/ICoordinator.cs
+++ b/src/MooVC/Threading/ICoordinator.cs
@@ -25,8 +25,8 @@ public interface ICoordinator<T>
     /// A timeout that specifies how long the operation should wait for coordination to be granted.
     /// </param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The result of the task is metadata relating to the mutual exclusive access
-    /// granted by the coordinator in the specified context.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The result of the task is metadata relating
+    /// to the mutual exclusive access granted by the coordinator in the specified context.
     /// </returns>
     Task<ICoordinationContext<T>> ApplyAsync(T context, CancellationToken? cancellationToken = default, TimeSpan? timeout = default);
 }

--- a/src/MooVC/Threading/ICoordinator.cs
+++ b/src/MooVC/Threading/ICoordinator.cs
@@ -18,15 +18,11 @@ public interface ICoordinator<T>
     /// Asynchronously applies coordination in the specified context.
     /// </summary>
     /// <param name="context">The context in which coordination is to be applied.</param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
-    /// </param>
-    /// <param name="timeout">
-    /// A timeout that specifies how long the operation should wait for coordination to be granted.
-    /// </param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <param name="timeout">A timeout that specifies how long the operation should wait for coordination to be granted.</param>
     /// <returns>
-    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation. The result of the task is metadata relating
-    /// to the mutual exclusive access granted by the coordinator in the specified context.
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The result of the task is metadata relating to the mutual exclusive access granted by the coordinator in the specified context.
     /// </returns>
     Task<ICoordinationContext<T>> ApplyAsync(T context, CancellationToken? cancellationToken = default, TimeSpan? timeout = default);
 }

--- a/src/MooVC/Threading/ICoordinator.cs
+++ b/src/MooVC/Threading/ICoordinator.cs
@@ -4,9 +4,29 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Represents a coordinator, which is a component that is responsible for managing access to resources based on context specific metadata.
+/// Coordination reduces contention by ensuring mutual exclusivity is only applied by type specific context metadata, rather than by type.
+/// It is essentially the difference between locking a database table or locking a single row.
+/// </summary>
+/// <typeparam name="T">The type to which the context applies.</typeparam>
 public interface ICoordinator<T>
     : IDisposable
     where T : notnull
 {
+    /// <summary>
+    /// Asynchronously applies coordination in the specified context.
+    /// </summary>
+    /// <param name="context">The context in which coordination is to be applied.</param>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used to cancel the operation.
+    /// </param>
+    /// <param name="timeout">
+    /// A timeout that specifies how long the operation should wait for coordination to be granted.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The result of the task is metadata relating to the mutual exclusive access
+    /// granted by the coordinator in the specified context.
+    /// </returns>
     Task<ICoordinationContext<T>> ApplyAsync(T context, CancellationToken? cancellationToken = default, TimeSpan? timeout = default);
 }

--- a/src/MooVC/Threading/ICoordinator.cs
+++ b/src/MooVC/Threading/ICoordinator.cs
@@ -19,7 +19,7 @@ public interface ICoordinator<T>
     /// </summary>
     /// <param name="context">The context in which coordination is to be applied.</param>
     /// <param name="cancellationToken">
-    /// A cancellation token that can be used to cancel the operation.
+    /// A <see cref="CancellationToken" /> that can be used to cancel the operation.
     /// </param>
     /// <param name="timeout">
     /// A timeout that specifies how long the operation should wait for coordination to be granted.

--- a/src/MooVC/Threading/Initializer.cs
+++ b/src/MooVC/Threading/Initializer.cs
@@ -6,6 +6,10 @@ using System.Threading.Tasks;
 using static MooVC.Ensure;
 using static MooVC.Threading.Resources;
 
+/// <summary>
+/// Provides support for asynchronous lazy initialization of a resource.
+/// </summary>
+/// <typeparam name="T">The type of the resource to be initialized.</typeparam>
 public sealed class Initializer<T>
     where T : notnull
 {
@@ -14,15 +18,33 @@ public sealed class Initializer<T>
     private T? resource;
     private int waiting;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Initializer{T}"/> class.
+    /// </summary>
+    /// <param name="initializer">A function that initializes the resource.</param>
     public Initializer(Func<CancellationToken, Task<T>> initializer)
     {
         this.initializer = IsNotNull(initializer, message: InitializerInitializerRequired);
     }
 
+    /// <summary>
+    /// Gets a value indicating whether the resource has been initialized.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the resource has been initialized; otherwise, <c>false</c>.
+    /// </value>
     public bool IsInitialized { get; private set; }
 
     private SemaphoreSlim Mutex => mutex.Value;
 
+    /// <summary>
+    /// Asynchronously initializes the resource and coordinates access to it.
+    /// </summary>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation.
+    /// The result of the task is the initialized resource.
+    /// </returns>
     public async Task<T> InitializeAsync(CancellationToken? cancellationToken = default)
     {
         if (!IsInitialized)


### PR DESCRIPTION
# Release v7.1.0

In preparation for the removal of ISerializable as part of Microsoft's BinaryFormatter Obsoletion Strategy, all supporting elements have been marked as obsolete, with the intention of full removal in v8. Please see https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md for more information.

## Enhancements

- Marked all Serialization.SerializationInfoExtensions as obsolete.
- Marked all Serialization.SerializationInfoEnumeratorExtensions as obsolete.
- Marked all implementations specific to ISerializable as obsolete.
- Updated all public and protected elements to include documentation headers.