### PR TITLE
Add tests for Combine overload using formatter

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/StringExtensionsTests/WhenCombineIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StringExtensionsTests/WhenCombineIsCalled.cs
@@ -1,5 +1,8 @@
 namespace MooVC.Syntax.CSharp.StringExtensionsTests;
 
+using System.Collections.Immutable;
+using System.Linq;
+
 public sealed class WhenCombineIsCalled
 {
     private const string Separator = ",";
@@ -86,5 +89,93 @@ public sealed class WhenCombineIsCalled
 
         // Assert
         result.ShouldBe(string.Join(separator, samples));
+    }
+
+    [Fact]
+    public void GivenFormatterIsNullThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        string separator = Separator;
+        ImmutableArray<string> elements = ImmutableArray.Create(samples);
+        Func<string, string>? formatter = default;
+
+        // Act
+        Action action = () => separator.Combine(elements, formatter!);
+
+        // Assert
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(action);
+        exception.ParamName.ShouldBe(nameof(formatter));
+    }
+
+    [Fact]
+    public void GivenElementsAreDefaultThenAnEmptyStringIsReturned()
+    {
+        // Arrange
+        string separator = Separator;
+        ImmutableArray<string> elements = default;
+
+        // Act
+        string result = separator.Combine(elements, value => value);
+
+        // Assert
+        result.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void GivenElementsAreEmptyThenAnEmptyStringIsReturned()
+    {
+        // Arrange
+        string separator = Separator;
+        ImmutableArray<string> elements = ImmutableArray<string>.Empty;
+
+        // Act
+        string result = separator.Combine(elements, value => value);
+
+        // Assert
+        result.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void GivenSeparatorIsNullThenArgumentNullExceptionIsThrownWhenElementsAreProvided()
+    {
+        // Arrange
+        string? separator = default;
+        ImmutableArray<string> elements = ImmutableArray.Create(samples);
+
+        // Act
+        Action action = () => separator!.Combine(elements, value => value);
+
+        // Assert
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(action);
+        exception.ParamName.ShouldBe(nameof(separator));
+    }
+
+    [Fact]
+    public void GivenSeparatorIsEmptyThenArgumentExceptionIsThrownWhenElementsAreProvided()
+    {
+        // Arrange
+        string separator = string.Empty;
+        ImmutableArray<string> elements = ImmutableArray.Create(samples);
+
+        // Act
+        Action action = () => separator.Combine(elements, value => value);
+
+        // Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(action);
+        exception.ParamName.ShouldBe(nameof(separator));
+    }
+
+    [Fact]
+    public void GivenMultipleElementsThenTheyAreFormattedAndCombinedWithTheSeparator()
+    {
+        // Arrange
+        string separator = Separator;
+        ImmutableArray<string> elements = ImmutableArray.Create(samples);
+
+        // Act
+        string result = separator.Combine(elements, value => value.ToUpperInvariant());
+
+        // Assert
+        result.ShouldBe(string.Join(separator, samples.Select(value => value.ToUpperInvariant())));
     }
 }


### PR DESCRIPTION
## Summary
- add comprehensive coverage for the Combine overload handling ImmutableArray inputs with custom formatter
- verify separator validation, default/empty element handling, and formatter invocation behaviors

## Testing
- dotnet test *(fails: dotnet command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69234a75a1ec8323ae2ed9e2fc4fb48c)