### PR TITLE
Add tests for syntax options, constructs, results, symbols, scope, segment and struct kind

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenConstructorIsCalled.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenConstructorIsCalled
+{
+    [Fact]
+    public void GivenDefaultsThenValuesAreInitialized()
+    {
+        // Arrange
+        var subject = new Options();
+
+        // Act
+        Qualifier.Options namespaceOption = subject.Namespace;
+        Snippet.Options snippets = subject.Snippets;
+
+        // Assert
+        namespaceOption.ShouldBe(Qualifier.Options.File);
+        snippets.ShouldBe(Snippet.Options.Default);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -1,0 +1,34 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
+{
+    [Fact]
+    public void GivenEquivalentOptionsThenReturnsTrue()
+    {
+        // Arrange
+        Options left = new Options();
+        Options right = new Options();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentOptionsThenReturnsFalse()
+    {
+        // Arrange
+        Options left = new Options();
+        Options right = new Options().WithNamespace(Qualifier.Options.Block);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
     public void GivenEquivalentOptionsThenReturnsTrue()
     {
         // Arrange
-        Options left = new Options();
-        Options right = new Options();
+        var left = new Options();
+        var right = new Options();
 
         // Act
         bool result = left == right;
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
     public void GivenDifferentOptionsThenReturnsFalse()
     {
         // Arrange
-        Options left = new Options();
+        var left = new Options();
         Options right = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNonOptionsObjectThenReturnsFalse()
+    {
+        // Arrange
+        Options subject = new Options();
+
+        // Act
+        bool result = subject.Equals(new object());
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenOptionsObjectThenReturnsTrue()
+    {
+        // Arrange
+        Options subject = new Options();
+        object other = new Options();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsObjectIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenNonOptionsObjectThenReturnsFalse()
     {
         // Arrange
-        Options subject = new Options();
+        var subject = new Options();
 
         // Act
         bool result = subject.Equals(new object());
@@ -19,7 +19,7 @@ public sealed class WhenEqualsObjectIsCalled
     public void GivenOptionsObjectThenReturnsTrue()
     {
         // Arrange
-        Options subject = new Options();
+        var subject = new Options();
         object other = new Options();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsOptionsIsCalled
     public void GivenNullThenReturnsFalse()
     {
         // Arrange
-        Options subject = new Options();
+        var subject = new Options();
         Options? other = default;
 
         // Act
@@ -22,8 +22,8 @@ public sealed class WhenEqualsOptionsIsCalled
     public void GivenEqualValuesThenReturnsTrue()
     {
         // Arrange
-        Options subject = new Options();
-        Options other = new Options();
+        var subject = new Options();
+        var other = new Options();
 
         // Act
         bool result = subject.Equals(other);
@@ -36,7 +36,7 @@ public sealed class WhenEqualsOptionsIsCalled
     public void GivenDifferentValuesThenReturnsFalse()
     {
         // Arrange
-        Options subject = new Options();
+        var subject = new Options();
         Options other = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -1,0 +1,48 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenEqualsOptionsIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Options subject = new Options();
+        Options? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Options subject = new Options();
+        Options other = new Options();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Options subject = new Options();
+        Options other = new Options().WithNamespace(Qualifier.Options.Block);
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualOptionsThenHashCodesMatch()
+    {
+        // Arrange
+        Options left = new Options();
+        Options right = new Options();
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        leftHash.ShouldBe(rightHash);
+    }
+
+    [Fact]
+    public void GivenDifferentOptionsThenHashCodesDiffer()
+    {
+        // Arrange
+        Options left = new Options();
+        Options right = new Options().WithNamespace(Qualifier.Options.Block);
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        leftHash.ShouldNotBe(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenGetHashCodeIsCalled
     public void GivenEqualOptionsThenHashCodesMatch()
     {
         // Arrange
-        Options left = new Options();
-        Options right = new Options();
+        var left = new Options();
+        var right = new Options();
 
         // Act
         int leftHash = left.GetHashCode();
@@ -23,7 +23,7 @@ public sealed class WhenGetHashCodeIsCalled
     public void GivenDifferentOptionsThenHashCodesDiffer()
     {
         // Arrange
-        Options left = new Options();
+        var left = new Options();
         Options right = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -1,0 +1,34 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
+{
+    [Fact]
+    public void GivenEquivalentOptionsThenReturnsFalse()
+    {
+        // Arrange
+        Options left = new Options();
+        Options right = new Options();
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentOptionsThenReturnsTrue()
+    {
+        // Arrange
+        Options left = new Options();
+        Options right = new Options().WithNamespace(Qualifier.Options.Block);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
     public void GivenEquivalentOptionsThenReturnsFalse()
     {
         // Arrange
-        Options left = new Options();
-        Options right = new Options();
+        var left = new Options();
+        var right = new Options();
 
         // Act
         bool result = left != right;
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
     public void GivenDifferentOptionsThenReturnsTrue()
     {
         // Arrange
-        Options left = new Options();
+        var left = new Options();
         Options right = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenIsDefaultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenIsDefaultIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+public sealed class WhenIsDefaultIsCalled
+{
+    [Fact]
+    public void GivenDefaultValuesThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Options();
+
+        // Act
+        bool result = subject.IsDefault;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenNonDefaultValuesThenReturnsFalse()
+    {
+        // Arrange
+        Options subject = new Options()
+            .WithNamespace(Members.Qualifier.Options.Block);
+
+        // Act
+        bool result = subject.IsDefault;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithNamespaceIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithNamespaceIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+using MooVC.Syntax.CSharp.Members;
+
+public sealed class WhenWithNamespaceIsCalled
+{
+    [Fact]
+    public void GivenNamespaceThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Options original = new Options();
+
+        // Act
+        Options result = original.WithNamespace(Qualifier.Options.Block);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Namespace.ShouldBe(Qualifier.Options.Block);
+        result.Snippets.ShouldBe(original.Snippets);
+        original.Namespace.ShouldBe(Qualifier.Options.File);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithNamespaceIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithNamespaceIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenWithNamespaceIsCalled
     public void GivenNamespaceThenReturnsUpdatedInstance()
     {
         // Arrange
-        Options original = new Options();
+        var original = new Options();
 
         // Act
         Options result = original.WithNamespace(Qualifier.Options.Block);

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithSnippetsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithSnippetsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithSnippetsIsCalled
     public void GivenSnippetsThenReturnsUpdatedInstance()
     {
         // Arrange
-        Options original = new Options();
+        var original = new Options();
         Snippet.Options replacement = new Snippet.Options().WithWhitespace("	");
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithSnippetsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenWithSnippetsIsCalled.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
+
+public sealed class WhenWithSnippetsIsCalled
+{
+    [Fact]
+    public void GivenSnippetsThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Options original = new Options();
+        Snippet.Options replacement = new Snippet.Options().WithWhitespace("	");
+
+        // Act
+        Options result = original.WithSnippets(replacement);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Snippets.ShouldBe(replacement);
+        result.Namespace.ShouldBe(original.Namespace);
+        result.IsDefault.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/StructTests/KindTests/WhenPlusOperatorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/StructTests/KindTests/WhenPlusOperatorIsCalled.cs
@@ -1,0 +1,60 @@
+namespace MooVC.Syntax.CSharp.Concepts.StructTests.KindTests;
+
+public sealed class WhenPlusOperatorIsCalled
+{
+    [Fact]
+    public void GivenReadonlyRecordThenCombinedKindReturned()
+    {
+        // Arrange
+        Struct.Kind left = Struct.Kind.ReadOnly;
+        Struct.Kind right = Struct.Kind.Record;
+
+        // Act
+        Struct.Kind result = left + right;
+
+        // Assert
+        result.ToString().ShouldBe("readonly record");
+    }
+
+    [Fact]
+    public void GivenInvalidCombinationThenThrows()
+    {
+        // Arrange
+        Struct.Kind left = Struct.Kind.Ref;
+        Struct.Kind right = Struct.Kind.Record;
+
+        // Act
+        Func<Struct.Kind> result = () => left + right;
+
+        // Assert
+        _ = result.ShouldThrow<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GivenNullLeftThenThrows()
+    {
+        // Arrange
+        Struct.Kind? left = default;
+        Struct.Kind right = Struct.Kind.Record;
+
+        // Act
+        Func<Struct.Kind> result = () => left! + right;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenNullRightThenThrows()
+    {
+        // Arrange
+        Struct.Kind left = Struct.Kind.Record;
+        Struct.Kind? right = default;
+
+        // Act
+        Func<Struct.Kind> result = () => left + right!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Generics/ConstructExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Generics/ConstructExtensionsTests/WhenToSnippetIsCalled.cs
@@ -50,7 +50,9 @@ public sealed class WhenToSnippetIsCalled
 
         const string expected = """
             Alpha
+
             Beta
+
             Gamma
             """;
 

--- a/src/MooVC.Syntax.CSharp.Tests/Generics/ConstructExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Generics/ConstructExtensionsTests/WhenToSnippetIsCalled.cs
@@ -1,0 +1,63 @@
+namespace MooVC.Syntax.CSharp.Generics.ConstructExtensionsTests;
+
+using System.Collections.Immutable;
+using MooVC.Syntax.CSharp.Concepts;
+using MooVC.Syntax.CSharp.Operators;
+
+public sealed class WhenToSnippetIsCalled
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenEmptyArrayThenEmptySnippetReturned(bool isDefault)
+    {
+        // Arrange
+        ImmutableArray<Construct> constructs = isDefault
+            ? default
+            : [];
+
+        // Act
+        var snippet = constructs.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ShouldBe(Snippet.Empty);
+    }
+
+    [Fact]
+    public void GivenNullOptionsThenThrows()
+    {
+        // Arrange
+        ImmutableArray<Construct> constructs = [OperatorsTestsData.CreateConstruct("Alpha")];
+        Snippet.Options? options = default;
+
+        // Act
+        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = constructs.ToSnippet(options!));
+
+        // Assert
+        exception.ParamName.ShouldBe(nameof(options));
+    }
+
+    [Fact]
+    public void GivenValuesThenOrderedSnippetReturned()
+    {
+        // Arrange
+        ImmutableArray<Construct> constructs =
+        [
+            OperatorsTestsData.CreateConstruct("Gamma"),
+            OperatorsTestsData.CreateConstruct("Alpha"),
+            OperatorsTestsData.CreateConstruct("Beta"),
+        ];
+
+        const string expected = """
+            Alpha
+            Beta
+            Gamma
+            """;
+
+        // Act
+        var snippet = constructs.ToSnippet(Snippet.Options.Default);
+
+        // Assert
+        snippet.ToString().ShouldBe(expected);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ResultTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/ResultTestsData.cs
@@ -1,0 +1,16 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+internal static class ResultTestsData
+{
+    public const string DefaultTypeName = "Value";
+
+    public static Result Create(Result.Kind? modifier = default, Result.Modality? mode = default, Symbol? type = default)
+    {
+        return new Result
+        {
+            Modifier = modifier ?? Result.Kind.None,
+            Mode = mode ?? Result.Modality.Asynchronous,
+            Type = type ?? new Symbol { Name = new Identifier(DefaultTypeName) },
+        };
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualityOperatorResultResultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualityOperatorResultResultIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenEqualityOperatorResultResultIsCalled
+{
+    [Fact]
+    public void GivenEquivalentResultsThenReturnsTrue()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result right = ResultTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentResultsThenReturnsFalse()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result right = ResultTestsData.Create(modifier: Result.Kind.Ref);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNonResultObjectThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(new object());
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenResultObjectThenReturnsTrue()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        object other = ResultTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsResultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenEqualsResultIsCalled.cs
@@ -1,0 +1,46 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenEqualsResultIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        Result? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        Result other = ResultTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create();
+        Result other = ResultTestsData.Create(type: new Symbol { Name = new Identifier("Other") });
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,34 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualResultsThenHashCodesAreEqual()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create();
+        Result second = ResultTestsData.Create();
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldBe(secondHash);
+    }
+
+    [Fact]
+    public void GivenDifferentResultsThenHashCodesDiffer()
+    {
+        // Arrange
+        Result first = ResultTestsData.Create();
+        Result second = ResultTestsData.Create(modifier: Result.Kind.Ref);
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldNotBe(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorFromTypeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorFromTypeIsCalled.cs
@@ -1,0 +1,30 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenImplicitOperatorFromTypeIsCalled
+{
+    [Fact]
+    public void GivenNullThenThrows()
+    {
+        // Arrange
+        Type? value = default;
+
+        // Act
+        Func<Result> result = () => value!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenTypeThenResultUsesSymbolType()
+    {
+        // Arrange
+        Type value = typeof(Guid);
+
+        // Act
+        Result result = value;
+
+        // Assert
+        result.Type.Name.ShouldBe(new Identifier(nameof(Guid)));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToSnippetIsCalled.cs
@@ -1,0 +1,30 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenImplicitOperatorToSnippetIsCalled
+{
+    [Fact]
+    public void GivenNullSubjectThenThrows()
+    {
+        // Arrange
+        Result? subject = default;
+
+        // Act
+        Func<Snippet> result = () => subject;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenResultThenSnippetMatchesToString()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(modifier: Result.Kind.Ref, mode: Result.Modality.Asynchronous);
+
+        // Act
+        Snippet result = subject;
+
+        // Assert
+        result.ToString().ShouldBe(subject.ToString());
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,30 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Fact]
+    public void GivenNullSubjectThenThrows()
+    {
+        // Arrange
+        Result? subject = default;
+
+        // Act
+        Func<string> result = () => subject;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenResultThenStringMatchesToString()
+    {
+        // Arrange
+        Result subject = ResultTestsData.Create(modifier: Result.Kind.Ref, mode: Result.Modality.Asynchronous);
+
+        // Act
+        string result = subject;
+
+        // Assert
+        result.ShouldBe(subject.ToString());
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenInequalityOperatorResultResultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenInequalityOperatorResultResultIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenInequalityOperatorResultResultIsCalled
+{
+    [Fact]
+    public void GivenEquivalentResultsThenReturnsFalse()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result right = ResultTestsData.Create();
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentResultsThenReturnsTrue()
+    {
+        // Arrange
+        Result left = ResultTestsData.Create();
+        Result right = ResultTestsData.Create(mode: Result.Modality.Synchronous);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModeIsCalled.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenWithModeIsCalled
+{
+    [Fact]
+    public void GivenModeThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Result original = ResultTestsData.Create(mode: Result.Modality.Asynchronous);
+
+        // Act
+        Result result = original.WithMode(Result.Modality.Synchronous);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Mode.ShouldBe(Result.Modality.Synchronous);
+        result.Modifier.ShouldBe(original.Modifier);
+        result.Type.ShouldBe(original.Type);
+        original.Mode.ShouldBe(Result.Modality.Asynchronous);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithModifierIsCalled.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenWithModifierIsCalled
+{
+    [Fact]
+    public void GivenModifierThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Result original = ResultTestsData.Create(modifier: Result.Kind.None);
+
+        // Act
+        Result result = original.WithModifier(Result.Kind.Ref);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Modifier.ShouldBe(Result.Kind.Ref);
+        result.Mode.ShouldBe(original.Mode);
+        result.Type.ShouldBe(original.Type);
+        original.Modifier.ShouldBe(Result.Kind.None);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithTypeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithTypeIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Members.ResultTests;
+
+public sealed class WhenWithTypeIsCalled
+{
+    [Fact]
+    public void GivenTypeThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Result original = ResultTestsData.Create();
+        Symbol type = new Symbol { Name = new Identifier("Updated") };
+
+        // Act
+        Result result = original.WithType(type);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Type.ShouldBe(type);
+        result.Modifier.ShouldBe(original.Modifier);
+        result.Mode.ShouldBe(original.Mode);
+        original.Type.Name.ShouldBe(new Identifier(ResultTestsData.DefaultTypeName));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithTypeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ResultTests/WhenWithTypeIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenWithTypeIsCalled
     {
         // Arrange
         Result original = ResultTestsData.Create();
-        Symbol type = new Symbol { Name = new Identifier("Updated") };
+        var type = new Symbol { Name = new Identifier("Updated") };
 
         // Act
         Result result = original.WithType(type);

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ScopeTests/WhenComparisonOperatorsAreCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ScopeTests/WhenComparisonOperatorsAreCalled.cs
@@ -1,0 +1,44 @@
+namespace MooVC.Syntax.CSharp.Members.ScopeTests;
+
+public sealed class WhenComparisonOperatorsAreCalled
+{
+    [Fact]
+    public void GivenNullLeftThenLessThanIsTrue()
+    {
+        // Arrange
+        Scope? left = default;
+        Scope right = Scope.Public;
+
+        // Act
+        bool lessThan = left < right;
+        bool greaterThan = left > right;
+        bool lessThanOrEqual = left <= right;
+        bool greaterThanOrEqual = left >= right;
+
+        // Assert
+        lessThan.ShouldBeTrue();
+        greaterThan.ShouldBeFalse();
+        lessThanOrEqual.ShouldBeTrue();
+        greaterThanOrEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenPrivateAndPublicThenOrderingReflectsAccessibility()
+    {
+        // Arrange
+        Scope left = Scope.Private;
+        Scope right = Scope.Public;
+
+        // Act
+        bool lessThan = left < right;
+        bool greaterThan = left > right;
+        bool lessThanOrEqual = left <= right;
+        bool greaterThanOrEqual = left >= right;
+
+        // Assert
+        lessThan.ShouldBeTrue();
+        greaterThan.ShouldBeFalse();
+        lessThanOrEqual.ShouldBeTrue();
+        greaterThanOrEqual.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/ScopeTests/WhenPlusOperatorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/ScopeTests/WhenPlusOperatorIsCalled.cs
@@ -1,0 +1,74 @@
+namespace MooVC.Syntax.CSharp.Members.ScopeTests;
+
+public sealed class WhenPlusOperatorIsCalled
+{
+    [Fact]
+    public void GivenPrivateProtectedThenCombinedScopeReturned()
+    {
+        // Arrange
+        Scope left = Scope.Private;
+        Scope right = Scope.Protected;
+
+        // Act
+        Scope result = left + right;
+
+        // Assert
+        result.ToString().ShouldBe("private protected");
+    }
+
+    [Fact]
+    public void GivenProtectedInternalThenCombinedScopeReturned()
+    {
+        // Arrange
+        Scope left = Scope.Protected;
+        Scope right = Scope.Internal;
+
+        // Act
+        Scope result = left + right;
+
+        // Assert
+        result.ToString().ShouldBe("protected internal");
+    }
+
+    [Fact]
+    public void GivenInvalidCombinationThenThrows()
+    {
+        // Arrange
+        Scope left = Scope.Private;
+        Scope right = Scope.Public;
+
+        // Act
+        Func<Scope> result = () => left + right;
+
+        // Assert
+        _ = result.ShouldThrow<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GivenNullLeftThenThrows()
+    {
+        // Arrange
+        Scope? left = default;
+        Scope right = Scope.Public;
+
+        // Act
+        Func<Scope> result = () => left! + right;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenNullRightThenThrows()
+    {
+        // Arrange
+        Scope left = Scope.Public;
+        Scope? right = default;
+
+        // Act
+        Func<Scope> result = () => left + right!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/SegmentTests/WhenComparisonOperatorsAreCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/SegmentTests/WhenComparisonOperatorsAreCalled.cs
@@ -1,0 +1,44 @@
+namespace MooVC.Syntax.CSharp.Members.SegmentTests;
+
+public sealed class WhenComparisonOperatorsAreCalled
+{
+    [Fact]
+    public void GivenNullLeftThenLessThanIsTrue()
+    {
+        // Arrange
+        Segment? left = default;
+        Segment right = "Alpha";
+
+        // Act
+        bool lessThan = left < right;
+        bool greaterThan = left > right;
+        bool lessThanOrEqual = left <= right;
+        bool greaterThanOrEqual = left >= right;
+
+        // Assert
+        lessThan.ShouldBeTrue();
+        greaterThan.ShouldBeFalse();
+        lessThanOrEqual.ShouldBeTrue();
+        greaterThanOrEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenAlphabeticalValuesThenOrderingMatchesOrdinalComparison()
+    {
+        // Arrange
+        Segment left = "Alpha";
+        Segment right = "Beta";
+
+        // Act
+        bool lessThan = left < right;
+        bool greaterThan = left > right;
+        bool lessThanOrEqual = left <= right;
+        bool greaterThanOrEqual = left >= right;
+
+        // Assert
+        lessThan.ShouldBeTrue();
+        greaterThan.ShouldBeFalse();
+        lessThanOrEqual.ShouldBeTrue();
+        greaterThanOrEqual.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenComparisonOperatorsAreCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenComparisonOperatorsAreCalled.cs
@@ -1,0 +1,44 @@
+namespace MooVC.Syntax.CSharp.Members.SymbolTests;
+
+public sealed class WhenComparisonOperatorsAreCalled
+{
+    [Fact]
+    public void GivenNullLeftThenLessThanIsTrue()
+    {
+        // Arrange
+        Symbol? left = default;
+        Symbol right = SymbolTestsData.Create(name: "Beta");
+
+        // Act
+        bool lessThan = left < right;
+        bool greaterThan = left > right;
+        bool lessThanOrEqual = left <= right;
+        bool greaterThanOrEqual = left >= right;
+
+        // Assert
+        lessThan.ShouldBeTrue();
+        greaterThan.ShouldBeFalse();
+        lessThanOrEqual.ShouldBeTrue();
+        greaterThanOrEqual.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentNamesThenOrderingFollowsName()
+    {
+        // Arrange
+        Symbol left = SymbolTestsData.Create(name: "Alpha");
+        Symbol right = SymbolTestsData.Create(name: "Beta");
+
+        // Act
+        bool lessThan = left < right;
+        bool greaterThan = left > right;
+        bool lessThanOrEqual = left <= right;
+        bool greaterThanOrEqual = left >= right;
+
+        // Assert
+        lessThan.ShouldBeTrue();
+        greaterThan.ShouldBeFalse();
+        lessThanOrEqual.ShouldBeTrue();
+        greaterThanOrEqual.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenImplicitOperatorFromTypeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenImplicitOperatorFromTypeIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.CSharp.Members.SymbolTests;
+
+public sealed class WhenImplicitOperatorFromTypeIsCalled
+{
+    [Fact]
+    public void GivenNullThenThrows()
+    {
+        // Arrange
+        Type? value = default;
+
+        // Act
+        Func<Symbol> result = () => value!;
+
+        // Assert
+        _ = result.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenTypeThenSymbolUsesNameAndQualifier()
+    {
+        // Arrange
+        Type value = typeof(System.Text.StringBuilder);
+
+        // Act
+        Symbol subject = value;
+
+        // Assert
+        subject.Name.ShouldBe(new Identifier(nameof(System.Text.StringBuilder)));
+        subject.Qualifier.ShouldBe(new Qualifier(["System", "Text"]));
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenIsNullableIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenIsNullableIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Members.SymbolTests;
+
+public sealed class WhenIsNullableIsCalled
+{
+    [Fact]
+    public void GivenNullableThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Symbol original = SymbolTestsData.Create(name: "Value");
+
+        // Act
+        Symbol result = original.IsNullable(true);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.IsNullable.ShouldBeTrue();
+        result.Name.ShouldBe(original.Name);
+        result.Qualifier.ShouldBe(original.Qualifier);
+        result.Arguments.ShouldBe(original.Arguments);
+        original.IsNullable.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenWithArgumentsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenWithArgumentsIsCalled.cs
@@ -1,0 +1,24 @@
+namespace MooVC.Syntax.CSharp.Members.SymbolTests;
+
+using System.Linq;
+
+public sealed class WhenWithArgumentsIsCalled
+{
+    [Fact]
+    public void GivenArgumentsThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Symbol original = SymbolTestsData.Create(name: "Container", arguments: new Symbol { Name = new Identifier("First") });
+        Symbol[] additional = [new Symbol { Name = new Identifier("Second") }];
+
+        // Act
+        Symbol result = original.WithArguments(additional);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Arguments.ShouldBe(original.Arguments.Concat(additional));
+        result.Name.ShouldBe(original.Name);
+        result.Qualifier.ShouldBe(original.Qualifier);
+        result.IsNullable.ShouldBe(original.IsNullable);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenWithNameIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenWithNameIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Members.SymbolTests;
+
+public sealed class WhenWithNameIsCalled
+{
+    [Fact]
+    public void GivenNameThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Symbol original = SymbolTestsData.Create(name: "Original");
+        var name = new Identifier("Updated");
+
+        // Act
+        Symbol result = original.WithName(name);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Name.ShouldBe(name);
+        result.Qualifier.ShouldBe(original.Qualifier);
+        result.Arguments.ShouldBe(original.Arguments);
+        result.IsNullable.ShouldBe(original.IsNullable);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenWithQualifierIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Members/SymbolTests/WhenWithQualifierIsCalled.cs
@@ -1,0 +1,22 @@
+namespace MooVC.Syntax.CSharp.Members.SymbolTests;
+
+public sealed class WhenWithQualifierIsCalled
+{
+    [Fact]
+    public void GivenQualifierThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Symbol original = SymbolTestsData.Create(name: "Value", qualifier: new Qualifier(["System"]));
+        var qualifier = new Qualifier(["MooVC", "Syntax"]);
+
+        // Act
+        Symbol result = original.WithQualifier(qualifier);
+
+        // Assert
+        result.ShouldNotBeSameAs(original);
+        result.Qualifier.ShouldBe(qualifier);
+        result.Name.ShouldBe(original.Name);
+        result.Arguments.ShouldBe(original.Arguments);
+        result.IsNullable.ShouldBe(original.IsNullable);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide comprehensive unit test coverage for generated functionality produced by `Fluentify`, `Valuify` and `Monify` across core syntax types.
- Ensure correct behavior for implicit conversions, comparison operators, and `ToSnippet`/`ToString` formatting for syntax model classes.
- Validate `Options` defaults and `With*` fluent updates used by snippet/construct rendering.
- Cover operator combinations and error cases for `Scope` and `Struct.Kind` plus-operators.

### Description

- Added a set of new test files (32 files) under `src/MooVC.Syntax.CSharp.Tests` that exercise `Concepts.Options`, `Generics.ConstructExtensions.ToSnippet`, `Members.Result`, `Members.Symbol`, `Members.Scope`, `Members.Segment` and `Concepts.Struct.Kind` behaviors.
- Added `ResultTestsData` helper used by the new `Result` tests to construct canonical `Result` instances.
- Tests assert implicit conversions, comparison operators (`<`, `>`, `<=`, `>=`), equality/inequality operators, `ToString`/`ToSnippet` outputs, and `With*` fluent methods.
- Added negative tests for invalid operator combinations and null-argument guarding to verify thrown exceptions.

### Testing

- New unit test files were created and staged/committed to the repository.
- An attempt was made to run the test suite with `dotnet test`, but the command failed because the .NET SDK is not available in the environment (error: `dotnet` not found).
- No automated test run succeeded in this environment due to the missing SDK, so test execution status is unknown locally.
- All added tests follow the repository test conventions and are ready to run in an environment with the .NET SDK (`dotnet`) installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6950455029f88323807592d7a5ad01a8)