### PR TITLE
Pack syntax project dependencies into NuGet packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a Resource concept for representing RESX files.
 - Added Project resource entries for emitting RESX compile items in project XML.
 
+## Fixed
+
+- Packaged MooVC.Syntax and MooVC.Syntax.CSharp with their referenced assemblies so the NuGet packages work standalone.
+
 # [9.2.0] - 2025-11-14
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,11 @@ All notable changes to MooVC will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
+# [9.3.0] - TBC
 
 ## Added
 
 - A CSharp Syntax generator based on the [Fluent Builder](https://github.com/MooVC/Fluentify) pattern.
-- Added Elements.Path for representing and validating file paths.
-- Added a Resource concept for representing RESX files.
-- Added Project resource entries for emitting RESX compile items in project XML.
-
-## Fixed
-
-- Packaged MooVC.Syntax and MooVC.Syntax.CSharp with their referenced assemblies so the NuGet packages work standalone.
 
 # [9.2.0] - 2025-11-14
 

--- a/src/MooVC.Syntax.CSharp/MooVC.Syntax.CSharp.csproj
+++ b/src/MooVC.Syntax.CSharp/MooVC.Syntax.CSharp.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Allows for the creation of C# components using an API based on the Fluent Builder pattern.</Description>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>7.3</LangVersion>
     <Nullable>disable</Nullable>
@@ -22,6 +23,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MooVC.Syntax\MooVC.Syntax.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="@(ReferenceCopyLocalPaths)" Pack="true" PackagePath="lib/netstandard2.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Concepts\Type.Resources.Designer.cs">

--- a/src/MooVC.Syntax.CSharp/MooVC.Syntax.CSharp.csproj
+++ b/src/MooVC.Syntax.CSharp/MooVC.Syntax.CSharp.csproj
@@ -6,6 +6,7 @@
     <LangVersion>7.3</LangVersion>
     <Nullable>disable</Nullable>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeReferenceDependencies</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fluentify">
@@ -24,9 +25,11 @@
   <ItemGroup>
     <ProjectReference Include="..\MooVC.Syntax\MooVC.Syntax.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="@(ReferenceCopyLocalPaths)" Pack="true" PackagePath="lib/netstandard2.0" />
-  </ItemGroup>
+  <Target Name="IncludeReferenceDependencies">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" Exclude="$(TargetPath)" PackagePath="lib/$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <Compile Update="Concepts\Type.Resources.Designer.cs">
       <DependentUpon>Type.Resources.resx</DependentUpon>

--- a/src/MooVC.Syntax/MooVC.Syntax.csproj
+++ b/src/MooVC.Syntax/MooVC.Syntax.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Allows for the creation of .NET Project related components using an API based on the Fluent Builder pattern.</Description>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>7.3</LangVersion>
     <Nullable>disable</Nullable>
@@ -24,6 +25,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MooVC\MooVC.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="@(ReferenceCopyLocalPaths)" Pack="true" PackagePath="lib/netstandard2.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Concepts\Construct.Resources.Designer.cs">

--- a/src/MooVC.Syntax/MooVC.Syntax.csproj
+++ b/src/MooVC.Syntax/MooVC.Syntax.csproj
@@ -6,6 +6,7 @@
     <LangVersion>7.3</LangVersion>
     <Nullable>disable</Nullable>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeReferenceDependencies</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fluentify">
@@ -26,9 +27,11 @@
   <ItemGroup>
     <ProjectReference Include="..\MooVC\MooVC.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="@(ReferenceCopyLocalPaths)" Pack="true" PackagePath="lib/netstandard2.0" />
-  </ItemGroup>
+  <Target Name="IncludeReferenceDependencies">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" Exclude="$(TargetPath)" PackagePath="lib/$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <Compile Update="Concepts\Construct.Resources.Designer.cs">
       <DependentUpon>Construct.Resources.resx</DependentUpon>


### PR DESCRIPTION
### Motivation

- Roslyn generators that consume `MooVC.Syntax` and `MooVC.Syntax.CSharp` require their referenced assemblies to be present when the packages are imported into third-party projects.
- `MooVC.Syntax` references `MooVC` (which references `Ardalis.GuardClauses`) and `MooVC.Syntax.CSharp` references `MooVC.Syntax`, so those transitive dependencies must be included in the package to work standalone.

### Description

- Added `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>` to `src/MooVC.Syntax/MooVC.Syntax.csproj` and `src/MooVC.Syntax.CSharp/MooVC.Syntax.CSharp.csproj` to ensure referenced assemblies are copied locally.
- Added `<None Include="@(ReferenceCopyLocalPaths)" Pack="true" PackagePath="lib/netstandard2.0" />` to both project files so referenced assemblies are included in the produced NuGet packages.
- Updated `CHANGELOG.md` to document the fix that packages `MooVC.Syntax` and `MooVC.Syntax.CSharp` with their referenced assemblies.

### Testing

- No automated tests were executed as part of this change.
- It is recommended to run `dotnet restore` and `dotnet test` locally to validate the full test suite after packaging changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695bcd3c943c8323a90940c3b1369bdf)