### PR TITLE
Add coverage for solution attribute value objects

### DIFF
--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualityOperatorBuildTypeBuildTypeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualityOperatorBuildTypeBuildTypeIsCalled.cs
@@ -1,0 +1,48 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.BuildTypeTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualityOperatorBuildTypeBuildTypeIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Configurations.BuildType? left = default;
+        Configurations.BuildType? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Configurations.BuildType("Custom");
+        var right = new Configurations.BuildType("Custom");
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Configurations.BuildType("Custom");
+        var right = new Configurations.BuildType("Other");
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualsBuildTypeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualsBuildTypeIsCalled.cs
@@ -1,0 +1,48 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.BuildTypeTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsBuildTypeIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.BuildType("Custom");
+        Configurations.BuildType? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Configurations.BuildType("Custom");
+        var other = new Configurations.BuildType("Custom");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.BuildType("Custom");
+        var other = new Configurations.BuildType("Other");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualsObjectIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenEqualsObjectIsCalled
         var subject = new Configurations.BuildType("Custom");
 
         // Act
-        bool result = subject.Equals(null);
+        bool result = subject.Equals(default(object));
 
         // Assert
         result.ShouldBeFalse();

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,46 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.BuildTypeTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.BuildType("Custom");
+
+        // Act
+        bool result = subject.Equals(null);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.BuildType("Custom");
+
+        // Act
+        bool result = subject.Equals("Other");
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenBuildTypeWithSameValueThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Configurations.BuildType("Custom");
+        object other = new Configurations.BuildType("Custom");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.BuildTypeTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        var first = new Configurations.BuildType("Custom");
+        var second = new Configurations.BuildType("Custom");
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldBe(secondHash);
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenHashesDiffer()
+    {
+        // Arrange
+        var first = new Configurations.BuildType("Custom");
+        var second = new Configurations.BuildType("Other");
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldNotBe(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.BuildTypeTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Fact]
+    public void GivenValueThenReturnsValue()
+    {
+        // Arrange
+        var subject = new Configurations.BuildType("Custom");
+
+        // Act
+        string result = subject;
+
+        // Assert
+        result.ShouldBe("Custom");
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenInequalityOperatorBuildTypeBuildTypeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/BuildTypeTests/WhenInequalityOperatorBuildTypeBuildTypeIsCalled.cs
@@ -1,0 +1,48 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.BuildTypeTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenInequalityOperatorBuildTypeBuildTypeIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Configurations.BuildType? left = default;
+        Configurations.BuildType? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Configurations.BuildType("Custom");
+        var right = new Configurations.BuildType("Custom");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Configurations.BuildType("Custom");
+        var right = new Configurations.BuildType("Other");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualityOperatorPlatformPlatformIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualityOperatorPlatformPlatformIsCalled.cs
@@ -1,0 +1,48 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.PlatformTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualityOperatorPlatformPlatformIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Configurations.Platform? left = default;
+        Configurations.Platform? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Configurations.Platform("CustomPlatform");
+        var right = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Configurations.Platform("CustomPlatform");
+        var right = new Configurations.Platform("OtherPlatform");
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualsObjectIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenEqualsObjectIsCalled
         var subject = new Configurations.Platform("CustomPlatform");
 
         // Act
-        bool result = subject.Equals(null);
+        bool result = subject.Equals(default(object));
 
         // Assert
         result.ShouldBeFalse();

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,46 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.PlatformTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        bool result = subject.Equals(null);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        bool result = subject.Equals("OtherPlatform");
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenPlatformWithSameValueThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Configurations.Platform("CustomPlatform");
+        object other = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualsPlatformIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenEqualsPlatformIsCalled.cs
@@ -1,0 +1,48 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.PlatformTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsPlatformIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.Platform("CustomPlatform");
+        Configurations.Platform? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Configurations.Platform("CustomPlatform");
+        var other = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations.Platform("CustomPlatform");
+        var other = new Configurations.Platform("OtherPlatform");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.PlatformTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        var first = new Configurations.Platform("CustomPlatform");
+        var second = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldBe(secondHash);
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenHashesDiffer()
+    {
+        // Arrange
+        var first = new Configurations.Platform("CustomPlatform");
+        var second = new Configurations.Platform("OtherPlatform");
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldNotBe(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.PlatformTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Fact]
+    public void GivenValueThenReturnsValue()
+    {
+        // Arrange
+        var subject = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        string result = subject;
+
+        // Assert
+        result.ShouldBe("CustomPlatform");
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenInequalityOperatorPlatformPlatformIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests/PlatformTests/WhenInequalityOperatorPlatformPlatformIsCalled.cs
@@ -1,0 +1,48 @@
+namespace MooVC.Syntax.Attributes.Solution.ConfigurationsTests.PlatformTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenInequalityOperatorPlatformPlatformIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Configurations.Platform? left = default;
+        Configurations.Platform? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Configurations.Platform("CustomPlatform");
+        var right = new Configurations.Platform("CustomPlatform");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Configurations.Platform("CustomPlatform");
+        var right = new Configurations.Platform("OtherPlatform");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualityOperatorNameNameIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualityOperatorNameNameIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.NameTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualityOperatorNameNameIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Project.Name? left = default;
+        Project.Name? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string name = "ProjectName";
+        var left = new Project.Name(name);
+        var right = new Project.Name(name);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Project.Name("ProjectName");
+        var right = new Project.Name("OtherProjectName");
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualsNameIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualsNameIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.NameTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsNameIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.Name("ProjectName");
+        Project.Name? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string name = "ProjectName";
+        var subject = new Project.Name(name);
+        var other = new Project.Name(name);
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.Name("ProjectName");
+        var other = new Project.Name("OtherProjectName");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualsObjectIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenEqualsObjectIsCalled
         var subject = new Project.Name("ProjectName");
 
         // Act
-        bool result = subject.Equals(null);
+        bool result = subject.Equals(default(object));
 
         // Assert
         result.ShouldBeFalse();

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,47 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.NameTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.Name("ProjectName");
+
+        // Act
+        bool result = subject.Equals(null);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.Name("ProjectName");
+
+        // Act
+        bool result = subject.Equals("OtherProjectName");
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenNameWithSameValueThenReturnsTrue()
+    {
+        // Arrange
+        const string name = "ProjectName";
+        var subject = new Project.Name(name);
+        object other = new Project.Name(name);
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,37 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.NameTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        const string name = "ProjectName";
+        var first = new Project.Name(name);
+        var second = new Project.Name(name);
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldBe(secondHash);
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenHashesDiffer()
+    {
+        // Arrange
+        var first = new Project.Name("ProjectName");
+        var second = new Project.Name("OtherProjectName");
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldNotBe(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.NameTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Fact]
+    public void GivenValueThenReturnsValue()
+    {
+        // Arrange
+        const string name = "ProjectName";
+        var subject = new Project.Name(name);
+
+        // Act
+        string result = subject;
+
+        // Assert
+        result.ShouldBe(name);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenInequalityOperatorNameNameIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/NameTests/WhenInequalityOperatorNameNameIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.NameTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenInequalityOperatorNameNameIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Project.Name? left = default;
+        Project.Name? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        const string name = "ProjectName";
+        var left = new Project.Name(name);
+        var right = new Project.Name(name);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Project.Name("ProjectName");
+        var right = new Project.Name("OtherProjectName");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualityOperatorRelativePathRelativePathIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualityOperatorRelativePathRelativePathIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.RelativePathTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualityOperatorRelativePathRelativePathIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Project.RelativePath? left = default;
+        Project.RelativePath? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "src/Project.csproj";
+        var left = new Project.RelativePath(path);
+        var right = new Project.RelativePath(path);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Project.RelativePath("src/Project.csproj");
+        var right = new Project.RelativePath("src/Other.csproj");
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,47 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.RelativePathTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.RelativePath("src/Project.csproj");
+
+        // Act
+        bool result = subject.Equals(null);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.RelativePath("src/Project.csproj");
+
+        // Act
+        bool result = subject.Equals("src/Other.csproj");
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenRelativePathWithSameValueThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "src/Project.csproj";
+        var subject = new Project.RelativePath(path);
+        object other = new Project.RelativePath(path);
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualsObjectIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenEqualsObjectIsCalled
         var subject = new Project.RelativePath("src/Project.csproj");
 
         // Act
-        bool result = subject.Equals(null);
+        bool result = subject.Equals(default(object));
 
         // Assert
         result.ShouldBeFalse();

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualsRelativePathIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenEqualsRelativePathIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.RelativePathTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenEqualsRelativePathIsCalled
+{
+    [Fact]
+    public void GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.RelativePath("src/Project.csproj");
+        Project.RelativePath? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "src/Project.csproj";
+        var subject = new Project.RelativePath(path);
+        var other = new Project.RelativePath(path);
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Project.RelativePath("src/Project.csproj");
+        var other = new Project.RelativePath("src/Other.csproj");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,37 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.RelativePathTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Fact]
+    public void GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        const string path = "src/Project.csproj";
+        var first = new Project.RelativePath(path);
+        var second = new Project.RelativePath(path);
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldBe(secondHash);
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenHashesDiffer()
+    {
+        // Arrange
+        var first = new Project.RelativePath("src/Project.csproj");
+        var second = new Project.RelativePath("src/Other.csproj");
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        firstHash.ShouldNotBe(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.RelativePathTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Fact]
+    public void GivenValueThenReturnsValue()
+    {
+        // Arrange
+        const string path = "src/Project.csproj";
+        var subject = new Project.RelativePath(path);
+
+        // Act
+        string result = subject;
+
+        // Assert
+        result.ShouldBe(path);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenInequalityOperatorRelativePathRelativePathIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests/RelativePathTests/WhenInequalityOperatorRelativePathRelativePathIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.Attributes.Solution.ProjectTests.RelativePathTests;
+
+using MooVC.Syntax.Attributes.Solution;
+
+public sealed class WhenInequalityOperatorRelativePathRelativePathIsCalled
+{
+    [Fact]
+    public void GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Project.RelativePath? left = default;
+        Project.RelativePath? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        const string path = "src/Project.csproj";
+        var left = new Project.RelativePath(path);
+        var right = new Project.RelativePath(path);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Project.RelativePath("src/Project.csproj");
+        var right = new Project.RelativePath("src/Other.csproj");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve unit-test coverage for generated value objects in the MooVC.Syntax project, with emphasis on Monify/Fluentify/Valuify-generated behaviors.
- Verify equality/inequality operators, `Equals(object)`, implicit casts, `GetHashCode`, `ToString`, and validation logic for solution-related types.
- Focus on the solution attribute value objects used across projects and configurations to prevent regressions in generated code handling.

### Description

- Added xUnit test suites for `Project.Name` and `Project.RelativePath` under `src/MooVC.Syntax.Tests/Attributes/Solution/ProjectTests` covering equality, inequality, `Equals(object)`, `GetHashCode`, and implicit operator behavior. 
- Added xUnit test suites for `Configurations.BuildType` and `Configurations.Platform` under `src/MooVC.Syntax.Tests/Attributes/Solution/ConfigurationsTests` covering equality, inequality, `Equals(object)`, `GetHashCode`, and implicit string casts. 
- Tests follow existing project conventions (xUnit + `Shouldly`) and mirror the repository test layout and naming patterns. 
- New tests exercise the generated features to increase coverage of Monify/Fluentify/Valuify-produced code paths.

### Testing

- No automated test suite was executed in this environment; `dotnet test` was not run here. 
- Please run `dotnet restore` and `dotnet test` locally or in CI to validate the added tests. 
- The tests were written to integrate with the existing test infrastructure and should pass when run against the current codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696621e012d8832390f58c494df1ae58)