### PR TITLE
Add comprehensive tests for indexer members

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/IndexerTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/IndexerTestsData.cs
@@ -1,0 +1,36 @@
+using MooVC.Syntax.CSharp.Members;
+
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+public static class IndexerTestsData
+{
+    public const string DefaultParameterName = "index";
+
+    public static readonly Symbol DefaultParameterType = typeof(int);
+    public static readonly Symbol DefaultResult = typeof(string);
+
+    public static Indexer Create(
+        Parameter? parameter = default,
+        Result? result = default,
+        Scope? scope = default)
+    {
+        Parameter parameterValue = parameter ?? new Parameter
+        {
+            Name = new Identifier(DefaultParameterName),
+            Type = DefaultParameterType,
+        };
+
+        Result resultValue = result ?? new Result
+        {
+            Mode = Result.Modality.Synchronous,
+            Type = DefaultResult,
+        };
+
+        return new Indexer
+        {
+            Parameter = parameterValue,
+            Result = resultValue,
+            Scope = scope ?? Scope.Public,
+        };
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenConstructorIsCalled.cs
@@ -1,0 +1,46 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using MooVC.Syntax.CSharp.Members;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenConstructorIsCalled
+{
+    [Fact]
+    public void GivenDefaultsThenIndexerIsUndefined()
+    {
+        // Act
+        var subject = new Indexer();
+
+        // Assert
+        subject.IsUndefined.ShouldBeTrue();
+        subject.Parameter.ShouldBe(Parameter.Undefined);
+        subject.Result.ShouldBe(Result.Void);
+        subject.Scope.ShouldBe(Scope.Public);
+    }
+
+    [Fact]
+    public void GivenValuesThenPropertiesAreAssigned()
+    {
+        // Arrange
+        Parameter parameter = ParameterTestsData.Create();
+        Result result = new Result
+        {
+            Mode = Result.Modality.Synchronous,
+            Type = typeof(string),
+        };
+
+        // Act
+        var subject = new Indexer
+        {
+            Parameter = parameter,
+            Result = result,
+            Scope = Scope.Private,
+        };
+
+        // Assert
+        subject.IsUndefined.ShouldBeFalse();
+        subject.Parameter.ShouldBe(parameter);
+        subject.Result.ShouldBe(result);
+        subject.Scope.ShouldBe(Scope.Private);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenEqualityOperatorIndexerIndexerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenEqualityOperatorIndexerIndexerIsCalled.cs
@@ -1,0 +1,127 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenEqualityOperatorIndexerIndexerIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Indexer? left = default;
+        Indexer? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsFalse()
+    {
+        // Arrange
+        Indexer? left = default;
+        Indexer right = IndexerTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Indexer first = IndexerTestsData.Create();
+        Indexer second = first;
+
+        // Act
+        bool result = first == second;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer right = IndexerTestsData.Create();
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentParametersThenReturnsFalse()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer right = IndexerTestsData.Create(
+            parameter: ParameterTestsData.Create(modifier: Parameter.Mode.Ref));
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentResultsThenReturnsFalse()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer right = IndexerTestsData.Create(result: new Result { Type = typeof(Guid) });
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentScopesThenReturnsFalse()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create(scope: Scope.Internal);
+        Indexer right = IndexerTestsData.Create(scope: Scope.Private);
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenEqualsIndexerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenEqualsIndexerIsCalled.cs
@@ -1,0 +1,93 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenEqualsIndexerIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Indexer? subject = default;
+        Indexer target = IndexerTestsData.Create();
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        Indexer target = subject;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        Indexer target = IndexerTestsData.Create();
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentParametersThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        Indexer target = IndexerTestsData.Create(
+            parameter: ParameterTestsData.Create(modifier: Parameter.Mode.Out));
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentResultsThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        Indexer target = IndexerTestsData.Create(result: new Result { Type = typeof(Guid) });
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentScopesThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create(scope: Scope.Internal);
+        Indexer target = IndexerTestsData.Create(scope: Scope.Private);
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,107 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        object? comparison = default;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        object comparison = string.Empty;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        object comparison = subject;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualIndexerThenReturnsTrue()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        object comparison = IndexerTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenIndexerWithDifferentParameterThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        object comparison = IndexerTestsData.Create(
+            parameter: ParameterTestsData.Create(modifier: Parameter.Mode.Out));
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenIndexerWithDifferentResultThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+        object comparison = IndexerTestsData.Create(result: new Result { Type = typeof(Guid) });
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenIndexerWithDifferentScopeThenReturnsFalse()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create(scope: Scope.Private);
+        object comparison = IndexerTestsData.Create(scope: Scope.Public);
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,69 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEquivalentInstancesThenCodesMatch()
+    {
+        // Arrange
+        Indexer first = IndexerTestsData.Create();
+        Indexer second = IndexerTestsData.Create();
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldBe(secondCode);
+    }
+
+    [Fact]
+    public void GivenDifferentParametersThenCodesDiffer()
+    {
+        // Arrange
+        Indexer first = IndexerTestsData.Create();
+        Indexer second = IndexerTestsData.Create(
+            parameter: ParameterTestsData.Create(modifier: Parameter.Mode.Out));
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldNotBe(secondCode);
+    }
+
+    [Fact]
+    public void GivenDifferentResultsThenCodesDiffer()
+    {
+        // Arrange
+        Indexer first = IndexerTestsData.Create();
+        Indexer second = IndexerTestsData.Create(result: new Result { Type = typeof(Guid) });
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldNotBe(secondCode);
+    }
+
+    [Fact]
+    public void GivenDifferentScopesThenCodesDiffer()
+    {
+        // Arrange
+        Indexer first = IndexerTestsData.Create(scope: Scope.Internal);
+        Indexer second = IndexerTestsData.Create(scope: Scope.Public);
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldNotBe(secondCode);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenImplicitOperatorToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenImplicitOperatorToSnippetIsCalled.cs
@@ -1,0 +1,33 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenImplicitOperatorToSnippetIsCalled
+{
+    [Fact]
+    public void GivenNullSubjectThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Indexer? subject = default;
+
+        // Act
+        Func<Snippet> result = () => subject!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenIndexerThenSnippetMatchesToSnippet()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+
+        // Act
+        Snippet result = subject;
+
+        // Assert
+        result.ShouldBe(Snippet.From(subject));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,33 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Fact]
+    public void GivenNullThenThrows()
+    {
+        // Arrange
+        Indexer? subject = default;
+
+        // Act
+        Func<string> result = () => subject!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenIndexerThenStringMatchesToString()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+
+        // Act
+        string result = subject;
+
+        // Assert
+        result.ShouldBe(subject.ToString());
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenInequalityOperatorIndexerIndexerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenInequalityOperatorIndexerIndexerIsCalled.cs
@@ -1,0 +1,125 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenInequalityOperatorIndexerIndexerIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Indexer? left = default;
+        Indexer? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsTrue()
+    {
+        // Arrange
+        Indexer? left = default;
+        Indexer right = IndexerTestsData.Create();
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsTrue()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsFalse()
+    {
+        // Arrange
+        Indexer first = IndexerTestsData.Create();
+        Indexer second = first;
+
+        // Act
+        bool result = first != second;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer right = IndexerTestsData.Create();
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentParametersThenReturnsTrue()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer right = IndexerTestsData.Create(
+            parameter: ParameterTestsData.Create(modifier: Parameter.Mode.Out));
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentResultsThenReturnsTrue()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create();
+        Indexer right = IndexerTestsData.Create(result: new Result { Type = typeof(Guid) });
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentScopesThenReturnsTrue()
+    {
+        // Arrange
+        Indexer left = IndexerTestsData.Create(scope: Scope.Internal);
+        Indexer right = IndexerTestsData.Create(scope: Scope.Protected);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenToStringIsCalled.cs
@@ -1,0 +1,33 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using MooVC.Syntax.CSharp;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenToStringIsCalled
+{
+    [Fact]
+    public void GivenUndefinedIndexerThenEmptyStringReturned()
+    {
+        // Arrange
+        Indexer subject = Indexer.Undefined;
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenIndexerWithValuesThenSignatureReturned()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        result.ShouldBe(" ".Combine(subject.Scope, subject.Parameter, subject.Result));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenValidateIsCalled.cs
@@ -1,0 +1,35 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenValidateIsCalled
+{
+    [Fact]
+    public void GivenUndefinedIndexerThenNoResultsReturned()
+    {
+        // Arrange
+        Indexer subject = Indexer.Undefined;
+
+        // Act
+        IEnumerable<ValidationResult> results = subject.Validate(new ValidationContext(subject));
+
+        // Assert
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenDefinedIndexerThenNotImplementedExceptionIsThrown()
+    {
+        // Arrange
+        Indexer subject = IndexerTestsData.Create();
+
+        // Act
+        Action action = () => subject.Validate(new ValidationContext(subject));
+
+        // Assert
+        _ = action.ShouldThrow<NotImplementedException>();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenWithParameterIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenWithParameterIsCalled.cs
@@ -1,0 +1,24 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using MooVC.Syntax.CSharp.Members;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenWithParameterIsCalled
+{
+    [Fact]
+    public void GivenParameterThenReturnsNewInstanceWithUpdatedParameter()
+    {
+        // Arrange
+        Indexer original = IndexerTestsData.Create();
+        Parameter parameter = ParameterTestsData.Create(name: "updated");
+
+        // Act
+        Indexer result = original.WithParameter(parameter);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Parameter.ShouldBe(parameter);
+        result.Result.ShouldBe(original.Result);
+        result.Scope.ShouldBe(original.Scope);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenWithResultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenWithResultIsCalled.cs
@@ -1,0 +1,27 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenWithResultIsCalled
+{
+    [Fact]
+    public void GivenResultThenReturnsNewInstanceWithUpdatedResult()
+    {
+        // Arrange
+        Indexer original = IndexerTestsData.Create();
+        var result = new Result
+        {
+            Mode = Result.Modality.Asynchronous,
+            Type = typeof(int),
+        };
+
+        // Act
+        Indexer instance = original.WithResult(result);
+
+        // Assert
+        instance.ShouldNotBeSameAs(original);
+        instance.Parameter.ShouldBe(original.Parameter);
+        instance.Result.ShouldBe(result);
+        instance.Scope.ShouldBe(original.Scope);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenWithScopeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerTests/WhenWithScopeIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenWithScopeIsCalled
+{
+    [Fact]
+    public void GivenScopeThenReturnsNewInstanceWithUpdatedScope()
+    {
+        // Arrange
+        Indexer original = IndexerTestsData.Create(scope: Scope.Internal);
+
+        // Act
+        Indexer result = original.WithScope(Scope.Private);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Parameter.ShouldBe(original.Parameter);
+        result.Result.ShouldBe(original.Result);
+        result.Scope.ShouldBe(Scope.Private);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualityOperatorKindKindIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualityOperatorKindKindIsCalled.cs
@@ -1,0 +1,97 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.KindTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualityOperatorKindKindIsCalled
+{
+    private const string Same = "ref";
+    private const string Different = "unsafe";
+
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        Result.Kind? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        Result.Kind right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind left = Same;
+        Result.Kind? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind first = Same;
+        Result.Kind second = first;
+
+        // Act
+        bool result = first == second;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind left = Same;
+        Result.Kind right = Same;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind left = Same;
+        Result.Kind right = Different;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualityOperatorKindStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualityOperatorKindStringIsCalled.cs
@@ -1,0 +1,79 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.KindTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualityOperatorKindStringIsCalled
+{
+    private const string Same = "ref";
+    private const string Different = "unsafe";
+
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        const string right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        string? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        const string right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        const string right = Different;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualsKindIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualsKindIsCalled.cs
@@ -1,0 +1,62 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.KindTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualsKindIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind? subject = default;
+        Result.Kind target = Result.Kind.Unsafe;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind subject = Result.Kind.Unsafe;
+        Result.Kind target = subject;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind subject = Result.Kind.Unsafe;
+        Result.Kind target = Result.Kind.Unsafe;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind subject = Result.Kind.Unsafe;
+        Result.Kind target = Result.Kind.Ref;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,62 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.KindTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind subject = Result.Kind.Unsafe;
+        object? comparison = default;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind subject = Result.Kind.Unsafe;
+        object comparison = string.Empty;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind subject = Result.Kind.Unsafe;
+        object comparison = Result.Kind.Unsafe;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValueThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind subject = Result.Kind.Unsafe;
+        object comparison = Result.Kind.Ref;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.KindTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualValuesThenCodesMatch()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        Result.Kind right = Result.Kind.Ref;
+
+        // Act
+        int leftCode = left.GetHashCode();
+        int rightCode = right.GetHashCode();
+
+        // Assert
+        leftCode.ShouldBe(rightCode);
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenCodesDiffer()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        Result.Kind right = Result.Kind.Unsafe;
+
+        // Act
+        int leftCode = left.GetHashCode();
+        int rightCode = right.GetHashCode();
+
+        // Assert
+        leftCode.ShouldNotBe(rightCode);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenInequalityOperatorKindKindIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenInequalityOperatorKindKindIsCalled.cs
@@ -1,0 +1,97 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.KindTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenInequalityOperatorKindKindIsCalled
+{
+    private const string Same = "ref";
+    private const string Different = "unsafe";
+
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        Result.Kind? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        Result.Kind right = Same;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind left = Same;
+        Result.Kind? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind first = Same;
+        Result.Kind second = first;
+
+        // Act
+        bool result = first != second;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind left = Same;
+        Result.Kind right = Same;
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind left = Same;
+        Result.Kind right = Different;
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenInequalityOperatorKindStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/KindTests/WhenInequalityOperatorKindStringIsCalled.cs
@@ -1,0 +1,79 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.KindTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenInequalityOperatorKindStringIsCalled
+{
+    private const string Same = "ref";
+    private const string Different = "unsafe";
+
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind? left = default;
+        const string right = Same;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        string? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        const string right = Same;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Kind left = Result.Kind.Ref;
+        const string right = Different;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualityOperatorModalityModalityIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualityOperatorModalityModalityIsCalled.cs
@@ -1,0 +1,97 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.ModalityTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualityOperatorModalityModalityIsCalled
+{
+    private const string Same = "async";
+    private const string Different = "";
+
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        Result.Modality? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        Result.Modality right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality left = Same;
+        Result.Modality? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality first = Same;
+        Result.Modality second = first;
+
+        // Act
+        bool result = first == second;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality left = Same;
+        Result.Modality right = Same;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality left = Same;
+        Result.Modality right = Different;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualityOperatorModalityStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualityOperatorModalityStringIsCalled.cs
@@ -1,0 +1,79 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.ModalityTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualityOperatorModalityStringIsCalled
+{
+    private const string Same = "async";
+    private const string Different = "";
+
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        const string right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        string? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        const string right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        const string right = Different;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualsModalityIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualsModalityIsCalled.cs
@@ -1,0 +1,62 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.ModalityTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualsModalityIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality? subject = default;
+        Result.Modality target = Result.Modality.Asynchronous;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality subject = Result.Modality.Asynchronous;
+        Result.Modality target = subject;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality subject = Result.Modality.Asynchronous;
+        Result.Modality target = Result.Modality.Asynchronous;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality subject = Result.Modality.Asynchronous;
+        Result.Modality target = Result.Modality.Synchronous;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,62 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.ModalityTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality subject = Result.Modality.Asynchronous;
+        object? comparison = default;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality subject = Result.Modality.Asynchronous;
+        object comparison = string.Empty;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality subject = Result.Modality.Asynchronous;
+        object comparison = Result.Modality.Asynchronous;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValueThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality subject = Result.Modality.Asynchronous;
+        object comparison = Result.Modality.Synchronous;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.ModalityTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualValuesThenCodesMatch()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        Result.Modality right = Result.Modality.Asynchronous;
+
+        // Act
+        int leftCode = left.GetHashCode();
+        int rightCode = right.GetHashCode();
+
+        // Assert
+        leftCode.ShouldBe(rightCode);
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenCodesDiffer()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        Result.Modality right = Result.Modality.Synchronous;
+
+        // Act
+        int leftCode = left.GetHashCode();
+        int rightCode = right.GetHashCode();
+
+        // Assert
+        leftCode.ShouldNotBe(rightCode);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenInequalityOperatorModalityModalityIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenInequalityOperatorModalityModalityIsCalled.cs
@@ -1,0 +1,97 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.ModalityTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenInequalityOperatorModalityModalityIsCalled
+{
+    private const string Same = "async";
+    private const string Different = "";
+
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        Result.Modality? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        Result.Modality right = Same;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality left = Same;
+        Result.Modality? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality first = Same;
+        Result.Modality second = first;
+
+        // Act
+        bool result = first != second;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality left = Same;
+        Result.Modality right = Same;
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality left = Same;
+        Result.Modality right = Different;
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenInequalityOperatorModalityStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ModalityTests/WhenInequalityOperatorModalityStringIsCalled.cs
@@ -1,0 +1,79 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests.ModalityTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenInequalityOperatorModalityStringIsCalled
+{
+    private const string Same = "async";
+    private const string Different = "";
+
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality? left = default;
+        const string right = Same;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        string? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        const string right = Same;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modality left = Result.Modality.Asynchronous;
+        const string right = Different;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ResultTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ResultTestsData.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public static class ResultTestsData
+{
+    public static readonly Symbol DefaultType = typeof(string);
+
+    public static Result Create(Result.Kind? modifier = default, Result.Modality? mode = default, Symbol? type = default)
+    {
+        return new Result
+        {
+            Mode = mode ?? Result.Modality.Asynchronous,
+            Modifier = modifier ?? Result.Kind.None,
+            Type = type ?? DefaultType,
+        };
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenAsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenAsIsCalled.cs
@@ -1,0 +1,63 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using System;
+using System.Threading.Tasks;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenAsIsCalled
+{
+    [Fact]
+    public void GivenNullWrapperThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+
+        // Act
+        Action action = () => subject.As(wrapper: null!);
+
+        // Assert
+        _ = action.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenWrapperThenTypeIsUpdated()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(type: typeof(int));
+
+        // Act
+        Result result = subject.As(typeof(ValueTuple));
+
+        // Assert
+        result.ShouldNotBeSameAs(subject);
+        result.Mode.ShouldBe(subject.Mode);
+        result.Modifier.ShouldBe(subject.Modifier);
+        result.Type.ShouldBe(subject.Type.WithQualifier(typeof(ValueTuple)).WithArguments(subject.Type));
+    }
+
+    [Fact]
+    public void GivenTaskThenTypeIsWrapped()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(type: typeof(int));
+
+        // Act
+        Result result = subject.AsTask();
+
+        // Assert
+        result.ShouldBe(subject.As(typeof(Task)));
+    }
+
+    [Fact]
+    public void GivenValueTaskThenTypeIsWrapped()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(type: typeof(int));
+
+        // Act
+        Result result = subject.AsValueTask();
+
+        // Assert
+        result.ShouldBe(subject.As(typeof(ValueTask)));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenConstructorIsCalled.cs
@@ -1,0 +1,40 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenConstructorIsCalled
+{
+    [Fact]
+    public void GivenDefaultsThenPropertiesAreAssigned()
+    {
+        // Act
+        var subject = new Result();
+
+        // Assert
+        subject.Modifier.ShouldBe(Result.Kind.None);
+        subject.Mode.ShouldBe(Result.Modality.Asynchronous);
+        subject.Type.ShouldBe(Symbol.Unspecified);
+    }
+
+    [Fact]
+    public void GivenValuesThenPropertiesAreAssigned()
+    {
+        // Arrange
+        Result.Kind modifier = Result.Kind.Ref;
+        Result.Modality mode = Result.Modality.Synchronous;
+        Symbol type = typeof(int);
+
+        // Act
+        var subject = new Result
+        {
+            Modifier = modifier,
+            Mode = mode,
+            Type = type,
+        };
+
+        // Assert
+        subject.Modifier.ShouldBe(modifier);
+        subject.Mode.ShouldBe(mode);
+        subject.Type.ShouldBe(type);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualityOperatorResultResultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualityOperatorResultResultIsCalled.cs
@@ -1,0 +1,120 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualityOperatorResultResultIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Result? left = default;
+        Result? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsFalse()
+    {
+        // Arrange
+        Result? left = default;
+        Result right = ResultTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsFalse()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create();
+        Result second = first;
+
+        // Act
+        bool result = first == second;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result right = ResultTestsData.Create();
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentModifiersThenReturnsFalse()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create(modifier: Result.Kind.Ref);
+        Result right = ResultTestsData.Create(modifier: Result.Kind.RefReadOnly);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentModesThenReturnsFalse()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create(mode: Result.Modality.Asynchronous);
+        Result right = ResultTestsData.Create(mode: Result.Modality.Synchronous);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypesThenReturnsFalse()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create(type: typeof(int));
+        Result right = ResultTestsData.Create(type: typeof(string));
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,104 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        object? comparison = default;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        object comparison = string.Empty;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        object comparison = subject;
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualResultThenReturnsTrue()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        object comparison = ResultTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenResultWithDifferentModifierThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(modifier: Result.Kind.Unsafe);
+        object comparison = ResultTestsData.Create(modifier: Result.Kind.Ref);
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenResultWithDifferentModeThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(mode: Result.Modality.Asynchronous);
+        object comparison = ResultTestsData.Create(mode: Result.Modality.Synchronous);
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenResultWithDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(type: typeof(int));
+        object comparison = ResultTestsData.Create(type: typeof(string));
+
+        // Act
+        bool result = subject.Equals(comparison);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsResultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsResultIsCalled.cs
@@ -1,0 +1,90 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualsResultIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Result? subject = default;
+        Result target = ResultTestsData.Create();
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsTrue()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        Result target = subject;
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        Result target = ResultTestsData.Create();
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentModifiersThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(modifier: Result.Kind.Ref);
+        Result target = ResultTestsData.Create(modifier: Result.Kind.Unsafe);
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentModesThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(mode: Result.Modality.Asynchronous);
+        Result target = ResultTestsData.Create(mode: Result.Modality.Synchronous);
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypesThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(type: typeof(int));
+        Result target = ResultTestsData.Create(type: typeof(string));
+
+        // Act
+        bool result = target.Equals(subject);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,66 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEquivalentInstancesThenCodesMatch()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create();
+        Result second = ResultTestsData.Create();
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldBe(secondCode);
+    }
+
+    [Fact]
+    public void GivenDifferentModifiersThenCodesDiffer()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create(modifier: Result.Kind.Unsafe);
+        Result second = ResultTestsData.Create(modifier: Result.Kind.Ref);
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldNotBe(secondCode);
+    }
+
+    [Fact]
+    public void GivenDifferentModesThenCodesDiffer()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create(mode: Result.Modality.Asynchronous);
+        Result second = ResultTestsData.Create(mode: Result.Modality.Synchronous);
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldNotBe(secondCode);
+    }
+
+    [Fact]
+    public void GivenDifferentTypesThenCodesDiffer()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create(type: typeof(int));
+        Result second = ResultTestsData.Create(type: typeof(string));
+
+        // Act
+        int firstCode = first.GetHashCode();
+        int secondCode = second.GetHashCode();
+
+        // Assert
+        firstCode.ShouldNotBe(secondCode);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToSnippetIsCalled.cs
@@ -1,0 +1,33 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenImplicitOperatorToSnippetIsCalled
+{
+    [Fact]
+    public void GivenNullSubjectThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Result? subject = default;
+
+        // Act
+        Func<Snippet> result = () => subject!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenResultThenSnippetMatchesToSnippet()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+
+        // Act
+        Snippet result = subject;
+
+        // Assert
+        result.ShouldBe(Snippet.From(subject));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,33 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using System;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Fact]
+    public void GivenNullSubjectThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Result? subject = default;
+
+        // Act
+        Func<string> result = () => subject!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenResultThenStringMatchesToString()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+
+        // Act
+        string result = subject;
+
+        // Assert
+        result.ShouldBe(subject.ToString());
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenInequalityOperatorResultResultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenInequalityOperatorResultResultIsCalled.cs
@@ -1,0 +1,122 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenInequalityOperatorResultResultIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Result? left = default;
+        Result? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenLeftNullRightValueThenReturnsTrue()
+    {
+        // Arrange
+        Result? left = default;
+        Result right = ResultTestsData.Create();
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenLeftValueRightNullThenReturnsTrue()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenSameReferenceThenReturnsFalse()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create();
+        Result second = first;
+
+        // Act
+        bool result = first != second;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result right = ResultTestsData.Create();
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeFalse();
+        resultRightLeft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentModifiersThenReturnsTrue()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create(modifier: Result.Kind.Ref);
+        Result right = ResultTestsData.Create(modifier: Result.Kind.RefReadOnly);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentModesThenReturnsTrue()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create(mode: Result.Modality.Asynchronous);
+        Result right = ResultTestsData.Create(mode: Result.Modality.Synchronous);
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        resultLeftRight.ShouldBeTrue();
+        resultRightLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentTypesThenReturnsTrue()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create(type: typeof(int));
+        Result right = ResultTestsData.Create(type: typeof(string));
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenToStringIsCalled.cs
@@ -1,0 +1,33 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenToStringIsCalled
+{
+    [Fact]
+    public void GivenDefaultResultThenReturnsExpectedRepresentation()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        result.ShouldBe(" ".Combine(subject.Mode, subject.Modifier, subject.Type));
+    }
+
+    [Fact]
+    public void GivenSynchronousVoidResultThenReturnsEmpty()
+    {
+        // Arrange
+        Result subject = Result.Void;
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        result.ShouldBe(" ".Combine(subject.Mode, subject.Modifier, subject.Type));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenValidateIsCalled.cs
@@ -1,0 +1,34 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenValidateIsCalled
+{
+    [Fact]
+    public void GivenUnspecifiedResultThenNoErrorsReturned()
+    {
+        // Arrange
+        var subject = new Result();
+
+        // Act
+        IEnumerable<ValidationResult> results = subject.Validate(new ValidationContext(subject));
+
+        // Assert
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenSpecifiedResultThenValidationIsPerformed()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(type: typeof(int));
+
+        // Act
+        IEnumerable<ValidationResult> results = subject.Validate(new ValidationContext(subject));
+
+        // Assert
+        results.ShouldBeEmpty();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModeIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenWithModeIsCalled
+{
+    [Fact]
+    public void GivenModeThenReturnsNewInstanceWithUpdatedMode()
+    {
+        // Arrange
+        Result original = ResultTestsData.Create(mode: Result.Modality.Synchronous);
+
+        // Act
+        Result result = original.WithMode(Result.Modality.Asynchronous);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Mode.ShouldBe(Result.Modality.Asynchronous);
+        result.Modifier.ShouldBe(original.Modifier);
+        result.Type.ShouldBe(original.Type);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModifierIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenWithModifierIsCalled
+{
+    [Fact]
+    public void GivenModifierThenReturnsNewInstanceWithUpdatedModifier()
+    {
+        // Arrange
+        Result original = ResultTestsData.Create(modifier: Result.Kind.Ref);
+
+        // Act
+        Result result = original.WithModifier(Result.Kind.Unsafe);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Mode.ShouldBe(original.Mode);
+        result.Modifier.ShouldBe(Result.Kind.Unsafe);
+        result.Type.ShouldBe(original.Type);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithTypeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithTypeIsCalled.cs
@@ -1,0 +1,23 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenWithTypeIsCalled
+{
+    [Fact]
+    public void GivenTypeThenReturnsNewInstanceWithUpdatedType()
+    {
+        // Arrange
+        Result original = ResultTestsData.Create(type: typeof(int));
+        Symbol type = typeof(string);
+
+        // Act
+        Result result = original.WithType(type);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Mode.ShouldBe(original.Mode);
+        result.Modifier.ShouldBe(original.Modifier);
+        result.Type.ShouldBe(type);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for Indexer covering equality, fluent methods, conversions, and validation paths
- introduce Result test data and coverage for its conversions, fluent helpers, and validation
- verify generated operators for Result.Kind and Result.Modality

## Testing
- not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935a7eb38448323afb8f92305ef56bd)