### PR TITLE
Add tests for member ToSnippet extensions

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/Members/AttributeExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/AttributeExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,7 +1,7 @@
 namespace MooVC.Syntax.CSharp.Members.AttributeExtensionsTests;
 
-using System;
 using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Members.AttributeTests;
 
 public sealed class WhenToSnippetIsCalled
 {
@@ -19,7 +19,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = attributes.ToSnippet(Snippet.Options.Default);
+        var snippet = attributes.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -50,12 +50,11 @@ public sealed class WhenToSnippetIsCalled
 
         const string expected = """
             [Alpha]
-
             [Beta]
             """;
 
         // Act
-        Snippet snippet = attributes.ToSnippet(Snippet.Options.Default);
+        var snippet = attributes.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/AttributeExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/AttributeExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,63 @@
+namespace MooVC.Syntax.CSharp.Members.AttributeExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+
+public sealed class WhenToSnippetIsCalled
+{
+    private const string FirstAttributeName = "Beta";
+    private const string SecondAttributeName = "Alpha";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Attribute> attributes = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = attributes.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Attribute> attributes = [AttributeTestsData.Create()];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = attributes.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenAnOrderedSnippetIsReturned()
+    {
+        // Arrange
+        Attribute first = AttributeTestsData.Create(name: FirstAttributeName);
+        Attribute second = AttributeTestsData.Create(name: SecondAttributeName);
+
+        ImmutableArray<Attribute> attributes = [first, second];
+
+        const string expected = """
+            [Alpha]
+
+            [Beta]
+            """;
+
+        // Act
+        Snippet snippet = attributes.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ConstructorExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ConstructorExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,122 @@
+namespace MooVC.Syntax.CSharp.Members.ConstructorExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Concepts;
+using MooVC.Syntax.CSharp.Operators;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenToSnippetIsCalled
+{
+    private static readonly Snippet.Options Options = Snippet.Options.Default
+        .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Constructor> constructors = isDefault
+            ? default
+            : [];
+
+        Construct construct = OperatorsTestsData.CreateConstruct();
+
+        // Act
+        Snippet snippet = constructors.ToSnippet(construct, Options);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullConstructThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Constructor> constructors = [Create(name: "First")];
+        OperatorsTestsData.TestConstruct? construct = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = constructors.ToSnippet(construct!, Options));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(construct));
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Constructor> constructors = [Create(name: "First")];
+        Construct construct = OperatorsTestsData.CreateConstruct();
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = constructors.ToSnippet(construct, options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenAnOrderedSnippetIsReturned()
+    {
+        // Arrange
+        Construct construct = OperatorsTestsData.CreateConstruct();
+
+        Constructor publicMinimal = Create(name: "First", parameters: []);
+        Constructor publicWithParameter = Create(name: "Second", parameters: [ParameterTestsData.Create()]);
+        Constructor protectedWithMultipleParameters = Create(
+            name: "Third",
+            parameters: [
+                ParameterTestsData.Create(name: "Second"),
+                ParameterTestsData.Create(name: "First"),
+            ],
+            scope: Scope.Protected);
+
+        ImmutableArray<Constructor> constructors =
+        [
+            publicWithParameter,
+            protectedWithMultipleParameters,
+            publicMinimal,
+        ];
+
+        const string expected = """
+            public First()
+            {
+                return default;
+            }
+
+            public Second(Version value)
+            {
+                return default;
+            }
+
+            protected Third(Version second, Version first)
+            {
+                return default;
+            }
+            """;
+
+        // Act
+        Snippet snippet = constructors.ToSnippet(construct, Options);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+
+    private static Constructor Create(
+        string name,
+        ImmutableArray<Parameter> parameters,
+        Scope? scope = default)
+    {
+        return new Constructor
+        {
+            Body = OperatorsTestsData.DefaultBody,
+            Extensibility = Extensibility.Implicit,
+            Parameters = parameters,
+            Scope = scope ?? Scope.Public,
+        };
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ConstructorExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ConstructorExtensionsTests/WhenToSnippetIsCalled.cs
@@ -3,12 +3,12 @@ namespace MooVC.Syntax.CSharp.Members.ConstructorExtensionsTests;
 using System;
 using System.Collections.Immutable;
 using MooVC.Syntax.CSharp.Concepts;
-using MooVC.Syntax.CSharp.Operators;
 using MooVC.Syntax.CSharp.Members.ParameterTests;
+using MooVC.Syntax.CSharp.Operators;
 
 public sealed class WhenToSnippetIsCalled
 {
-    private static readonly Snippet.Options Options = Snippet.Options.Default
+    private static readonly Snippet.Options options = Snippet.Options.Default
         .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
 
     [Theory]
@@ -24,7 +24,7 @@ public sealed class WhenToSnippetIsCalled
         Construct construct = OperatorsTestsData.CreateConstruct();
 
         // Act
-        Snippet snippet = constructors.ToSnippet(construct, Options);
+        var snippet = constructors.ToSnippet(construct, options);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -34,11 +34,11 @@ public sealed class WhenToSnippetIsCalled
     public void GivenNullConstructThenAnExceptionIsThrown()
     {
         // Arrange
-        ImmutableArray<Constructor> constructors = [Create(name: "First")];
+        ImmutableArray<Constructor> constructors = [Create([])];
         OperatorsTestsData.TestConstruct? construct = default;
 
         // Act
-        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = constructors.ToSnippet(construct!, Options));
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = constructors.ToSnippet(construct!, options));
 
         // Assert
         exception.ParamName.ShouldBe(nameof(construct));
@@ -48,7 +48,7 @@ public sealed class WhenToSnippetIsCalled
     public void GivenNullOptionsThenAnExceptionIsThrown()
     {
         // Arrange
-        ImmutableArray<Constructor> constructors = [Create(name: "First")];
+        ImmutableArray<Constructor> constructors = [Create([])];
         Construct construct = OperatorsTestsData.CreateConstruct();
         Snippet.Options? options = default;
 
@@ -65,10 +65,10 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         Construct construct = OperatorsTestsData.CreateConstruct();
 
-        Constructor publicMinimal = Create(name: "First", parameters: []);
-        Constructor publicWithParameter = Create(name: "Second", parameters: [ParameterTestsData.Create()]);
+        Constructor publicMinimal = Create(parameters: []);
+        Constructor publicWithParameter = Create(parameters: [ParameterTestsData.Create()]);
+
         Constructor protectedWithMultipleParameters = Create(
-            name: "Third",
             parameters: [
                 ParameterTestsData.Create(name: "Second"),
                 ParameterTestsData.Create(name: "First"),
@@ -100,16 +100,13 @@ public sealed class WhenToSnippetIsCalled
             """;
 
         // Act
-        Snippet snippet = constructors.ToSnippet(construct, Options);
+        var snippet = constructors.ToSnippet(construct, options);
 
         // Assert
         snippet.ToString().ShouldBe(expected);
     }
 
-    private static Constructor Create(
-        string name,
-        ImmutableArray<Parameter> parameters,
-        Scope? scope = default)
+    private static Constructor Create(ImmutableArray<Parameter> parameters, Scope? scope = default)
     {
         return new Constructor
         {

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ConstructorExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ConstructorExtensionsTests/WhenToSnippetIsCalled.cs
@@ -63,7 +63,7 @@ public sealed class WhenToSnippetIsCalled
     public void GivenValuesThenAnOrderedSnippetIsReturned()
     {
         // Arrange
-        Construct construct = OperatorsTestsData.CreateConstruct();
+        Construct construct = OperatorsTestsData.CreateConstruct(name: "Test");
 
         Constructor publicMinimal = Create(parameters: []);
         Constructor publicWithParameter = Create(parameters: [ParameterTestsData.Create()]);
@@ -71,6 +71,7 @@ public sealed class WhenToSnippetIsCalled
         Constructor protectedWithMultipleParameters = Create(
             parameters: [
                 ParameterTestsData.Create(name: "Second"),
+                ParameterTestsData.Create(name: "Third", modifier: Parameter.Mode.Params, type: typeof(Version[])),
                 ParameterTestsData.Create(name: "First"),
             ],
             scope: Scope.Protected);
@@ -83,17 +84,17 @@ public sealed class WhenToSnippetIsCalled
         ];
 
         const string expected = """
-            public First()
+            public Test()
             {
                 return default;
             }
 
-            public Second(Version value)
+            public Test(Version value)
             {
                 return default;
             }
 
-            protected Third(Version second, Version first)
+            protected Test(Version first, Version second, params Version[] third)
             {
                 return default;
             }

--- a/src/MooVC.Syntax.CSharp.Tests/Members/DirectiveExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/DirectiveExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,77 @@
+namespace MooVC.Syntax.CSharp.Members.DirectiveExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+
+public sealed class WhenToSnippetIsCalled
+{
+    private const string Alias = "Collections";
+    private const string CustomQualifier = "MooVC.Syntax";
+    private const string SystemQualifier = "System";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Directive> directives = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = directives.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Directive> directives = [Create(SystemQualifier)];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = directives.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenTheyAreOrderedCorrectly()
+    {
+        // Arrange
+        Directive alias = Create(CustomQualifier, alias: Alias);
+        Directive @using = Create(CustomQualifier);
+        Directive system = Create(SystemQualifier);
+        Directive @static = Create($"{SystemQualifier}.Console", isStatic: true);
+
+        ImmutableArray<Directive> directives = [@static, system, @using, alias];
+
+        const string expected = """
+            using Collections = MooVC.Syntax;
+            using MooVC.Syntax;
+            using System;
+            using static System.Console;
+            """;
+
+        // Act
+        Snippet snippet = directives.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+
+    private static Directive Create(string qualifier, string? alias = default, bool isStatic = false)
+    {
+        return new Directive
+        {
+            Alias = alias is null ? Identifier.Unnamed : new Identifier(alias),
+            IsStatic = isStatic,
+            Qualifier = qualifier,
+        };
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/DirectiveExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/DirectiveExtensionsTests/WhenToSnippetIsCalled.cs
@@ -20,7 +20,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = directives.ToSnippet(Snippet.Options.Default);
+        var snippet = directives.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -52,14 +52,14 @@ public sealed class WhenToSnippetIsCalled
         ImmutableArray<Directive> directives = [@static, system, @using, alias];
 
         const string expected = """
-            using Collections = MooVC.Syntax;
-            using MooVC.Syntax;
             using System;
+            using MooVC.Syntax;
+            using Collections = MooVC.Syntax;
             using static System.Console;
             """;
 
         // Act
-        Snippet snippet = directives.ToSnippet(Snippet.Options.Default);
+        var snippet = directives.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/DirectiveTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/DirectiveTests/WhenToStringIsCalled.cs
@@ -31,7 +31,7 @@ public sealed class WhenToStringIsCalled
         string result = subject.ToString();
 
         // Assert
-        result.ShouldBe("using static System.Console");
+        result.ShouldBe("using static System.Console;");
     }
 
     [Fact]
@@ -48,6 +48,6 @@ public sealed class WhenToStringIsCalled
         string result = subject.ToString();
 
         // Assert
-        result.ShouldBe("using Alias =  MooVC.Syntax");
+        result.ShouldBe("using Alias = MooVC.Syntax;");
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/Members/EventExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/EventExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,83 @@
+namespace MooVC.Syntax.CSharp.Members.EventExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Members.EventTests;
+
+public sealed class WhenToSnippetIsCalled
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Event> events = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = events.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Event> events = [EventTestsData.Create()];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = events.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenAnOrderedSnippetIsReturned()
+    {
+        // Arrange
+        Event @public = EventTestsData.Create(name: "Alpha", behaviours: new Event.Methods { Add = Snippet.From("a+=1;") });
+        Event @protected = EventTestsData.Create(name: "Beta", scope: Scope.Protected, behaviours: new Event.Methods { Remove = Snippet.From("b-=1;") });
+        Event @virtual = EventTestsData.Create(name: "Gamma", behaviours: new Event.Methods { Invoke = Snippet.From("g();") });
+
+        @virtual.Extensibility = Extensibility.Virtual;
+
+        ImmutableArray<Event> events =
+        [
+            @public,
+            @protected,
+            @virtual,
+        ];
+
+        const string expected = """
+            public virtual event Handler Gamma
+            {
+                g();
+            }
+
+            public event Handler Alpha
+            {
+                a+=1;
+            }
+
+            protected event Handler Beta
+            {
+                b-=1;
+            }
+            """;
+
+        Snippet.Options options = Snippet.Options.Default
+            .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
+
+        // Act
+        Snippet snippet = events.ToSnippet(options);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/EventTests/MethodsTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/EventTests/MethodsTests/WhenToStringIsCalled.cs
@@ -34,7 +34,7 @@ public sealed class WhenToStringIsCalled
         // Arrange
         var subject = new Event.Methods
         {
-            Add = Snippet.From("value"),
+            Add = Snippet.From("value;"),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Members/EventTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/EventTests/WhenToStringIsCalled.cs
@@ -41,8 +41,8 @@ public sealed class WhenToStringIsCalled
         // Arrange
         var methods = new Event.Methods
         {
-            Add = Snippet.From("value"),
-            Remove = Snippet.From("Console.WriteLine(value)"),
+            Add = Snippet.From("value;"),
+            Remove = Snippet.From("Console.WriteLine(value);"),
         };
 
         Event subject = EventTestsData.Create(behaviours: methods);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/FieldExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/FieldExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,84 @@
+namespace MooVC.Syntax.CSharp.Members.FieldExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+
+public sealed class WhenToSnippetIsCalled
+{
+    private const string FirstFieldName = "Alpha";
+    private const string SecondFieldName = "Beta";
+    private const string ThirdFieldName = "Gamma";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Field> fields = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = fields.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Field> fields = [Create(name: FirstFieldName)];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = fields.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenTheyAreOrderedByStaticReadonlyScopeAndName()
+    {
+        // Arrange
+        Field staticReadonly = Create(name: ThirdFieldName, isStatic: true, isReadOnly: true);
+        Field staticMutable = Create(name: SecondFieldName, isStatic: true, isReadOnly: false, scope: Scope.Private);
+        Field instanceReadonly = Create(name: FirstFieldName, isStatic: false, isReadOnly: true, scope: Scope.Public);
+
+        ImmutableArray<Field> fields =
+        [
+            instanceReadonly,
+            staticMutable,
+            staticReadonly,
+        ];
+
+        const string expected = """
+            public static readonly string Gamma;
+
+            private static string Beta;
+
+            public readonly string Alpha;
+            """;
+
+        // Act
+        Snippet snippet = fields.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+
+    private static Field Create(string name, bool isStatic = false, bool isReadOnly = true, Scope? scope = default)
+    {
+        return new Field
+        {
+            IsReadOnly = isReadOnly,
+            IsStatic = isStatic,
+            Name = new Identifier(name),
+            Scope = scope ?? Scope.Public,
+            Type = typeof(string),
+        };
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/FieldExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/FieldExtensionsTests/WhenToSnippetIsCalled.cs
@@ -20,7 +20,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = fields.ToSnippet(Snippet.Options.Default);
+        var snippet = fields.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -57,14 +57,12 @@ public sealed class WhenToSnippetIsCalled
 
         const string expected = """
             public static readonly string Gamma;
-
             private static string Beta;
-
             public readonly string Alpha;
             """;
 
         // Act
-        Snippet snippet = fields.ToSnippet(Snippet.Options.Default);
+        var snippet = fields.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,89 @@
+namespace MooVC.Syntax.CSharp.Members.IndexerExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Members.IndexerTests;
+
+public sealed class WhenToSnippetIsCalled
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Indexer> indexers = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = indexers.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Indexer> indexers = [IndexerTestsData.Create()];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = indexers.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenTheyAreOrderedByScopeExtensibilityParameterAndResult()
+    {
+        // Arrange
+        Indexer publicVirtual = IndexerTestsData.Create(parameter: new Parameter { Name = "Beta" }, result: new Result { Type = new Symbol { Name = "int" } });
+        publicVirtual.Extensibility = Extensibility.Virtual;
+
+        Indexer publicStatic = IndexerTestsData.Create(parameter: new Parameter { Name = "Alpha" }, result: new Result { Type = new Symbol { Name = "string" } });
+        publicStatic.Extensibility = Extensibility.Static;
+
+        Indexer protectedVirtual = IndexerTestsData.Create(parameter: new Parameter { Name = "Gamma" }, result: new Result { Type = new Symbol { Name = "int" } }, scope: Scope.Protected);
+        protectedVirtual.Extensibility = Extensibility.Virtual;
+
+        ImmutableArray<Indexer> indexers =
+        [
+            protectedVirtual,
+            publicVirtual,
+            publicStatic,
+        ];
+
+        const string expected = """
+            public static string this[Version alpha]
+            {
+                get;
+                set;
+            }
+
+            public virtual int this[Version beta]
+            {
+                get;
+                set;
+            }
+
+            protected virtual int this[Version gamma]
+            {
+                get;
+                set;
+            }
+            """;
+
+        Snippet.Options options = Snippet.Options.Default
+            .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
+
+        // Act
+        Snippet snippet = indexers.ToSnippet(options);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
@@ -42,15 +42,15 @@ public sealed class WhenToSnippetIsCalled
     {
         // Arrange
         Indexer publicVirtual = IndexerTestsData.Create(
-            parameter: new Parameter { Name = "Beta" },
+            parameter: new Parameter { Name = "Beta", Type = typeof(Version) },
             result: new Result { Type = new Symbol { Name = "int" } });
 
         Indexer publicStatic = IndexerTestsData.Create(
-            parameter: new Parameter { Name = "Alpha" },
+            parameter: new Parameter { Name = "Alpha", Type = typeof(Version) },
             result: new Result { Type = new Symbol { Name = "string" } });
 
         Indexer protectedVirtual = IndexerTestsData.Create(
-            parameter: new Parameter { Name = "Gamma" },
+            parameter: new Parameter { Name = "Gamma", Type = typeof(Version) },
             result: new Result { Type = new Symbol { Name = "int" } },
             scope: Scope.Protected);
 
@@ -69,19 +69,16 @@ public sealed class WhenToSnippetIsCalled
             public static string this[Version alpha]
             {
                 get;
-                set;
             }
 
             public virtual int this[Version beta]
             {
                 get;
-                set;
             }
 
             protected virtual int this[Version gamma]
             {
                 get;
-                set;
             }
             """;
 

--- a/src/MooVC.Syntax.CSharp.Tests/Members/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
@@ -17,7 +17,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = indexers.ToSnippet(Snippet.Options.Default);
+        var snippet = indexers.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -41,13 +41,21 @@ public sealed class WhenToSnippetIsCalled
     public void GivenValuesThenTheyAreOrderedByScopeExtensibilityParameterAndResult()
     {
         // Arrange
-        Indexer publicVirtual = IndexerTestsData.Create(parameter: new Parameter { Name = "Beta" }, result: new Result { Type = new Symbol { Name = "int" } });
+        Indexer publicVirtual = IndexerTestsData.Create(
+            parameter: new Parameter { Name = "Beta" },
+            result: new Result { Type = new Symbol { Name = "int" } });
+
+        Indexer publicStatic = IndexerTestsData.Create(
+            parameter: new Parameter { Name = "Alpha" },
+            result: new Result { Type = new Symbol { Name = "string" } });
+
+        Indexer protectedVirtual = IndexerTestsData.Create(
+            parameter: new Parameter { Name = "Gamma" },
+            result: new Result { Type = new Symbol { Name = "int" } },
+            scope: Scope.Protected);
+
         publicVirtual.Extensibility = Extensibility.Virtual;
-
-        Indexer publicStatic = IndexerTestsData.Create(parameter: new Parameter { Name = "Alpha" }, result: new Result { Type = new Symbol { Name = "string" } });
         publicStatic.Extensibility = Extensibility.Static;
-
-        Indexer protectedVirtual = IndexerTestsData.Create(parameter: new Parameter { Name = "Gamma" }, result: new Result { Type = new Symbol { Name = "int" } }, scope: Scope.Protected);
         protectedVirtual.Extensibility = Extensibility.Virtual;
 
         ImmutableArray<Indexer> indexers =
@@ -81,7 +89,7 @@ public sealed class WhenToSnippetIsCalled
             .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
 
         // Act
-        Snippet snippet = indexers.ToSnippet(options);
+        var snippet = indexers.ToSnippet(options);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/MethodExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/MethodExtensionsTests/WhenToSnippetIsCalled.cs
@@ -44,13 +44,13 @@ public sealed class WhenToSnippetIsCalled
         Method staticMethod = MethodTestsData.Create(
             name: new Declaration { Name = "Beta" },
             scope: Scope.Public,
-            result: new Result { Type = typeof(int) },
+            result: new Result { Type = typeof(int) }.AsTask(),
             body: Snippet.From("return 1;"));
 
         Method publicVirtual = MethodTestsData.Create(
             name: new Declaration { Name = "Alpha" },
             scope: Scope.Public,
-            result: new Result { Type = typeof(void) },
+            result: Result.Void,
             body: Snippet.From("return;"));
 
         Method protectedVirtual = MethodTestsData.Create(
@@ -70,7 +70,7 @@ public sealed class WhenToSnippetIsCalled
         ];
 
         const string expected = """
-            public static int Beta(int value)
+            public static async Task<int> Beta(int value)
             {
                 return 1;
             }

--- a/src/MooVC.Syntax.CSharp.Tests/Members/MethodExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/MethodExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,86 @@
+namespace MooVC.Syntax.CSharp.Members.MethodExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Members.MethodTests;
+
+public sealed class WhenToSnippetIsCalled
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Method> methods = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = methods.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Method> methods = [MethodTestsData.Create()];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = methods.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenTheyAreOrderedByStaticScopeExtensibilityAndName()
+    {
+        // Arrange
+        Method staticMethod = MethodTestsData.Create(name: new Declaration { Name = "Beta" }, scope: Scope.Public, result: new Result { Type = typeof(int) }, body: Snippet.From("return 1;"));
+        staticMethod.Extensibility = Extensibility.Static;
+
+        Method publicVirtual = MethodTestsData.Create(name: new Declaration { Name = "Alpha" }, scope: Scope.Public, result: new Result { Type = typeof(void) }, body: Snippet.From("return;"));
+        publicVirtual.Extensibility = Extensibility.Virtual;
+
+        Method protectedVirtual = MethodTestsData.Create(name: new Declaration { Name = "Gamma" }, scope: Scope.Protected, body: Snippet.From("return 3;"));
+        protectedVirtual.Extensibility = Extensibility.Virtual;
+
+        ImmutableArray<Method> methods =
+        [
+            publicVirtual,
+            protectedVirtual,
+            staticMethod,
+        ];
+
+        const string expected = """
+            public static int Beta(int value)
+            {
+                return 1;
+            }
+
+            public virtual void Alpha(int value)
+            {
+                return;
+            }
+
+            protected virtual string Gamma(int value)
+            {
+                return 3;
+            }
+            """;
+
+        Snippet.Options options = Snippet.Options.Default
+            .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
+
+        // Act
+        Snippet snippet = methods.ToSnippet(options);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/MethodExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/MethodExtensionsTests/WhenToSnippetIsCalled.cs
@@ -17,7 +17,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = methods.ToSnippet(Snippet.Options.Default);
+        var snippet = methods.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -41,13 +41,25 @@ public sealed class WhenToSnippetIsCalled
     public void GivenValuesThenTheyAreOrderedByStaticScopeExtensibilityAndName()
     {
         // Arrange
-        Method staticMethod = MethodTestsData.Create(name: new Declaration { Name = "Beta" }, scope: Scope.Public, result: new Result { Type = typeof(int) }, body: Snippet.From("return 1;"));
+        Method staticMethod = MethodTestsData.Create(
+            name: new Declaration { Name = "Beta" },
+            scope: Scope.Public,
+            result: new Result { Type = typeof(int) },
+            body: Snippet.From("return 1;"));
+
+        Method publicVirtual = MethodTestsData.Create(
+            name: new Declaration { Name = "Alpha" },
+            scope: Scope.Public,
+            result: new Result { Type = typeof(void) },
+            body: Snippet.From("return;"));
+
+        Method protectedVirtual = MethodTestsData.Create(
+            name: new Declaration { Name = "Gamma" },
+            scope: Scope.Protected,
+            body: Snippet.From("return 3;"));
+
         staticMethod.Extensibility = Extensibility.Static;
-
-        Method publicVirtual = MethodTestsData.Create(name: new Declaration { Name = "Alpha" }, scope: Scope.Public, result: new Result { Type = typeof(void) }, body: Snippet.From("return;"));
         publicVirtual.Extensibility = Extensibility.Virtual;
-
-        Method protectedVirtual = MethodTestsData.Create(name: new Declaration { Name = "Gamma" }, scope: Scope.Protected, body: Snippet.From("return 3;"));
         protectedVirtual.Extensibility = Extensibility.Virtual;
 
         ImmutableArray<Method> methods =
@@ -78,7 +90,7 @@ public sealed class WhenToSnippetIsCalled
             .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
 
         // Act
-        Snippet snippet = methods.ToSnippet(options);
+        var snippet = methods.ToSnippet(options);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ParameterExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ParameterExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,64 @@
+namespace MooVC.Syntax.CSharp.Members.ParameterExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Members.ParameterTests;
+
+public sealed class WhenToSnippetIsCalled
+{
+    private const string FirstName = "Bravo";
+    private const string SecondName = "Alpha";
+    private const string ThirdName = "Delta";
+    private const string FourthName = "Charlie";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Parameter> parameters = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = parameters.ToSnippet(Parameter.Options.Camel);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Parameter> parameters = [ParameterTestsData.Create()];
+        Parameter.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = parameters.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenTheyAreOrderedByDefaultParamsAndName()
+    {
+        // Arrange
+        Parameter noDefault = ParameterTestsData.Create(name: FirstName);
+        Parameter withDefault = ParameterTestsData.Create(name: SecondName, @default: Snippet.From("42"));
+        Parameter @params = ParameterTestsData.Create(name: ThirdName, modifier: Parameter.Mode.Params);
+        Parameter later = ParameterTestsData.Create(name: FourthName);
+
+        ImmutableArray<Parameter> parameters = [withDefault, @params, later, noDefault];
+
+        const string expected = "Version bravo, Version charlie, params Version delta, Version alpha = 42";
+
+        // Act
+        Snippet snippet = parameters.ToSnippet(Parameter.Options.Camel);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ParameterExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ParameterExtensionsTests/WhenToSnippetIsCalled.cs
@@ -48,7 +48,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         Parameter noDefault = ParameterTestsData.Create(name: FirstName);
         Parameter withDefault = ParameterTestsData.Create(name: SecondName, @default: Snippet.From("42"));
-        Parameter @params = ParameterTestsData.Create(name: ThirdName, modifier: Parameter.Mode.Params);
+        Parameter @params = ParameterTestsData.Create(name: ThirdName, modifier: Parameter.Mode.Params, type: typeof(Version[]));
         Parameter later = ParameterTestsData.Create(name: FourthName);
 
         ImmutableArray<Parameter> parameters = [withDefault, @params, later, noDefault];

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ParameterExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ParameterExtensionsTests/WhenToSnippetIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = parameters.ToSnippet(Parameter.Options.Camel);
+        var snippet = parameters.ToSnippet(Parameter.Options.Camel);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -53,10 +53,10 @@ public sealed class WhenToSnippetIsCalled
 
         ImmutableArray<Parameter> parameters = [withDefault, @params, later, noDefault];
 
-        const string expected = "Version bravo, Version charlie, params Version delta, Version alpha = 42";
+        const string expected = "Version bravo, Version charlie, Version alpha = 42, params Version[] delta";
 
         // Act
-        Snippet snippet = parameters.ToSnippet(Parameter.Options.Camel);
+        var snippet = parameters.ToSnippet(Parameter.Options.Camel);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/PropertyExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/PropertyExtensionsTests/WhenToSnippetIsCalled.cs
@@ -17,7 +17,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = properties.ToSnippet(Snippet.Options.Default);
+        var snippet = properties.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -42,12 +42,11 @@ public sealed class WhenToSnippetIsCalled
     {
         // Arrange
         Property staticProperty = PropertyTestsData.Create(name: "Beta", scope: Scope.Public, type: typeof(int));
-        staticProperty.Extensibility = Extensibility.Static;
-
         Property publicVirtual = PropertyTestsData.Create(name: "Alpha", scope: Scope.Public, type: typeof(void));
-        publicVirtual.Extensibility = Extensibility.Virtual;
-
         Property protectedVirtual = PropertyTestsData.Create(name: "Gamma", scope: Scope.Protected, type: typeof(string));
+
+        staticProperty.Extensibility = Extensibility.Static;
+        publicVirtual.Extensibility = Extensibility.Virtual;
         protectedVirtual.Extensibility = Extensibility.Virtual;
 
         ImmutableArray<Property> properties =
@@ -87,7 +86,7 @@ public sealed class WhenToSnippetIsCalled
             .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
 
         // Act
-        Snippet snippet = properties.ToSnippet(options);
+        var snippet = properties.ToSnippet(options);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/PropertyExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/PropertyExtensionsTests/WhenToSnippetIsCalled.cs
@@ -42,7 +42,7 @@ public sealed class WhenToSnippetIsCalled
     {
         // Arrange
         Property staticProperty = PropertyTestsData.Create(name: "Beta", scope: Scope.Public, type: typeof(int));
-        Property publicVirtual = PropertyTestsData.Create(name: "Alpha", scope: Scope.Public, type: typeof(void));
+        Property publicVirtual = PropertyTestsData.Create(name: "Alpha", scope: Scope.Public, type: typeof(Version));
         Property protectedVirtual = PropertyTestsData.Create(name: "Gamma", scope: Scope.Protected, type: typeof(string));
 
         staticProperty.Extensibility = Extensibility.Static;
@@ -63,14 +63,16 @@ public sealed class WhenToSnippetIsCalled
                 {
                     value;
                 }
+                set;
             }
 
-            public virtual void Alpha
+            public virtual Version Alpha
             {
                 get
                 {
                     value;
                 }
+                set;
             }
 
             protected virtual string Gamma
@@ -79,6 +81,7 @@ public sealed class WhenToSnippetIsCalled
                 {
                     value;
                 }
+                set;
             }
             """;
 

--- a/src/MooVC.Syntax.CSharp.Tests/Members/PropertyExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/PropertyExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,95 @@
+namespace MooVC.Syntax.CSharp.Members.PropertyExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Members.PropertyTests;
+
+public sealed class WhenToSnippetIsCalled
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Property> properties = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = properties.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Property> properties = [PropertyTestsData.Create()];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = properties.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenTheyAreOrderedByStaticScopeExtensibilityAndName()
+    {
+        // Arrange
+        Property staticProperty = PropertyTestsData.Create(name: "Beta", scope: Scope.Public, type: typeof(int));
+        staticProperty.Extensibility = Extensibility.Static;
+
+        Property publicVirtual = PropertyTestsData.Create(name: "Alpha", scope: Scope.Public, type: typeof(void));
+        publicVirtual.Extensibility = Extensibility.Virtual;
+
+        Property protectedVirtual = PropertyTestsData.Create(name: "Gamma", scope: Scope.Protected, type: typeof(string));
+        protectedVirtual.Extensibility = Extensibility.Virtual;
+
+        ImmutableArray<Property> properties =
+        [
+            publicVirtual,
+            staticProperty,
+            protectedVirtual,
+        ];
+
+        const string expected = """
+            public static int Beta
+            {
+                get
+                {
+                    value;
+                }
+            }
+
+            public virtual void Alpha
+            {
+                get
+                {
+                    value;
+                }
+            }
+
+            protected virtual string Gamma
+            {
+                get
+                {
+                    value;
+                }
+            }
+            """;
+
+        Snippet.Options options = Snippet.Options.Default
+            .WithBlock(block => block.WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces));
+
+        // Act
+        Snippet snippet = properties.ToSnippet(options);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/QualifierExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/QualifierExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,59 @@
+namespace MooVC.Syntax.CSharp.Members.QualifierExtensionsTests;
+
+using System;
+using System.Collections.Immutable;
+
+public sealed class WhenToSnippetIsCalled
+{
+    private const string FirstQualifier = "MooVC.Sandbox";
+    private const string SecondQualifier = "MooVC.Core";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Qualifier> qualifiers = isDefault
+            ? default
+            : [];
+
+        // Act
+        Snippet snippet = qualifiers.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenAnExceptionIsThrown()
+    {
+        // Arrange
+        ImmutableArray<Qualifier> qualifiers = [FirstQualifier];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = qualifiers.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenTheyAreOrderedAlphabetically()
+    {
+        // Arrange
+        ImmutableArray<Qualifier> qualifiers = [FirstQualifier, SecondQualifier];
+
+        const string expected = """
+            MooVC.Core
+            MooVC.Sandbox
+            """;
+
+        // Act
+        Snippet snippet = qualifiers.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/QualifierExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/QualifierExtensionsTests/WhenToSnippetIsCalled.cs
@@ -19,7 +19,7 @@ public sealed class WhenToSnippetIsCalled
             : [];
 
         // Act
-        Snippet snippet = qualifiers.ToSnippet(Snippet.Options.Default);
+        var snippet = qualifiers.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ShouldBe(Snippet.Empty);
@@ -51,7 +51,7 @@ public sealed class WhenToSnippetIsCalled
             """;
 
         // Act
-        Snippet snippet = qualifiers.ToSnippet(Snippet.Options.Default);
+        var snippet = qualifiers.ToSnippet(Snippet.Options.Default);
 
         // Assert
         snippet.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.CSharp/Members/AttributeExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/AttributeExtensions.ToSnippet.cs
@@ -19,7 +19,19 @@
                 .Select(attribute => Snippet.From(options, attribute))
                 .ToArray();
 
-            return Snippet.Blank.Combine(content);
+            if (content.Length == 1)
+            {
+                return content[0];
+            }
+
+            Snippet stacked = content[0];
+
+            for (int index = 1; index < content.Length; index++)
+            {
+                stacked = content[index].Stack(options, stacked);
+            }
+
+            return stacked;
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/AttributeExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/AttributeExtensions.ToSnippet.cs
@@ -14,24 +14,11 @@
                 return Snippet.Empty;
             }
 
-            Snippet[] content = attributes
+            return attributes
                 .OrderBy(attribute => attribute.Name)
                 .Select(attribute => Snippet.From(options, attribute))
-                .ToArray();
-
-            if (content.Length == 1)
-            {
-                return content[0];
-            }
-
-            Snippet stacked = content[0];
-
-            for (int index = 1; index < content.Length; index++)
-            {
-                stacked = content[index].Stack(options, stacked);
-            }
-
-            return stacked;
+                .ToImmutableArray()
+                .Stack(options);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Constructor.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Constructor.cs
@@ -76,10 +76,11 @@ namespace MooVC.Syntax.CSharp.Members
 
         private Snippet GetSignature(Identifier name, Snippet.Options options)
         {
+            string construct = name.ToSnippet(Identifier.Options.Pascal);
             string extensibility = Extensibility;
             var parameters = Parameters.ToSnippet(Parameter.Options.Camel);
             string scope = Scope;
-            string signature = Separator.Combine(scope, extensibility, $"{name}({parameters})");
+            string signature = Separator.Combine(scope, extensibility, $"{construct}({parameters})");
 
             return Snippet.From(options, signature);
         }

--- a/src/MooVC.Syntax.CSharp/Members/Directive.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Directive.cs
@@ -56,8 +56,9 @@
 
             string prefix = GetPrefix();
             string qualifier = Qualifier.ToString();
+            string combined = Separator.Combine("using", prefix, qualifier);
 
-            return Separator.Combine("using", prefix, qualifier);
+            return string.Concat(combined, ";");
         }
 
         public Snippet ToSnippet(Snippet.Options options)
@@ -103,7 +104,7 @@
 
             if (!Alias.IsUnnamed)
             {
-                return $"{Alias.ToSnippet(Identifier.Options.Pascal)} = ";
+                return $"{Alias.ToSnippet(Identifier.Options.Pascal)} =";
             }
 
             return string.Empty;

--- a/src/MooVC.Syntax.CSharp/Members/DirectiveExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/DirectiveExtensions.ToSnippet.cs
@@ -8,22 +8,26 @@
     {
         internal static Snippet ToSnippet(this ImmutableArray<Directive> directives, Snippet.Options options)
         {
-            Snippet[] statements = directives
+            if (directives.IsDefaultOrEmpty)
+            {
+                return Snippet.Empty;
+            }
+
+            return directives
                 .Select(directive => new
                 {
                     Rendering = directive.ToString(),
                     Value = directive,
                 })
                 .OrderBy(directive => directive.Value.IsStatic)
-                .ThenBy(directive => directive.Value.IsSystem)
-                .ThenBy(directive => directive.Value.Alias.IsUnnamed)
+                .ThenByDescending(directive => directive.Value.Alias.IsUnnamed)
+                .ThenByDescending(directive => directive.Value.IsSystem)
                 .ThenBy(directive => directive.Value.Alias)
                 .ThenBy(directive => directive.Value.Qualifier)
                 .ThenBy(directive => directive.Rendering)
                 .Select(directive => Snippet.From(options, directive.Rendering))
-                .ToArray();
-
-            return Snippet.Blank.Combine(options, statements);
+                .ToImmutableArray()
+                .Stack(options);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Event.Methods.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Event.Methods.cs
@@ -78,11 +78,6 @@
                     return Snippet.From($"{keyword};");
                 }
 
-                if (snippet.IsSingleLine)
-                {
-                    return Snippet.From($"{keyword} => {snippet};");
-                }
-
                 return snippet.Block(options, opening: Snippet.From(keyword));
             }
         }

--- a/src/MooVC.Syntax.CSharp/Members/Event.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Event.cs
@@ -67,8 +67,7 @@
             var name = Name.ToSnippet(Identifier.Options.Pascal);
             string scope = Scope;
             string signature = Separator.Combine(scope, extensibility, "event", handler, name);
-
-            Snippet methods = Behaviours;
+            var methods = Behaviours.ToSnippet(options);
 
             if (methods.IsEmpty)
             {

--- a/src/MooVC.Syntax.CSharp/Members/EventExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/EventExtensions.ToSnippet.cs
@@ -15,7 +15,6 @@
 
             Snippet[] content = events
                 .OrderByDescending(@event => @event.Scope)
-                .ThenByDescending(@event => @event.Extensibility)
                 .ThenBy(@event => @event.Name)
                 .Select(@event => @event.ToSnippet(options))
                 .ToArray();

--- a/src/MooVC.Syntax.CSharp/Members/FieldExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/FieldExtensions.ToSnippet.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Immutable;
     using System.Linq;
-    using MooVC.Linq;
 
     public static partial class FieldExtensions
     {
@@ -14,15 +13,14 @@
                 return Snippet.Empty;
             }
 
-            Snippet[] content = fields
+            return fields
                 .OrderByDescending(field => field.IsStatic)
                 .ThenByDescending(field => field.IsReadOnly)
                 .ThenByDescending(field => field.Scope)
                 .ThenBy(field => field.Name)
                 .Select(field => field.ToSnippet(options))
-                .ToArray();
-
-            return Snippet.Blank.Combine(options, content);
+                .ToImmutableArray()
+                .Stack(options);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Method.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Method.cs
@@ -113,7 +113,7 @@ namespace MooVC.Syntax.CSharp.Members
             string extensibility = Extensibility;
             string name = Name;
             var parameters = Parameters.ToSnippet(Parameter.Options.Camel);
-            string result = Result;
+            string result = Result.IsVoid ? "void" : Result;
             string scope = Scope;
             var clauses = Name.Parameters.ToSnippet(parameter => parameter.Constraints.ToSnippet(options), options);
             string signature = Separator.Combine(scope, extensibility, result, $"{name}({parameters})");

--- a/src/MooVC.Syntax.CSharp/Members/ParameterExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/ParameterExtensions.ToSnippet.cs
@@ -16,8 +16,8 @@
             }
 
             var ordered = parameters
-                .OrderByDescending(parameter => parameter.Default.IsEmpty)
-                .ThenBy(parameter => parameter.Modifier.IsParams)
+                .OrderBy(parameter => parameter.Modifier.IsParams)
+                .ThenByDescending(parameter => parameter.Default.IsEmpty)
                 .ThenBy(parameter => parameter.Name)
                 .ToImmutableArray();
 

--- a/src/MooVC.Syntax.CSharp/Members/QualifierExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/QualifierExtensions.ToSnippet.cs
@@ -13,12 +13,11 @@
                 return Snippet.Empty;
             }
 
-            string[] values = usings
+            return usings
                 .OrderBy(@using => @using)
-                .Select(@using => @using.ToString())
-                .ToArray();
-
-            return Snippet.Empty.Append(options, values);
+                .Select(@using => @using.ToSnippet(options))
+                .ToImmutableArray()
+                .Stack(options);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/BinaryExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/BinaryExtensions.ToSnippet.cs
@@ -14,7 +14,7 @@
                 return Snippet.Empty;
             }
 
-            var content = binaries
+            Snippet[] content = binaries
                 .OrderByDescending(binary => binary.Scope)
                 .ThenBy(binary => binary.Operator)
                 .Select(binary => binary.ToSnippet(construct, options))

--- a/src/MooVC.Syntax.CSharp/Operators/ComparisonExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/ComparisonExtensions.ToSnippet.cs
@@ -14,7 +14,7 @@
                 return Snippet.Empty;
             }
 
-            var content = comparisons
+            Snippet[] content = comparisons
                 .OrderByDescending(comparison => comparison.Scope)
                 .ThenBy(comparison => comparison.Operator)
                 .Select(comparison => comparison.ToSnippet(construct, options))

--- a/src/MooVC.Syntax.CSharp/Operators/ConversionExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/ConversionExtensions.ToSnippet.cs
@@ -15,7 +15,7 @@
                 return Snippet.Empty;
             }
 
-            var content = conversions
+            Snippet[] content = conversions
                 .OrderByDescending(conversion => conversion.Scope)
                 .ThenBy(conversion => conversion.Subject)
                 .ThenBy(conversion => conversion.Direction)

--- a/src/MooVC.Syntax.CSharp/SnippetExtensions.Stack.cs
+++ b/src/MooVC.Syntax.CSharp/SnippetExtensions.Stack.cs
@@ -1,0 +1,24 @@
+﻿namespace MooVC.Syntax.CSharp
+{
+    using System.Collections.Immutable;
+
+    internal static partial class SnippetExtensions
+    {
+        public static Snippet Stack(this ImmutableArray<Snippet> snippets, Snippet.Options options)
+        {
+            if (snippets.Length == 1)
+            {
+                return snippets[0];
+            }
+
+            Snippet stacked = snippets[0];
+
+            for (int index = 1; index < snippets.Length; index++)
+            {
+                stacked = snippets[index].Stack(options, stacked);
+            }
+
+            return stacked;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for ToSnippet collection extensions across member types such as attributes, constructors, events, fields, indexers, methods, parameters, properties, and qualifiers
- verify ordering, null argument handling, and empty array behaviors using consistent multi-line snippet options

## Testing
- not run (dotnet not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949b6116c348323882159f51abc2cf6)