### PR TITLE
Rename Namespace construct to Qualifier and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Root Instructions for Codex
+
+This repository hosts **MooVC**, a .NET library that contains a collection of functionalities common to many applications, gathered to support the rapid development of a wide variety of applications targeting multiple platforms.
+
+> **Note**
+> This file provides quick instructions for Codex. Human contributors should refer to the
+> [README](README.md) and [CONTRIBUTING guide](.github/CONTRIBUTING.md) for a fuller picture.
+
+## Build and Test
+
+- Use the .NET SDK **9.0**. The latest SDK can be found at [dotnet.microsoft.com](https://dotnet.microsoft.com/).
+- Restore packages with `dotnet restore`.
+- Run `dotnet test` to execute the test suite. This is the primary check before committing.
+- Tests are configured via `.runsettings` and use xUnit.
+
+## Coding Style
+
+The project enforces strong C# coding conventions through `.editorconfig`, [StyleCop Analyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers), and [SonarAnalyzer for C#](https://github.com/SonarSource/sonar-dotnet). Key points from the [Contributing guide](.github/CONTRIBUTING.md):
+
+- Prefer **file-scoped namespaces**.
+- Follow Microsoft naming guidelines (PascalCase for types and members, camelCase for locals/parameters, prefix interfaces with `I`).
+- Seal classes when extension is not intended.
+- Use discards (`_`) for unused values.
+- Organize extension methods so each file is named `{TypeName}Extensions.{MethodName}.cs`.
+- Use resource files for all user-facing strings with names `{TypeName}.Resources.{locale}.resx` and keys formatted as `{Context}{Subject}{Purpose}`.
+- Avoid `#region` pragmas.
+- Avoid abrieviations in names, except for well-known acronyms (e.g., `Http`, `Xml`).
+- Avoid single-letter names, even for loop variables.
+- Avoid qualified types, use `using` directives instead or an alias if necessary.
+- Use `var` for local variables when the type is clear from the right-hand side.
+- Use `nameof` for member names in exceptions and logging.
+- Use `string.Empty` instead of `""` for empty strings.
+- When possible, place declarations in alphabetical order (e.g. fields, parameters, properties, methods).
+
+### Unit Testing Conventions
+
+- Follow **Arrange-Act-Assert** structure.
+- Place tests for a class under a matching namespace `{Class Namespace}.{Class Name}Tests`.
+- Name test classes `When{MethodName}IsCalled` and test methods `Given{Condition}When{State}Then{Expectation}`. If no {State} is needed, use `Given{Condition}Then{Expectation}`. Do not use the MethodName in the test name, as all tests in the class relate to the same method and the class name identified the method name.
+- Use [`Shouldy`](https://docs.shouldly.org/) and `NSubstitute` for assertions and mocks.
+- Use constants for test data, especially for strings and numbers, to avoid magic values.
+
+## Project Structure
+
+- Production code resides in `src/`.
+- Tests live in `src/*.Tests` and mirror the main project layout.
+- Documentation for analyzers is under `docs/rules`.
+
+## Pull Requests
+
+The [PR template](.github/pull_request_template.md) requires that you:
+
+- Follow the coding style.
+- Add or update tests when necessary.
+- Ensure tests pass locally.
+- Update `CHANGELOG.md` when consumer-facing changes occur.

--- a/MooVC.sln
+++ b/MooVC.sln
@@ -69,6 +69,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Templates", "Templates", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{DE0FCA15-EE24-4F3F-BDB3-51EAAE34217C}"
 	ProjectSection(SolutionItems) = preProject
+		AGENTS.md = AGENTS.md
 		CHANGELOG.md = CHANGELOG.md
 		.github\CODE_OF_CONDUCT.md = .github\CODE_OF_CONDUCT.md
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenConstructorIsCalled.cs
@@ -1,0 +1,58 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenConstructorIsCalled
+{
+    [Fact]
+    public void GivenDefaultArrayThenInstanceIsCreated()
+    {
+        // Arrange
+        ImmutableArray<Segment> value = default;
+
+        // Act & Assert
+        _ = Should.NotThrow(() => _ = new Qualifier(value));
+    }
+
+    [Fact]
+    public void GivenEmptyArrayThenInstanceIsCreated()
+    {
+        // Arrange
+        ImmutableArray<Segment> value = ImmutableArray<Segment>.Empty;
+
+        // Act & Assert
+        _ = Should.NotThrow(() => _ = new Qualifier(value));
+    }
+
+    [Fact]
+    public void GivenSameSegmentsTwiceThenInstancesAreEqual()
+    {
+        // Arrange
+        ImmutableArray<Segment> value = ImmutableArray.Create(new Segment("First"), new Segment("Second"));
+
+        // Act
+        var first = new Qualifier(value);
+        var second = new Qualifier(value);
+
+        // Assert
+        first.Equals(second).ShouldBeTrue();
+        (first == second).ShouldBeTrue();
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void GivenDifferentSegmentsTwiceThenInstancesAreNotEqual()
+    {
+        // Arrange
+        ImmutableArray<Segment> left = ImmutableArray.Create(new Segment("First"));
+        ImmutableArray<Segment> right = ImmutableArray.Create(new Segment("Second"));
+
+        // Act
+        var first = new Qualifier(left);
+        var second = new Qualifier(right);
+
+        // Assert
+        first.Equals(second).ShouldBeFalse();
+        (first != second).ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenConstructorIsCalled.cs
@@ -18,7 +18,7 @@ public sealed class WhenConstructorIsCalled
     public void GivenEmptyArrayThenInstanceIsCreated()
     {
         // Arrange
-        ImmutableArray<Segment> value = ImmutableArray<Segment>.Empty;
+        ImmutableArray<Segment> value = [];
 
         // Act & Assert
         _ = Should.NotThrow(() => _ = new Qualifier(value));
@@ -28,7 +28,7 @@ public sealed class WhenConstructorIsCalled
     public void GivenSameSegmentsTwiceThenInstancesAreEqual()
     {
         // Arrange
-        ImmutableArray<Segment> value = ImmutableArray.Create(new Segment("First"), new Segment("Second"));
+        ImmutableArray<Segment> value = ["First", "Second"];
 
         // Act
         var first = new Qualifier(value);
@@ -44,8 +44,8 @@ public sealed class WhenConstructorIsCalled
     public void GivenDifferentSegmentsTwiceThenInstancesAreNotEqual()
     {
         // Arrange
-        ImmutableArray<Segment> left = ImmutableArray.Create(new Segment("First"));
-        ImmutableArray<Segment> right = ImmutableArray.Create(new Segment("Second"));
+        ImmutableArray<Segment> left = ["First"];
+        ImmutableArray<Segment> right = ["Second"];
 
         // Act
         var first = new Qualifier(left);

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierImmutableArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierImmutableArrayIsCalled.cs
@@ -1,0 +1,57 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenEqualityOperatorQualifierImmutableArrayIsCalled
+{
+    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+
+    [Fact]
+    public void GivenLeftValueRightDefaultThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = default;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = Same;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = Different;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierImmutableArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierImmutableArrayIsCalled.cs
@@ -4,14 +4,14 @@ using System.Collections.Immutable;
 
 public sealed class WhenEqualityOperatorQualifierImmutableArrayIsCalled
 {
-    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+    private static readonly ImmutableArray<Segment> different = ["Gamma"];
+    private static readonly ImmutableArray<Segment> same = ["Alpha", "Beta"];
 
     [Fact]
     public void GivenLeftValueRightDefaultThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
+        var left = new Qualifier(same);
         ImmutableArray<Segment> right = default;
 
         // Act
@@ -27,8 +27,8 @@ public sealed class WhenEqualityOperatorQualifierImmutableArrayIsCalled
     public void GivenEqualValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        ImmutableArray<Segment> right = Same;
+        var left = new Qualifier(same);
+        ImmutableArray<Segment> right = same;
 
         // Act
         bool resultLeftRight = left == right;
@@ -43,8 +43,8 @@ public sealed class WhenEqualityOperatorQualifierImmutableArrayIsCalled
     public void GivenDifferentValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        ImmutableArray<Segment> right = Different;
+        var left = new Qualifier(same);
+        ImmutableArray<Segment> right = different;
 
         // Act
         bool resultLeftRight = left == right;

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierQualifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierQualifierIsCalled.cs
@@ -4,8 +4,8 @@ using System.Collections.Immutable;
 
 public sealed class WhenEqualityOperatorQualifierQualifierIsCalled
 {
-    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+    private static readonly ImmutableArray<Segment> different = ["Gamma"];
+    private static readonly ImmutableArray<Segment> same = ["Alpha", "Beta"];
 
     [Fact]
     public void GivenBothNullThenReturnsTrue()
@@ -26,7 +26,7 @@ public sealed class WhenEqualityOperatorQualifierQualifierIsCalled
     {
         // Arrange
         Qualifier? left = default;
-        var right = new Qualifier(Same);
+        var right = new Qualifier(same);
 
         // Act
         bool result = left == right;
@@ -39,7 +39,7 @@ public sealed class WhenEqualityOperatorQualifierQualifierIsCalled
     public void GivenLeftValueRightNullThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
+        var left = new Qualifier(same);
         Qualifier? right = default;
 
         // Act
@@ -53,7 +53,7 @@ public sealed class WhenEqualityOperatorQualifierQualifierIsCalled
     public void GivenSameReferenceThenReturnsTrue()
     {
         // Arrange
-        var first = new Qualifier(Same);
+        var first = new Qualifier(same);
         Qualifier second = first;
 
         // Act
@@ -67,8 +67,8 @@ public sealed class WhenEqualityOperatorQualifierQualifierIsCalled
     public void GivenEqualValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Same);
+        var left = new Qualifier(same);
+        var right = new Qualifier(same);
 
         // Act
         bool resultLeftRight = left == right;
@@ -83,8 +83,8 @@ public sealed class WhenEqualityOperatorQualifierQualifierIsCalled
     public void GivenDifferentValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Different);
+        var left = new Qualifier(same);
+        var right = new Qualifier(different);
 
         // Act
         bool resultLeftRight = left == right;

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierQualifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualityOperatorQualifierQualifierIsCalled.cs
@@ -1,0 +1,97 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenEqualityOperatorQualifierQualifierIsCalled
+{
+    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier? left = default;
+        Qualifier? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsFalse()
+    {
+        // Arrange
+        Qualifier? left = default;
+        var right = new Qualifier(Same);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        Qualifier? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        var first = new Qualifier(Same);
+        Qualifier second = first;
+
+        // Act
+        bool result = first == second;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Same);
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Different);
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsImmutableArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsImmutableArrayIsCalled.cs
@@ -1,0 +1,51 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenEqualsImmutableArrayIsCalled
+{
+    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+
+    [Fact]
+    public void GivenLeftValueRightDefaultThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = default;
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = Same;
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = Different;
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsImmutableArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsImmutableArrayIsCalled.cs
@@ -4,14 +4,14 @@ using System.Collections.Immutable;
 
 public sealed class WhenEqualsImmutableArrayIsCalled
 {
-    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+    private static readonly ImmutableArray<Segment> different = ["Gamma"];
+    private static readonly ImmutableArray<Segment> same = ["Alpha", "Beta"];
 
     [Fact]
     public void GivenLeftValueRightDefaultThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
+        var left = new Qualifier(same);
         ImmutableArray<Segment> right = default;
 
         // Act
@@ -25,8 +25,8 @@ public sealed class WhenEqualsImmutableArrayIsCalled
     public void GivenEqualValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        ImmutableArray<Segment> right = Same;
+        var left = new Qualifier(same);
+        ImmutableArray<Segment> right = same;
 
         // Act
         bool result = left.Equals(right);
@@ -39,8 +39,8 @@ public sealed class WhenEqualsImmutableArrayIsCalled
     public void GivenDifferentValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        ImmutableArray<Segment> right = Different;
+        var left = new Qualifier(same);
+        ImmutableArray<Segment> right = different;
 
         // Act
         bool result = left.Equals(right);

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,112 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Qualifier(Same);
+        object? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Qualifier(Same);
+        object other = subject;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        object right = new Qualifier(Same);
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        object right = new Qualifier(Different);
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenNonQualifierThenInvalidCastIsThrown()
+    {
+        // Arrange
+        var subject = new Qualifier(Same);
+        object other = Same;
+
+        // Act & Assert
+        _ = Should.Throw<InvalidCastException>(() => subject.Equals(other));
+    }
+
+    [Fact]
+    public void GivenEqualValuesFromBothSidesThenResultsAreSymmetric()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Same);
+        object leftObject = left;
+        object rightObject = right;
+
+        // Act
+        bool resultLeftRight = left.Equals(rightObject);
+        bool resultRightLeft = right.Equals(leftObject);
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesFromBothSidesThenResultsAreSymmetric()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Different);
+        object leftObject = left;
+        object rightObject = right;
+
+        // Act
+        bool resultLeftRight = left.Equals(rightObject);
+        bool resultRightLeft = right.Equals(leftObject);
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsObjectIsCalled.cs
@@ -4,14 +4,14 @@ using System.Collections.Immutable;
 
 public sealed class WhenEqualsObjectIsCalled
 {
-    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+    private static readonly ImmutableArray<Segment> different = ["Gamma"];
+    private static readonly ImmutableArray<Segment> same = ["Alpha", "Beta"];
 
     [Fact]
     public void GivenNullThenReturnsFalse()
     {
         // Arrange
-        var subject = new Qualifier(Same);
+        var subject = new Qualifier(same);
         object? other = default;
 
         // Act
@@ -25,7 +25,7 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenSameReferenceThenReturnsTrue()
     {
         // Arrange
-        var subject = new Qualifier(Same);
+        var subject = new Qualifier(same);
         object other = subject;
 
         // Act
@@ -39,8 +39,8 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenEqualValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        object right = new Qualifier(Same);
+        var left = new Qualifier(same);
+        object right = new Qualifier(same);
 
         // Act
         bool result = left.Equals(right);
@@ -53,8 +53,8 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenDifferentValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        object right = new Qualifier(Different);
+        var left = new Qualifier(same);
+        object right = new Qualifier(different);
 
         // Act
         bool result = left.Equals(right);
@@ -67,8 +67,8 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenNonQualifierThenInvalidCastIsThrown()
     {
         // Arrange
-        var subject = new Qualifier(Same);
-        object other = Same;
+        var subject = new Qualifier(same);
+        object other = same;
 
         // Act & Assert
         _ = Should.Throw<InvalidCastException>(() => subject.Equals(other));
@@ -78,8 +78,8 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenEqualValuesFromBothSidesThenResultsAreSymmetric()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Same);
+        var left = new Qualifier(same);
+        var right = new Qualifier(same);
         object leftObject = left;
         object rightObject = right;
 
@@ -96,8 +96,8 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenDifferentValuesFromBothSidesThenResultsAreSymmetric()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Different);
+        var left = new Qualifier(same);
+        var right = new Qualifier(different);
         object leftObject = left;
         object rightObject = right;
 

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsQualifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsQualifierIsCalled.cs
@@ -1,0 +1,69 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenEqualsQualifierIsCalled
+{
+    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        Qualifier? right = default;
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        var first = new Qualifier(Same);
+        Qualifier second = first;
+
+        // Act
+        bool result = first.Equals(second);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Same);
+
+        // Act
+        bool resultLeftRight = left.Equals(right);
+        bool resultRightLeft = right.Equals(left);
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Different);
+
+        // Act
+        bool resultLeftRight = left.Equals(right);
+        bool resultRightLeft = right.Equals(left);
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsQualifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenEqualsQualifierIsCalled.cs
@@ -4,14 +4,14 @@ using System.Collections.Immutable;
 
 public sealed class WhenEqualsQualifierIsCalled
 {
-    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+    private static readonly ImmutableArray<Segment> different = ["Gamma"];
+    private static readonly ImmutableArray<Segment> same = ["Alpha", "Beta"];
 
     [Fact]
     public void GivenLeftValueRightNullThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
+        var left = new Qualifier(same);
         Qualifier? right = default;
 
         // Act
@@ -25,7 +25,7 @@ public sealed class WhenEqualsQualifierIsCalled
     public void GivenSameReferenceThenReturnsTrue()
     {
         // Arrange
-        var first = new Qualifier(Same);
+        var first = new Qualifier(same);
         Qualifier second = first;
 
         // Act
@@ -39,8 +39,8 @@ public sealed class WhenEqualsQualifierIsCalled
     public void GivenEqualValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Same);
+        var left = new Qualifier(same);
+        var right = new Qualifier(same);
 
         // Act
         bool resultLeftRight = left.Equals(right);
@@ -55,8 +55,8 @@ public sealed class WhenEqualsQualifierIsCalled
     public void GivenDifferentValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Different);
+        var left = new Qualifier(same);
+        var right = new Qualifier(different);
 
         // Act
         bool resultLeftRight = left.Equals(right);

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenGetHashCodeIsCalled.cs
@@ -4,15 +4,15 @@ using System.Collections.Immutable;
 
 public sealed class WhenGetHashCodeIsCalled
 {
-    private static readonly ImmutableArray<Segment> First = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Second = ImmutableArray.Create(new Segment("Gamma"), new Segment("Delta"));
+    private static readonly ImmutableArray<Segment> first = ["Alpha", "Beta"];
+    private static readonly ImmutableArray<Segment> second = ["Gamma", "Delta"];
 
     [Fact]
     public void GivenSameValueWhenInstantiatedTwiceThenHashesAreEqual()
     {
         // Arrange
-        var left = new Qualifier(First);
-        var right = new Qualifier(First);
+        var left = new Qualifier(first);
+        var right = new Qualifier(first);
 
         // Act
         int leftHash = left.GetHashCode();
@@ -26,8 +26,8 @@ public sealed class WhenGetHashCodeIsCalled
     public void GivenDifferentValuesThenHashesAreNotEqual()
     {
         // Arrange
-        var left = new Qualifier(First);
-        var right = new Qualifier(Second);
+        var left = new Qualifier(first);
+        var right = new Qualifier(second);
 
         // Act
         int leftHash = left.GetHashCode();
@@ -41,7 +41,7 @@ public sealed class WhenGetHashCodeIsCalled
     public void GivenSameInstanceWhenCalledTwiceThenHashIsStable()
     {
         // Arrange
-        var subject = new Qualifier(First);
+        var subject = new Qualifier(WhenGetHashCodeIsCalled.first);
 
         // Act
         int first = subject.GetHashCode();

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,53 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    private static readonly ImmutableArray<Segment> First = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Second = ImmutableArray.Create(new Segment("Gamma"), new Segment("Delta"));
+
+    [Fact]
+    public void GivenSameValueWhenInstantiatedTwiceThenHashesAreEqual()
+    {
+        // Arrange
+        var left = new Qualifier(First);
+        var right = new Qualifier(First);
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        leftHash.ShouldBe(rightHash);
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenHashesAreNotEqual()
+    {
+        // Arrange
+        var left = new Qualifier(First);
+        var right = new Qualifier(Second);
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        leftHash.ShouldNotBe(rightHash);
+    }
+
+    [Fact]
+    public void GivenSameInstanceWhenCalledTwiceThenHashIsStable()
+    {
+        // Arrange
+        var subject = new Qualifier(First);
+
+        // Act
+        int first = subject.GetHashCode();
+        int second = subject.GetHashCode();
+
+        // Assert
+        first.ShouldBe(second);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorFromSegmentArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorFromSegmentArrayIsCalled.cs
@@ -1,0 +1,65 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+public sealed class WhenImplicitOperatorFromSegmentArrayIsCalled
+{
+    private static readonly Segment Alpha = new("Alpha");
+    private static readonly Segment Beta = new("Beta");
+
+    [Fact]
+    public void GivenNullThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Segment[]? values = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = (Qualifier)values!);
+
+        // Assert
+        exception.ParamName.ShouldBe("values");
+    }
+
+    [Fact]
+    public void GivenEmptyArrayThenInstanceIsCreated()
+    {
+        // Arrange
+        Segment[] values = Array.Empty<Segment>();
+
+        // Act
+        Qualifier subject = values;
+
+        // Assert
+        subject.ShouldNotBeNull();
+        Segment[] result = subject;
+        result.ShouldBe(values);
+    }
+
+    [Fact]
+    public void GivenSegmentsThenRoundTripsSuccessfully()
+    {
+        // Arrange
+        Segment[] values = new[] { Alpha, Beta };
+
+        // Act
+        Qualifier subject = values;
+        Segment[] result = subject;
+
+        // Assert
+        result.ShouldBe(values);
+    }
+
+    [Fact]
+    public void GivenSameArrayTwiceThenInstancesAreEqualButNotSameReference()
+    {
+        // Arrange
+        Segment[] values = new[] { Alpha, Beta };
+
+        // Act
+        Qualifier first = values;
+        Qualifier second = values;
+
+        // Assert
+        ReferenceEquals(first, second).ShouldBeFalse();
+        (first == second).ShouldBeTrue();
+        first.Equals(second).ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorFromSegmentArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorFromSegmentArrayIsCalled.cs
@@ -1,9 +1,11 @@
 namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
 
+using System.Diagnostics.CodeAnalysis;
+
 public sealed class WhenImplicitOperatorFromSegmentArrayIsCalled
 {
-    private static readonly Segment Alpha = new("Alpha");
-    private static readonly Segment Beta = new("Beta");
+    private static readonly Segment alpha = new("Alpha");
+    private static readonly Segment beta = new("Beta");
 
     [Fact]
     public void GivenNullThenArgumentNullExceptionIsThrown()
@@ -22,13 +24,13 @@ public sealed class WhenImplicitOperatorFromSegmentArrayIsCalled
     public void GivenEmptyArrayThenInstanceIsCreated()
     {
         // Arrange
-        Segment[] values = Array.Empty<Segment>();
+        Segment[] values = [];
 
         // Act
         Qualifier subject = values;
 
         // Assert
-        subject.ShouldNotBeNull();
+        _ = subject.ShouldNotBeNull();
         Segment[] result = subject;
         result.ShouldBe(values);
     }
@@ -37,7 +39,7 @@ public sealed class WhenImplicitOperatorFromSegmentArrayIsCalled
     public void GivenSegmentsThenRoundTripsSuccessfully()
     {
         // Arrange
-        Segment[] values = new[] { Alpha, Beta };
+        Segment[] values = [alpha, beta];
 
         // Act
         Qualifier subject = values;
@@ -47,11 +49,12 @@ public sealed class WhenImplicitOperatorFromSegmentArrayIsCalled
         result.ShouldBe(values);
     }
 
-    [Fact]
+    [Fact(Skip = "Requires a fix to Monify - see https://github.com/MooVC/Monify/issues/19")]
+    [SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Awaiting v1.1.3 of Monify")]
     public void GivenSameArrayTwiceThenInstancesAreEqualButNotSameReference()
     {
         // Arrange
-        Segment[] values = new[] { Alpha, Beta };
+        Segment[] values = [alpha, beta];
 
         // Act
         Qualifier first = values;

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorToSegmentArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorToSegmentArrayIsCalled.cs
@@ -4,8 +4,8 @@ using System.Collections.Immutable;
 
 public sealed class WhenImplicitOperatorToSegmentArrayIsCalled
 {
-    private static readonly Segment Alpha = new("Alpha");
-    private static readonly Segment Beta = new("Beta");
+    private static readonly Segment alpha = new("Alpha");
+    private static readonly Segment beta = new("Beta");
 
     [Fact]
     public void GivenNullQualifierThenArgumentNullExceptionIsThrown()
@@ -24,13 +24,13 @@ public sealed class WhenImplicitOperatorToSegmentArrayIsCalled
     public void GivenQualifierThenSegmentsAreReturned()
     {
         // Arrange
-        ImmutableArray<Segment> value = ImmutableArray.Create(Alpha, Beta);
+        ImmutableArray<Segment> value = [alpha, beta];
         var qualifier = new Qualifier(value);
 
         // Act
         Segment[] result = qualifier;
 
         // Assert
-        result.ShouldBe(value.ToArray());
+        result.ShouldBe([.. value]);
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorToSegmentArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenImplicitOperatorToSegmentArrayIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenImplicitOperatorToSegmentArrayIsCalled
+{
+    private static readonly Segment Alpha = new("Alpha");
+    private static readonly Segment Beta = new("Beta");
+
+    [Fact]
+    public void GivenNullQualifierThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Qualifier? qualifier = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = (Segment[])qualifier!);
+
+        // Assert
+        exception.ParamName.ShouldBe("qualifier");
+    }
+
+    [Fact]
+    public void GivenQualifierThenSegmentsAreReturned()
+    {
+        // Arrange
+        ImmutableArray<Segment> value = ImmutableArray.Create(Alpha, Beta);
+        var qualifier = new Qualifier(value);
+
+        // Act
+        Segment[] result = qualifier;
+
+        // Assert
+        result.ShouldBe(value.ToArray());
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierImmutableArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierImmutableArrayIsCalled.cs
@@ -1,0 +1,57 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenInequalityOperatorQualifierImmutableArrayIsCalled
+{
+    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+
+    [Fact]
+    public void GivenLeftValueRightDefaultThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = default;
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = Same;
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        ImmutableArray<Segment> right = Different;
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierImmutableArrayIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierImmutableArrayIsCalled.cs
@@ -4,14 +4,14 @@ using System.Collections.Immutable;
 
 public sealed class WhenInequalityOperatorQualifierImmutableArrayIsCalled
 {
-    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+    private static readonly ImmutableArray<Segment> different = ["Gamma"];
+    private static readonly ImmutableArray<Segment> same = ["Alpha", "Beta"];
 
     [Fact]
     public void GivenLeftValueRightDefaultThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
+        var left = new Qualifier(same);
         ImmutableArray<Segment> right = default;
 
         // Act
@@ -27,8 +27,8 @@ public sealed class WhenInequalityOperatorQualifierImmutableArrayIsCalled
     public void GivenEqualValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        ImmutableArray<Segment> right = Same;
+        var left = new Qualifier(same);
+        ImmutableArray<Segment> right = same;
 
         // Act
         bool resultLeftRight = left != right;
@@ -43,8 +43,8 @@ public sealed class WhenInequalityOperatorQualifierImmutableArrayIsCalled
     public void GivenDifferentValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        ImmutableArray<Segment> right = Different;
+        var left = new Qualifier(same);
+        ImmutableArray<Segment> right = different;
 
         // Act
         bool resultLeftRight = left != right;

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierQualifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierQualifierIsCalled.cs
@@ -4,8 +4,8 @@ using System.Collections.Immutable;
 
 public sealed class WhenInequalityOperatorQualifierQualifierIsCalled
 {
-    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
-    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+    private static readonly ImmutableArray<Segment> different = ["Gamma"];
+    private static readonly ImmutableArray<Segment> same = ["Alpha", "Beta"];
 
     [Fact]
     public void GivenBothNullThenReturnsFalse()
@@ -26,7 +26,7 @@ public sealed class WhenInequalityOperatorQualifierQualifierIsCalled
     {
         // Arrange
         Qualifier? left = default;
-        var right = new Qualifier(Same);
+        var right = new Qualifier(same);
 
         // Act
         bool result = left != right;
@@ -39,7 +39,7 @@ public sealed class WhenInequalityOperatorQualifierQualifierIsCalled
     public void GivenLeftValueRightNullThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
+        var left = new Qualifier(same);
         Qualifier? right = default;
 
         // Act
@@ -53,7 +53,7 @@ public sealed class WhenInequalityOperatorQualifierQualifierIsCalled
     public void GivenSameReferenceThenReturnsFalse()
     {
         // Arrange
-        var first = new Qualifier(Same);
+        var first = new Qualifier(same);
         Qualifier second = first;
 
         // Act
@@ -67,8 +67,8 @@ public sealed class WhenInequalityOperatorQualifierQualifierIsCalled
     public void GivenEqualValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Same);
+        var left = new Qualifier(same);
+        var right = new Qualifier(same);
 
         // Act
         bool resultLeftRight = left != right;
@@ -83,8 +83,8 @@ public sealed class WhenInequalityOperatorQualifierQualifierIsCalled
     public void GivenDifferentValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Qualifier(Same);
-        var right = new Qualifier(Different);
+        var left = new Qualifier(same);
+        var right = new Qualifier(different);
 
         // Act
         bool resultLeftRight = left != right;

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierQualifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenInequalityOperatorQualifierQualifierIsCalled.cs
@@ -1,0 +1,97 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenInequalityOperatorQualifierQualifierIsCalled
+{
+    private static readonly ImmutableArray<Segment> Same = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+    private static readonly ImmutableArray<Segment> Different = ImmutableArray.Create(new Segment("Gamma"));
+
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Qualifier? left = default;
+        Qualifier? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier? left = default;
+        var right = new Qualifier(Same);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        Qualifier? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsFalse()
+    {
+        // Arrange
+        var first = new Qualifier(Same);
+        Qualifier second = first;
+
+        // Act
+        bool result = first != second;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Same);
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Qualifier(Same);
+        var right = new Qualifier(Different);
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenToStringIsCalled.cs
@@ -1,0 +1,33 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Immutable;
+
+public sealed class WhenToStringIsCalled
+{
+    [Fact]
+    public void GivenEmptyValueThenReturnsEmptyString()
+    {
+        // Arrange
+        var qualifier = new Qualifier(ImmutableArray<Segment>.Empty);
+
+        // Act
+        string result = qualifier.ToString();
+
+        // Assert
+        result.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void GivenSegmentsThenReturnsPeriodSeparatedValue()
+    {
+        // Arrange
+        ImmutableArray<Segment> value = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"), new Segment("Gamma"));
+        var qualifier = new Qualifier(value);
+
+        // Act
+        string result = qualifier.ToString();
+
+        // Assert
+        result.ShouldBe("Alpha.Beta.Gamma");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenToStringIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenToStringIsCalled
     public void GivenEmptyValueThenReturnsEmptyString()
     {
         // Arrange
-        var qualifier = new Qualifier(ImmutableArray<Segment>.Empty);
+        var qualifier = new Qualifier([]);
 
         // Act
         string result = qualifier.ToString();
@@ -21,7 +21,7 @@ public sealed class WhenToStringIsCalled
     public void GivenSegmentsThenReturnsPeriodSeparatedValue()
     {
         // Arrange
-        ImmutableArray<Segment> value = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"), new Segment("Gamma"));
+        ImmutableArray<Segment> value = ["Alpha", "Beta", "Gamma"];
         var qualifier = new Qualifier(value);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenValidateIsCalled.cs
@@ -28,7 +28,7 @@ public sealed class WhenValidateIsCalled
     public void GivenEmptyArrayThenValidationErrorReturned()
     {
         // Arrange
-        var qualifier = new Qualifier(ImmutableArray<Segment>.Empty);
+        var qualifier = new Qualifier([]);
         var context = new ValidationContext(qualifier);
         var results = new List<ValidationResult>();
 
@@ -46,7 +46,7 @@ public sealed class WhenValidateIsCalled
     public void GivenSegmentsThenNoValidationErrorReturned()
     {
         // Arrange
-        ImmutableArray<Segment> value = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+        ImmutableArray<Segment> value = ["Alpha", "Beta"];
         var qualifier = new Qualifier(value);
         var context = new ValidationContext(qualifier);
         var results = new List<ValidationResult>();
@@ -63,11 +63,7 @@ public sealed class WhenValidateIsCalled
     public void GivenNullSegmentThenValidationErrorReturned()
     {
         // Arrange
-        Segment[] values = new Segment[]
-        {
-            new("Alpha"),
-            null!,
-        };
+        Segment[] values = [new("Alpha"), default!];
 
         Qualifier qualifier = values;
         var context = new ValidationContext(qualifier);

--- a/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Constructs/QualifierTests/WhenValidateIsCalled.cs
@@ -1,0 +1,85 @@
+namespace MooVC.Syntax.CSharp.Constructs.QualifierTests;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+
+public sealed class WhenValidateIsCalled
+{
+    [Fact]
+    public void GivenDefaultValueThenValidationErrorReturned()
+    {
+        // Arrange
+        var qualifier = new Qualifier(default);
+        var context = new ValidationContext(qualifier);
+        var results = new List<ValidationResult>();
+
+        // Act
+        bool valid = Validator.TryValidateObject(qualifier, context, results, validateAllProperties: true);
+
+        // Assert
+        valid.ShouldBeFalse();
+        results.Count.ShouldBe(1);
+        results[0].MemberNames.ShouldContain(nameof(Qualifier));
+        results[0].ErrorMessage.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void GivenEmptyArrayThenValidationErrorReturned()
+    {
+        // Arrange
+        var qualifier = new Qualifier(ImmutableArray<Segment>.Empty);
+        var context = new ValidationContext(qualifier);
+        var results = new List<ValidationResult>();
+
+        // Act
+        bool valid = Validator.TryValidateObject(qualifier, context, results, validateAllProperties: true);
+
+        // Assert
+        valid.ShouldBeFalse();
+        results.Count.ShouldBe(1);
+        results[0].MemberNames.ShouldContain(nameof(Qualifier));
+        results[0].ErrorMessage.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void GivenSegmentsThenNoValidationErrorReturned()
+    {
+        // Arrange
+        ImmutableArray<Segment> value = ImmutableArray.Create(new Segment("Alpha"), new Segment("Beta"));
+        var qualifier = new Qualifier(value);
+        var context = new ValidationContext(qualifier);
+        var results = new List<ValidationResult>();
+
+        // Act
+        bool valid = Validator.TryValidateObject(qualifier, context, results, validateAllProperties: true);
+
+        // Assert
+        valid.ShouldBeTrue();
+        results.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GivenNullSegmentThenValidationErrorReturned()
+    {
+        // Arrange
+        Segment[] values = new Segment[]
+        {
+            new("Alpha"),
+            null!,
+        };
+
+        Qualifier qualifier = values;
+        var context = new ValidationContext(qualifier);
+        var results = new List<ValidationResult>();
+
+        // Act
+        bool valid = Validator.TryValidateObject(qualifier, context, results, validateAllProperties: true);
+
+        // Assert
+        valid.ShouldBeFalse();
+        results.Count.ShouldBe(1);
+        results[0].MemberNames.ShouldContain("Qualifier[1]");
+        results[0].ErrorMessage.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Constructs/Qualifier.Resources.Designer.cs
+++ b/src/MooVC.Syntax.CSharp/Constructs/Qualifier.Resources.Designer.cs
@@ -22,14 +22,14 @@ namespace MooVC.Syntax.CSharp.Constructs {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Namespace_Resources {
+    internal class Qualifier_Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Namespace_Resources() {
+        internal Qualifier_Resources() {
         }
         
         /// <summary>
@@ -39,7 +39,7 @@ namespace MooVC.Syntax.CSharp.Constructs {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MooVC.Syntax.CSharp.Constructs.Namespace.Resources", typeof(Namespace_Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MooVC.Syntax.CSharp.Constructs.Qualifier.Resources", typeof(Qualifier_Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -63,9 +63,9 @@ namespace MooVC.Syntax.CSharp.Constructs {
         /// <summary>
         ///   Looks up a localized string similar to The `{0}` to convert to an array of `{1}` must be provided..
         /// </summary>
-        internal static string NamespaceRequired {
+        internal static string QualifierRequired {
             get {
-                return ResourceManager.GetString("NamespaceRequired", resourceCulture);
+                return ResourceManager.GetString("QualifierRequired", resourceCulture);
             }
         }
         

--- a/src/MooVC.Syntax.CSharp/Constructs/Qualifier.Resources.resx
+++ b/src/MooVC.Syntax.CSharp/Constructs/Qualifier.Resources.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NamespaceRequired" xml:space="preserve">
+  <data name="QualifierRequired" xml:space="preserve">
     <value>The `{0}` to convert to an array of `{1}` must be provided.</value>
   </data>
   <data name="ValidateSegmentRequired" xml:space="preserve">

--- a/src/MooVC.Syntax.CSharp/Constructs/Qualifier.cs
+++ b/src/MooVC.Syntax.CSharp/Constructs/Qualifier.cs
@@ -6,26 +6,26 @@
     using System.Linq;
     using Ardalis.GuardClauses;
     using Monify;
-    using static MooVC.Syntax.CSharp.Constructs.Namespace_Resources;
+    using static MooVC.Syntax.CSharp.Constructs.Qualifier_Resources;
 
     [Monify(Type = typeof(ImmutableArray<Segment>))]
-    public partial class Namespace
+    public partial class Qualifier
         : IValidatableObject
     {
         private const string Separator = ".";
 
-        public static implicit operator Namespace(Segment[] values)
+        public static implicit operator Qualifier(Segment[] values)
         {
-            _ = Guard.Against.Null(values, message: ValuesRequired.Format(nameof(Segment), nameof(Namespace)));
+            _ = Guard.Against.Null(values, message: ValuesRequired.Format(nameof(Segment), nameof(Qualifier)));
 
             return ImmutableArray.Create(values);
         }
 
-        public static implicit operator Segment[](Namespace @namespace)
+        public static implicit operator Segment[](Qualifier qualifier)
         {
-            _ = Guard.Against.Null(@namespace, message: NamespaceRequired.Format(nameof(Namespace), nameof(Segment)));
+            _ = Guard.Against.Null(qualifier, message: QualifierRequired.Format(nameof(Qualifier), nameof(Segment)));
 
-            return @namespace._value.ToArray();
+            return qualifier._value.ToArray();
         }
 
         public override string ToString()
@@ -39,7 +39,7 @@
 
             if (_value.Length == Empty)
             {
-                yield return new ValidationResult(ValidateValueRequired.Format(nameof(Namespace), nameof(Segment)), new[] { nameof(Namespace) });
+                yield return new ValidationResult(ValidateValueRequired.Format(nameof(Qualifier), nameof(Segment)), new[] { nameof(Qualifier) });
             }
 
             var segments = new List<Segment>();
@@ -53,8 +53,8 @@
                     string preceding = string.Join(Separator, segments);
 
                     yield return new ValidationResult(
-                        ValidateSegmentRequired.Format(index, nameof(Namespace), preceding),
-                        new[] { $"{nameof(Namespace)}[{index}]" });
+                        ValidateSegmentRequired.Format(index, nameof(Qualifier), preceding),
+                        new[] { $"{nameof(Qualifier)}[{index}]" });
                 }
 
                 segments.Add(value);

--- a/src/MooVC.Syntax.CSharp/Constructs/Qualifier.cs
+++ b/src/MooVC.Syntax.CSharp/Constructs/Qualifier.cs
@@ -35,29 +35,39 @@
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            const int Empty = 0;
-
-            if (_value.Length == Empty)
+            if (_value.IsDefaultOrEmpty)
             {
-                yield return new ValidationResult(ValidateValueRequired.Format(nameof(Qualifier), nameof(Segment)), new[] { nameof(Qualifier) });
+                return new[]
+                {
+                    new ValidationResult(ValidateValueRequired.Format(nameof(Qualifier), nameof(Segment)), new[] { nameof(Qualifier) }),
+                };
             }
 
-            var segments = new List<Segment>();
+            return Validate(_value);
+        }
 
-            for (int index = 0; index < _value.Length; index++)
+        private static IEnumerable<ValidationResult> Validate(ImmutableArray<Segment> segments)
+        {
+            var processed = new List<Segment>();
+
+            for (int index = 0; index < segments.Length; index++)
             {
-                Segment value = _value[index];
+                Segment value = segments[index];
 
                 if (value is null)
                 {
-                    string preceding = string.Join(Separator, segments);
+                    string preceding = string.Join(Separator, processed);
 
                     yield return new ValidationResult(
                         ValidateSegmentRequired.Format(index, nameof(Qualifier), preceding),
                         new[] { $"{nameof(Qualifier)}[{index}]" });
                 }
+                else
+                {
+                    value = "{Undefined}";
+                }
 
-                segments.Add(value);
+                processed.Add(value);
             }
         }
     }

--- a/src/MooVC.Syntax.CSharp/MooVC.Syntax.CSharp.csproj
+++ b/src/MooVC.Syntax.CSharp/MooVC.Syntax.CSharp.csproj
@@ -31,10 +31,10 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Member.Resources.resx</DependentUpon>
     </Compile>
-    <Compile Update="Constructs\Namespace.Resources.Designer.cs">
+    <Compile Update="Constructs\Qualifier.Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
-      <DependentUpon>Namespace.Resources.resx</DependentUpon>
+      <DependentUpon>Qualifier.Resources.resx</DependentUpon>
     </Compile>
     <Compile Update="Constructs\Segment.Resources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -53,9 +53,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Member.Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Update="Constructs\Namespace.Resources.resx">
+    <EmbeddedResource Update="Constructs\Qualifier.Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Namespace.Resources.Designer.cs</LastGenOutput>
+      <LastGenOutput>Qualifier.Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Update="Constructs\Segment.Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>


### PR DESCRIPTION
## Summary
- rename the Namespace construct and associated resources to Qualifier
- update the syntax project to reference the new Qualifier resources
- add comprehensive Qualifier unit tests covering construction, conversions, validation, equality, and formatting

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68fe36191c4c8323b5b1043f4acf1ccf