### PR TITLE
Add FileSystemWriter for modelling outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - A CSharp Syntax generator based on the [Fluent Builder](https://github.com/MooVC/Fluentify) pattern.
+- A FileSystemWriter for emitting generated files directly to disk.
 
 # [9.2.0] - 2025-11-14
 

--- a/src/MooVC.Modelling/FileSystemWriter.Options.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.Options.cs
@@ -1,0 +1,9 @@
+namespace MooVC.Modelling;
+
+internal partial class FileSystemWriter
+{
+    public sealed record Options(int BufferSize)
+    {
+        public static readonly Options Default = new(4096);
+    }
+}

--- a/src/MooVC.Modelling/FileSystemWriter.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.cs
@@ -6,8 +6,9 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
-internal sealed class FileSystemWriter
+internal sealed partial class FileSystemWriter(IOptionsSnapshot<FileSystemWriter.Options> options)
     : IWriter
 {
     public async Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken)
@@ -40,7 +41,7 @@ internal sealed class FileSystemWriter
         return Directory.GetCurrentDirectory();
     }
 
-    private static async Task Write(File file, string rootPath, CancellationToken cancellationToken)
+    private async Task Write(File file, string rootPath, CancellationToken cancellationToken)
     {
         string filePath = Path.GetFullPath(Path.Combine(rootPath, file.FilePath));
         string? directoryPath = Path.GetDirectoryName(filePath);
@@ -57,7 +58,7 @@ internal sealed class FileSystemWriter
             FileMode.Create,
             FileAccess.Write,
             FileShare.None,
-            bufferSize: 4096,
+            bufferSize: options.Value.BufferSize,
             useAsync: true);
 
         await stream

--- a/src/MooVC.Modelling/FileSystemWriter.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.cs
@@ -1,0 +1,67 @@
+namespace MooVC.Modelling;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+internal sealed class FileSystemWriter
+    : IWriter
+{
+    public async Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken)
+    {
+        string rootPath = ResolveRootPath(stream);
+
+        ConfiguredCancelableAsyncEnumerable<File> enumerable = files
+            .WithCancellation(cancellationToken)
+            .ConfigureAwait(false);
+
+        await foreach (File file in enumerable)
+        {
+            await Write(file, rootPath, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static string ResolveRootPath(Stream stream)
+    {
+        if (stream is FileStream fileStream)
+        {
+            string? directoryPath = Path.GetDirectoryName(fileStream.Name);
+
+            if (!string.IsNullOrWhiteSpace(directoryPath))
+            {
+                return directoryPath;
+            }
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+
+    private static async Task Write(File file, string rootPath, CancellationToken cancellationToken)
+    {
+        string filePath = Path.GetFullPath(Path.Combine(rootPath, file.FilePath));
+        string? directoryPath = Path.GetDirectoryName(filePath);
+
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            _ = Directory.CreateDirectory(directoryPath);
+        }
+
+        byte[] contentBytes = Encoding.UTF8.GetBytes(file.Content);
+
+        await using var stream = new FileStream(
+            filePath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            useAsync: true);
+
+        await stream
+            .WriteAsync(contentBytes, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Modelling;
+
+using Ardalis.GuardClauses;
+using Microsoft.Extensions.DependencyInjection;
+using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
+
+public static partial class ServiceCollectionExtensions
+{
+    private const string FileSystemServiceKey = "FileSystem";
+
+    public static IServiceCollection AddFileSystemWriter(this IServiceCollection services)
+    {
+        _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
+
+        return services.AddKeyedTransient<IWriter, FileSystemWriter>(FileSystemServiceKey);
+    }
+}

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
@@ -8,6 +8,7 @@ public static partial class ServiceCollectionExtensions
     {
         return services
             .AddGenerator()
+            .AddFileSystemWriter()
             .AddZipWriter();
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a writer that can emit generated `File` instances directly to disk so modelling output can be materialized to the filesystem on Windows and Linux.

### Description

- Add a new `FileSystemWriter` implementation in `src/MooVC.Modelling/FileSystemWriter.cs` that resolves a root path (from a `FileStream` or `Directory.GetCurrentDirectory()`), creates directories as required, and writes file contents using an async `FileStream` and UTF-8 encoding.
- Add a registration extension `AddFileSystemWriter` in `src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs` that registers the writer as a keyed transient with key `"FileSystem"` via `AddKeyedTransient<IWriter, FileSystemWriter>("FileSystem")`.
- Include the file system writer in the default setup by updating `AddModelling` in `src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs` to call `AddFileSystemWriter()` before `AddZipWriter()`.
- Update `CHANGELOG.md` to document the new `FileSystemWriter` feature.

### Testing

- No automated tests were executed for this change (`dotnet test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e4aab85c832f8e76832117554274)