### PR TITLE
Add csproj element models for Project concept

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/InterfaceTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/InterfaceTests/WhenToSnippetIsCalled.cs
@@ -7,7 +7,6 @@ using MooVC.Syntax.CSharp.Members;
 
 public sealed class WhenToSnippetIsCalled
 {
-
     [Fact]
     public void GivenOptionsNotProvidedThenArgumentNullExceptionIsThrown()
     {

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Import.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Import.cs
@@ -1,0 +1,41 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class Import
+    : IValidatableObject
+{
+    public static readonly Import Undefined = new Import();
+
+    internal Import()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Snippet Label { get; internal set; } = Snippet.Empty;
+
+    public Snippet Project { get; internal set; } = Snippet.Empty;
+
+    public Snippet Sdk { get; internal set; } = Snippet.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return Enumerable.Empty<ValidationResult>();
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Import.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Import.cs
@@ -1,41 +1,42 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class Import
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly Import Undefined = new Import();
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal Import()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class Import
+        : IValidatableObject
     {
-    }
+        public static readonly Import Undefined = new Import();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Snippet Label { get; internal set; } = Snippet.Empty;
-
-    public Snippet Project { get; internal set; } = Snippet.Empty;
-
-    public Snippet Sdk { get; internal set; } = Snippet.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal Import()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return Enumerable.Empty<ValidationResult>();
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Snippet Label { get; internal set; } = Snippet.Empty;
+
+        public Snippet Project { get; internal set; } = Snippet.Empty;
+
+        public Snippet Sdk { get; internal set; } = Snippet.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return Enumerable.Empty<ValidationResult>();
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Item.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Item.cs
@@ -1,54 +1,55 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class Item
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly Item Undefined = new Item();
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal Item()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class Item
+        : IValidatableObject
     {
-    }
+        public static readonly Item Undefined = new Item();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    public Snippet Exclude { get; internal set; } = Snippet.Empty;
-
-    public Snippet Include { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Identifier ItemType { get; internal set; } = Identifier.Unnamed;
-
-    public Snippet Label { get; internal set; } = Snippet.Empty;
-
-    public ImmutableArray<Metadata> Metadata { get; internal set; } = ImmutableArray<Metadata>.Empty;
-
-    public Snippet Remove { get; internal set; } = Snippet.Empty;
-
-    public Snippet Update { get; internal set; } = Snippet.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal Item()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .Include(nameof(ItemType), _ => !ItemType.IsUnnamed, ItemType)
-            .AndIf(!Metadata.IsDefaultOrEmpty, nameof(Metadata), metadata => !metadata.IsUndefined, Metadata)
-            .Results;
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        public Snippet Exclude { get; internal set; } = Snippet.Empty;
+
+        public Snippet Include { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Identifier ItemType { get; internal set; } = Identifier.Unnamed;
+
+        public Snippet Label { get; internal set; } = Snippet.Empty;
+
+        public ImmutableArray<Metadata> Metadata { get; internal set; } = ImmutableArray<Metadata>.Empty;
+
+        public Snippet Remove { get; internal set; } = Snippet.Empty;
+
+        public Snippet Update { get; internal set; } = Snippet.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .Include(nameof(ItemType), _ => !ItemType.IsUnnamed, ItemType)
+                .AndIf(!Metadata.IsDefaultOrEmpty, nameof(Metadata), metadata => !metadata.IsUndefined, Metadata)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Item.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Item.cs
@@ -1,0 +1,54 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class Item
+    : IValidatableObject
+{
+    public static readonly Item Undefined = new Item();
+
+    internal Item()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    public Snippet Exclude { get; internal set; } = Snippet.Empty;
+
+    public Snippet Include { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Identifier ItemType { get; internal set; } = Identifier.Unnamed;
+
+    public Snippet Label { get; internal set; } = Snippet.Empty;
+
+    public ImmutableArray<Metadata> Metadata { get; internal set; } = ImmutableArray<Metadata>.Empty;
+
+    public Snippet Remove { get; internal set; } = Snippet.Empty;
+
+    public Snippet Update { get; internal set; } = Snippet.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .Include(nameof(ItemType), _ => !ItemType.IsUnnamed, ItemType)
+            .AndIf(!Metadata.IsDefaultOrEmpty, nameof(Metadata), metadata => !metadata.IsUndefined, Metadata)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/ItemGroup.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/ItemGroup.cs
@@ -1,42 +1,43 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class ItemGroup
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly ItemGroup Undefined = new ItemGroup();
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal ItemGroup()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class ItemGroup
+        : IValidatableObject
     {
-    }
+        public static readonly ItemGroup Undefined = new ItemGroup();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public ImmutableArray<Item> Items { get; internal set; } = ImmutableArray<Item>.Empty;
-
-    public Snippet Label { get; internal set; } = Snippet.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal ItemGroup()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .IncludeIf(!Items.IsDefaultOrEmpty, nameof(Items), item => !item.IsUndefined, Items)
-            .Results;
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public ImmutableArray<Item> Items { get; internal set; } = ImmutableArray<Item>.Empty;
+
+        public Snippet Label { get; internal set; } = Snippet.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .IncludeIf(!Items.IsDefaultOrEmpty, nameof(Items), item => !item.IsUndefined, Items)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/ItemGroup.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/ItemGroup.cs
@@ -1,0 +1,42 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class ItemGroup
+    : IValidatableObject
+{
+    public static readonly ItemGroup Undefined = new ItemGroup();
+
+    internal ItemGroup()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public ImmutableArray<Item> Items { get; internal set; } = ImmutableArray<Item>.Empty;
+
+    public Snippet Label { get; internal set; } = Snippet.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .IncludeIf(!Items.IsDefaultOrEmpty, nameof(Items), item => !item.IsUndefined, Items)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Metadata.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Metadata.cs
@@ -1,42 +1,43 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class Metadata
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly Metadata Undefined = new Metadata();
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal Metadata()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class Metadata
+        : IValidatableObject
     {
-    }
+        public static readonly Metadata Undefined = new Metadata();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Identifier Name { get; internal set; } = Identifier.Unnamed;
-
-    public Snippet Value { get; internal set; } = Snippet.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal Metadata()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
-            .Results;
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+        public Snippet Value { get; internal set; } = Snippet.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Metadata.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Metadata.cs
@@ -1,0 +1,42 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class Metadata
+    : IValidatableObject
+{
+    public static readonly Metadata Undefined = new Metadata();
+
+    internal Metadata()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+    public Snippet Value { get; internal set; } = Snippet.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Property.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Property.cs
@@ -1,0 +1,42 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class Property
+    : IValidatableObject
+{
+    public static readonly Property Undefined = new Property();
+
+    internal Property()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+    public Snippet Value { get; internal set; } = Snippet.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Property.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Property.cs
@@ -1,42 +1,43 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class Property
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly Property Undefined = new Property();
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal Property()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class Property
+        : IValidatableObject
     {
-    }
+        public static readonly Property Undefined = new Property();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Identifier Name { get; internal set; } = Identifier.Unnamed;
-
-    public Snippet Value { get; internal set; } = Snippet.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal Property()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
-            .Results;
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+        public Snippet Value { get; internal set; } = Snippet.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/PropertyGroup.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/PropertyGroup.cs
@@ -1,0 +1,42 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class PropertyGroup
+    : IValidatableObject
+{
+    public static readonly PropertyGroup Undefined = new PropertyGroup();
+
+    internal PropertyGroup()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Snippet Label { get; internal set; } = Snippet.Empty;
+
+    public ImmutableArray<Property> Properties { get; internal set; } = ImmutableArray<Property>.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .IncludeIf(!Properties.IsDefaultOrEmpty, nameof(Properties), property => !property.IsUndefined, Properties)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/PropertyGroup.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/PropertyGroup.cs
@@ -1,42 +1,43 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class PropertyGroup
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly PropertyGroup Undefined = new PropertyGroup();
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal PropertyGroup()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class PropertyGroup
+        : IValidatableObject
     {
-    }
+        public static readonly PropertyGroup Undefined = new PropertyGroup();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Snippet Label { get; internal set; } = Snippet.Empty;
-
-    public ImmutableArray<Property> Properties { get; internal set; } = ImmutableArray<Property>.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal PropertyGroup()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .IncludeIf(!Properties.IsDefaultOrEmpty, nameof(Properties), property => !property.IsUndefined, Properties)
-            .Results;
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Snippet Label { get; internal set; } = Snippet.Empty;
+
+        public ImmutableArray<Property> Properties { get; internal set; } = ImmutableArray<Property>.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .IncludeIf(!Properties.IsDefaultOrEmpty, nameof(Properties), property => !property.IsUndefined, Properties)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Sdk.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Sdk.cs
@@ -1,42 +1,43 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class Sdk
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly Sdk Unspecified = new Sdk();
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal Sdk()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class Sdk
+        : IValidatableObject
     {
-    }
+        public static readonly Sdk Unspecified = new Sdk();
 
-    [Ignore]
-    public bool IsUnspecified => this == Unspecified;
-
-    public Snippet MinimumVersion { get; internal set; } = Snippet.Empty;
-
-    public Qualifier Name { get; internal set; } = Qualifier.Unqualified;
-
-    public Snippet Version { get; internal set; } = Snippet.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUnspecified)
+        internal Sdk()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .Include(nameof(Name), _ => !Name.IsUnqualified, Name)
-            .Results;
+        [Ignore]
+        public bool IsUnspecified => this == Unspecified;
+
+        public Snippet MinimumVersion { get; internal set; } = Snippet.Empty;
+
+        public Qualifier Name { get; internal set; } = Qualifier.Unqualified;
+
+        public Snippet Version { get; internal set; } = Snippet.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUnspecified)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .Include(nameof(Name), _ => !Name.IsUnqualified, Name)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Sdk.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Sdk.cs
@@ -1,0 +1,42 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class Sdk
+    : IValidatableObject
+{
+    public static readonly Sdk Unspecified = new Sdk();
+
+    internal Sdk()
+    {
+    }
+
+    [Ignore]
+    public bool IsUnspecified => this == Unspecified;
+
+    public Snippet MinimumVersion { get; internal set; } = Snippet.Empty;
+
+    public Qualifier Name { get; internal set; } = Qualifier.Unqualified;
+
+    public Snippet Version { get; internal set; } = Snippet.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUnspecified)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .Include(nameof(Name), _ => !Name.IsUnqualified, Name)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Target.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Target.cs
@@ -1,56 +1,57 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class Target
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly Target Undefined = new Target();
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal Target()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class Target
+        : IValidatableObject
     {
-    }
+        public static readonly Target Undefined = new Target();
 
-    public Snippet AfterTargets { get; internal set; } = Snippet.Empty;
-
-    public Snippet BeforeTargets { get; internal set; } = Snippet.Empty;
-
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    public Snippet DependsOnTargets { get; internal set; } = Snippet.Empty;
-
-    public Snippet Inputs { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Snippet Label { get; internal set; } = Snippet.Empty;
-
-    public Identifier Name { get; internal set; } = Identifier.Unnamed;
-
-    public Snippet Outputs { get; internal set; } = Snippet.Empty;
-
-    public ImmutableArray<TargetTask> Tasks { get; internal set; } = ImmutableArray<TargetTask>.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal Target()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
-            .AndIf(!Tasks.IsDefaultOrEmpty, nameof(Tasks), task => !task.IsUndefined, Tasks)
-            .Results;
+        public Snippet AfterTargets { get; internal set; } = Snippet.Empty;
+
+        public Snippet BeforeTargets { get; internal set; } = Snippet.Empty;
+
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        public Snippet DependsOnTargets { get; internal set; } = Snippet.Empty;
+
+        public Snippet Inputs { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Snippet Label { get; internal set; } = Snippet.Empty;
+
+        public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+        public Snippet Outputs { get; internal set; } = Snippet.Empty;
+
+        public ImmutableArray<TargetTask> Tasks { get; internal set; } = ImmutableArray<TargetTask>.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+                .AndIf(!Tasks.IsDefaultOrEmpty, nameof(Tasks), task => !task.IsUndefined, Tasks)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/Target.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/Target.cs
@@ -1,0 +1,56 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class Target
+    : IValidatableObject
+{
+    public static readonly Target Undefined = new Target();
+
+    internal Target()
+    {
+    }
+
+    public Snippet AfterTargets { get; internal set; } = Snippet.Empty;
+
+    public Snippet BeforeTargets { get; internal set; } = Snippet.Empty;
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    public Snippet DependsOnTargets { get; internal set; } = Snippet.Empty;
+
+    public Snippet Inputs { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Snippet Label { get; internal set; } = Snippet.Empty;
+
+    public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+    public Snippet Outputs { get; internal set; } = Snippet.Empty;
+
+    public ImmutableArray<TargetTask> Tasks { get; internal set; } = ImmutableArray<TargetTask>.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+            .AndIf(!Tasks.IsDefaultOrEmpty, nameof(Tasks), task => !task.IsUndefined, Tasks)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/TargetTask.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/TargetTask.cs
@@ -1,47 +1,48 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class TargetTask
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly TargetTask Undefined = new TargetTask();
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal TargetTask()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class TargetTask
+        : IValidatableObject
     {
-    }
+        public static readonly TargetTask Undefined = new TargetTask();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Identifier Name { get; internal set; } = Identifier.Unnamed;
-
-    public ImmutableArray<TaskOutput> Outputs { get; internal set; } = ImmutableArray<TaskOutput>.Empty;
-
-    public ImmutableArray<TaskParameter> Parameters { get; internal set; } = ImmutableArray<TaskParameter>.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal TargetTask()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
-            .AndIf(!Outputs.IsDefaultOrEmpty, nameof(Outputs), output => !output.IsUndefined, Outputs)
-            .AndIf(!Parameters.IsDefaultOrEmpty, nameof(Parameters), parameter => !parameter.IsUndefined, Parameters)
-            .Results;
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+        public ImmutableArray<TaskOutput> Outputs { get; internal set; } = ImmutableArray<TaskOutput>.Empty;
+
+        public ImmutableArray<TaskParameter> Parameters { get; internal set; } = ImmutableArray<TaskParameter>.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+                .AndIf(!Outputs.IsDefaultOrEmpty, nameof(Outputs), output => !output.IsUndefined, Outputs)
+                .AndIf(!Parameters.IsDefaultOrEmpty, nameof(Parameters), parameter => !parameter.IsUndefined, Parameters)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/TargetTask.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/TargetTask.cs
@@ -1,0 +1,47 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class TargetTask
+    : IValidatableObject
+{
+    public static readonly TargetTask Undefined = new TargetTask();
+
+    internal TargetTask()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+    public ImmutableArray<TaskOutput> Outputs { get; internal set; } = ImmutableArray<TaskOutput>.Empty;
+
+    public ImmutableArray<TaskParameter> Parameters { get; internal set; } = ImmutableArray<TaskParameter>.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+            .AndIf(!Outputs.IsDefaultOrEmpty, nameof(Outputs), output => !output.IsUndefined, Outputs)
+            .AndIf(!Parameters.IsDefaultOrEmpty, nameof(Parameters), parameter => !parameter.IsUndefined, Parameters)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/TaskOutput.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/TaskOutput.cs
@@ -1,46 +1,47 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class TaskOutput
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly TaskOutput Undefined = new TaskOutput();
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal TaskOutput()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class TaskOutput
+        : IValidatableObject
     {
-    }
+        public static readonly TaskOutput Undefined = new TaskOutput();
 
-    public Snippet Condition { get; internal set; } = Snippet.Empty;
-
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Identifier ItemName { get; internal set; } = Identifier.Unnamed;
-
-    public Identifier PropertyName { get; internal set; } = Identifier.Unnamed;
-
-    public Identifier TaskParameter { get; internal set; } = Identifier.Unnamed;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal TaskOutput()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .IncludeIf(!ItemName.IsUnnamed, nameof(ItemName), ItemName)
-            .AndIf(!PropertyName.IsUnnamed, nameof(PropertyName), PropertyName)
-            .AndIf(!TaskParameter.IsUnnamed, nameof(TaskParameter), TaskParameter)
-            .Results;
+        public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Identifier ItemName { get; internal set; } = Identifier.Unnamed;
+
+        public Identifier PropertyName { get; internal set; } = Identifier.Unnamed;
+
+        public Identifier TaskParameter { get; internal set; } = Identifier.Unnamed;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .IncludeIf(!ItemName.IsUnnamed, nameof(ItemName), ItemName)
+                .AndIf(!PropertyName.IsUnnamed, nameof(PropertyName), PropertyName)
+                .AndIf(!TaskParameter.IsUnnamed, nameof(TaskParameter), TaskParameter)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/TaskOutput.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/TaskOutput.cs
@@ -1,0 +1,46 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class TaskOutput
+    : IValidatableObject
+{
+    public static readonly TaskOutput Undefined = new TaskOutput();
+
+    internal TaskOutput()
+    {
+    }
+
+    public Snippet Condition { get; internal set; } = Snippet.Empty;
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Identifier ItemName { get; internal set; } = Identifier.Unnamed;
+
+    public Identifier PropertyName { get; internal set; } = Identifier.Unnamed;
+
+    public Identifier TaskParameter { get; internal set; } = Identifier.Unnamed;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .IncludeIf(!ItemName.IsUnnamed, nameof(ItemName), ItemName)
+            .AndIf(!PropertyName.IsUnnamed, nameof(PropertyName), PropertyName)
+            .AndIf(!TaskParameter.IsUnnamed, nameof(TaskParameter), TaskParameter)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/TaskParameter.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/TaskParameter.cs
@@ -1,40 +1,41 @@
-namespace MooVC.Syntax.CSharp.Attributes.Project;
-
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Fluentify;
-using MooVC.Syntax.CSharp.Elements;
-using Valuify;
-using Ignore = Valuify.IgnoreAttribute;
-
-[Fluentify]
-[Valuify]
-public sealed partial class TaskParameter
-    : IValidatableObject
+namespace MooVC.Syntax.CSharp.Attributes.Project
 {
-    public static readonly TaskParameter Undefined = new TaskParameter();
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Fluentify;
+    using MooVC.Syntax.CSharp.Elements;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    internal TaskParameter()
+    [Fluentify]
+    [Valuify]
+    public sealed partial class TaskParameter
+        : IValidatableObject
     {
-    }
+        public static readonly TaskParameter Undefined = new TaskParameter();
 
-    [Ignore]
-    public bool IsUndefined => this == Undefined;
-
-    public Identifier Name { get; internal set; } = Identifier.Unnamed;
-
-    public Snippet Value { get; internal set; } = Snippet.Empty;
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (IsUndefined)
+        internal TaskParameter()
         {
-            return Enumerable.Empty<ValidationResult>();
         }
 
-        return validationContext
-            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
-            .Results;
+        [Ignore]
+        public bool IsUndefined => this == Undefined;
+
+        public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+        public Snippet Value { get; internal set; } = Snippet.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (IsUndefined)
+            {
+                return Enumerable.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+                .Results;
+        }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Attributes/Project/TaskParameter.cs
+++ b/src/MooVC.Syntax.CSharp/Attributes/Project/TaskParameter.cs
@@ -1,0 +1,40 @@
+namespace MooVC.Syntax.CSharp.Attributes.Project;
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Fluentify;
+using MooVC.Syntax.CSharp.Elements;
+using Valuify;
+using Ignore = Valuify.IgnoreAttribute;
+
+[Fluentify]
+[Valuify]
+public sealed partial class TaskParameter
+    : IValidatableObject
+{
+    public static readonly TaskParameter Undefined = new TaskParameter();
+
+    internal TaskParameter()
+    {
+    }
+
+    [Ignore]
+    public bool IsUndefined => this == Undefined;
+
+    public Identifier Name { get; internal set; } = Identifier.Unnamed;
+
+    public Snippet Value { get; internal set; } = Snippet.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (IsUndefined)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        return validationContext
+            .Include(nameof(Name), _ => !Name.IsUnnamed, Name)
+            .Results;
+    }
+}

--- a/src/MooVC.Syntax.CSharp/Concepts/Project.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/Project.cs
@@ -2,16 +2,43 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.ComponentModel.DataAnnotations;
+    using MooVC.Syntax.CSharp.Attributes.Project;
 
     public sealed class Project
         : Construct
     {
-        public override bool IsUndefined => throw new NotImplementedException();
+        public ImmutableArray<Import> Imports { get; internal set; } = ImmutableArray<Import>.Empty;
+
+        public ImmutableArray<ItemGroup> ItemGroups { get; internal set; } = ImmutableArray<ItemGroup>.Empty;
+
+        public ImmutableArray<PropertyGroup> PropertyGroups { get; internal set; } = ImmutableArray<PropertyGroup>.Empty;
+
+        public ImmutableArray<Sdk> Sdks { get; internal set; } = ImmutableArray<Sdk>.Empty;
+
+        public ImmutableArray<Target> Targets { get; internal set; } = ImmutableArray<Target>.Empty;
+
+        public override bool IsUndefined => Imports.IsDefaultOrEmpty
+            && ItemGroups.IsDefaultOrEmpty
+            && PropertyGroups.IsDefaultOrEmpty
+            && Sdks.IsDefaultOrEmpty
+            && Targets.IsDefaultOrEmpty;
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            throw new NotImplementedException();
+            if (IsUndefined)
+            {
+                return Array.Empty<ValidationResult>();
+            }
+
+            return validationContext
+                .IncludeIf(!Imports.IsDefaultOrEmpty, nameof(Imports), import => !import.IsUndefined, Imports)
+                .AndIf(!ItemGroups.IsDefaultOrEmpty, nameof(ItemGroups), group => !group.IsUndefined, ItemGroups)
+                .AndIf(!PropertyGroups.IsDefaultOrEmpty, nameof(PropertyGroups), group => !group.IsUndefined, PropertyGroups)
+                .AndIf(!Sdks.IsDefaultOrEmpty, nameof(Sdks), sdk => !sdk.IsUnspecified, Sdks)
+                .AndIf(!Targets.IsDefaultOrEmpty, nameof(Targets), target => !target.IsUndefined, Targets)
+                .Results;
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Concepts/Project.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/Project.cs
@@ -4,11 +4,22 @@
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.ComponentModel.DataAnnotations;
+    using Fluentify;
     using MooVC.Syntax.CSharp.Attributes.Project;
+    using Valuify;
+    using Ignore = Valuify.IgnoreAttribute;
 
-    public sealed class Project
+    [Fluentify]
+    [Valuify]
+    public sealed partial class Project
         : Construct
     {
+        public static readonly Project Undefined = new Project();
+
+        internal Project()
+        {
+        }
+
         public ImmutableArray<Import> Imports { get; internal set; } = ImmutableArray<Import>.Empty;
 
         public ImmutableArray<ItemGroup> ItemGroups { get; internal set; } = ImmutableArray<ItemGroup>.Empty;
@@ -19,11 +30,8 @@
 
         public ImmutableArray<Target> Targets { get; internal set; } = ImmutableArray<Target>.Empty;
 
-        public override bool IsUndefined => Imports.IsDefaultOrEmpty
-            && ItemGroups.IsDefaultOrEmpty
-            && PropertyGroups.IsDefaultOrEmpty
-            && Sdks.IsDefaultOrEmpty
-            && Targets.IsDefaultOrEmpty;
+        [Ignore]
+        public override bool IsUndefined => this == Undefined;
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {


### PR DESCRIPTION
### Motivation

- Provide a complete in-memory representation of MSBuild project files so the `Project` concept can produce comprehensive csproj output.
- Consolidate subordinate csproj elements under `MooVC.Syntax.CSharp.Attributes.Project` to match the library structure.

### Description

- Added attribute model classes under `MooVC.Syntax.CSharp.Attributes.Project` for `Import`, `Item`, `ItemGroup`, `Metadata`, `Property`, `PropertyGroup`, `Sdk`, `Target`, `TargetTask`, `TaskOutput`, and `TaskParameter` as `IValidatableObject` types.
- Each new model exposes relevant properties (e.g. `Identifier`, `Snippet`, `ImmutableArray<T>`) and implements validation via `Validate` using the existing validation helpers like `IncludeIf`/`Include`.
- Extended `src/MooVC.Syntax.CSharp/Concepts/Project.cs` to hold `ImmutableArray<T>` collections for `Imports`, `ItemGroups`, `PropertyGroups`, `Sdks`, and `Targets`, and implemented `IsUndefined` and `Validate` logic to aggregate validations from those collections.
- Preserved project coding style and namespacing conventions, and added internal constructors and sentinel `Undefined`/`Unspecified` instances where appropriate.

### Testing

- No automated tests were executed as part of this change (`dotnet test` was not run).
- All changes were compiled and committed; further validation should run the repository test suite with `dotnet test` locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695135db8efc8323a8573fe34eeeb1bc)