### PR TITLE
Add modelling tests and in-memory file system support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,10 +12,12 @@
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="[3.11.0,3.12.0)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.4.0,4.5.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Monify" Version="1.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="[3.11.0,3.12.0)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.4.0,4.5.0)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/MooVC.slnx
+++ b/MooVC.slnx
@@ -62,6 +62,7 @@
     <File Path=".github/pull_request_template.md" />
   </Folder>
   <Folder Name="/Tests/">
+    <Project Path="src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj" />
     <Project Path="src/MooVC.Syntax.CSharp.Tests/MooVC.Syntax.CSharp.Tests.csproj">
       <Platform Solution="*|ARM32" Project="ARM32" />
     </Project>

--- a/src/MooVC.Modelling.Tests/FileSystemWriterOptionsTests/WhenDefaultIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileSystemWriterOptionsTests/WhenDefaultIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Modelling.FileSystemWriterOptionsTests;
+
+public sealed class WhenDefaultIsCalled
+{
+    private const int DefaultBufferSize = 4096;
+
+    [Fact]
+    public void GivenDefaultThenBufferSizeIsSet()
+    {
+        // Arrange
+        // Act
+        FileSystemWriter.Options options = FileSystemWriter.Options.Default;
+
+        // Assert
+        options.BufferSize.ShouldBe(DefaultBufferSize);
+    }
+}

--- a/src/MooVC.Modelling.Tests/FileSystemWriterOptionsTests/WhenDefaultIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileSystemWriterOptionsTests/WhenDefaultIsCalled.cs
@@ -7,8 +7,7 @@ public sealed class WhenDefaultIsCalled
     [Fact]
     public void GivenDefaultThenBufferSizeIsSet()
     {
-        // Arrange
-        // Act
+        // Arrange & Act
         FileSystemWriter.Options options = FileSystemWriter.Options.Default;
 
         // Assert

--- a/src/MooVC.Modelling.Tests/FileSystemWriterTests/InMemoryFileStream.cs
+++ b/src/MooVC.Modelling.Tests/FileSystemWriterTests/InMemoryFileStream.cs
@@ -1,0 +1,25 @@
+﻿namespace MooVC.Modelling.FileSystemWriterTests;
+
+internal sealed class InMemoryFileStream
+    : MemoryStream
+{
+    private readonly string _path;
+    private readonly Dictionary<string, byte[]> _fileContents;
+
+    public InMemoryFileStream(string path, int bufferSize, Dictionary<string, byte[]> fileContents)
+        : base(bufferSize)
+    {
+        _path = path;
+        _fileContents = fileContents;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _fileContents[_path] = ToArray();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/MooVC.Modelling.Tests/FileSystemWriterTests/InMemoryFileSystem.cs
+++ b/src/MooVC.Modelling.Tests/FileSystemWriterTests/InMemoryFileSystem.cs
@@ -1,0 +1,39 @@
+﻿namespace MooVC.Modelling.FileSystemWriterTests;
+
+internal sealed class InMemoryFileSystem
+    : IFileSystem
+{
+    private readonly Dictionary<string, byte[]> _fileContents = new(StringComparer.Ordinal);
+
+    public HashSet<string> CreatedDirectories { get; } = new(StringComparer.Ordinal);
+
+    public void CreateDirectory(string path)
+    {
+        _ = CreatedDirectories.Add(path);
+    }
+
+    public Stream CreateFileStream(string path, int bufferSize)
+    {
+        return new InMemoryFileStream(path, bufferSize, _fileContents);
+    }
+
+    public string GetCurrentDirectory()
+    {
+        return Environment.CurrentDirectory;
+    }
+
+    public string? GetDirectoryName(string path)
+    {
+        return Path.GetDirectoryName(path);
+    }
+
+    public string GetFullPath(string path)
+    {
+        return Path.GetFullPath(path, Environment.CurrentDirectory);
+    }
+
+    public bool TryGetFileContent(string path, out byte[]? fileContent)
+    {
+        return _fileContents.TryGetValue(path, out fileContent);
+    }
+}

--- a/src/MooVC.Modelling.Tests/FileSystemWriterTests/WhenWriteIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileSystemWriterTests/WhenWriteIsCalled.cs
@@ -1,0 +1,126 @@
+namespace MooVC.Modelling.FileSystemWriterTests;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+public sealed class WhenWriteIsCalled
+{
+    private const int BufferSize = 128;
+    private const string Content = "Hello, MooVC!";
+    private const string Extension = "txt";
+    private const string Name = "example";
+    private const string PathValue = "Models";
+    private const string RootPath = "Root";
+
+    [Fact]
+    public async Task GivenFilesThenContentIsWritten()
+    {
+        // Arrange
+        File testFile = new(Content, Extension, Name, PathValue);
+        IAsyncEnumerable<File> files = CreateFiles(testFile);
+        IFileSystem fileSystem = new InMemoryFileSystem(RootPath);
+        IOptionsSnapshot<FileSystemWriter.Options> optionsSnapshot = CreateOptionsSnapshot();
+        IWriter writer = new FileSystemWriter(fileSystem, optionsSnapshot);
+        await using var stream = new MemoryStream();
+        string expectedPath = fileSystem.GetFullPath(Path.Combine(RootPath, testFile.FilePath));
+        string? expectedDirectory = fileSystem.GetDirectoryName(expectedPath);
+
+        // Act
+        await writer.Write(files, stream, CancellationToken.None);
+
+        // Assert
+        InMemoryFileSystem inMemoryFileSystem = (InMemoryFileSystem)fileSystem;
+        bool isFound = inMemoryFileSystem.TryGetFileContent(expectedPath, out byte[]? fileContent);
+        isFound.ShouldBeTrue();
+        fileContent.ShouldNotBeNull();
+        Encoding.UTF8.GetString(fileContent).ShouldBe(Content);
+        expectedDirectory.ShouldNotBeNull();
+        inMemoryFileSystem.CreatedDirectories.ShouldContain(expectedDirectory);
+    }
+
+    private static IOptionsSnapshot<FileSystemWriter.Options> CreateOptionsSnapshot()
+    {
+        IOptionsSnapshot<FileSystemWriter.Options> optionsSnapshot = Substitute.For<IOptionsSnapshot<FileSystemWriter.Options>>();
+        optionsSnapshot.Value.Returns(new FileSystemWriter.Options(BufferSize));
+        return optionsSnapshot;
+    }
+
+    private static async IAsyncEnumerable<File> CreateFiles(params File[] files)
+    {
+        foreach (File file in files)
+        {
+            yield return file;
+            await Task.Yield();
+        }
+    }
+}
+
+internal sealed class InMemoryFileSystem
+    : IFileSystem
+{
+    private readonly Dictionary<string, byte[]> fileContents = new(StringComparer.Ordinal);
+    private readonly string rootPath;
+
+    public InMemoryFileSystem(string rootPath)
+    {
+        this.rootPath = rootPath;
+    }
+
+    public HashSet<string> CreatedDirectories { get; } = new(StringComparer.Ordinal);
+
+    public void CreateDirectory(string path)
+    {
+        _ = CreatedDirectories.Add(path);
+    }
+
+    public Stream CreateFileStream(string path, int bufferSize)
+    {
+        return new InMemoryFileStream(path, bufferSize, fileContents);
+    }
+
+    public string GetCurrentDirectory()
+    {
+        return rootPath;
+    }
+
+    public string? GetDirectoryName(string path)
+    {
+        return Path.GetDirectoryName(path);
+    }
+
+    public string GetFullPath(string path)
+    {
+        return Path.GetFullPath(path, rootPath);
+    }
+
+    public bool TryGetFileContent(string path, out byte[]? fileContent)
+    {
+        return fileContents.TryGetValue(path, out fileContent);
+    }
+}
+
+internal sealed class InMemoryFileStream
+    : MemoryStream
+{
+    private readonly string path;
+    private readonly Dictionary<string, byte[]> fileContents;
+
+    public InMemoryFileStream(string path, int bufferSize, Dictionary<string, byte[]> fileContents)
+        : base(bufferSize)
+    {
+        this.path = path;
+        this.fileContents = fileContents;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            fileContents[path] = ToArray();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/MooVC.Modelling.Tests/FileSystemWriterTests/WhenWriteIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileSystemWriterTests/WhenWriteIsCalled.cs
@@ -1,7 +1,6 @@
 namespace MooVC.Modelling.FileSystemWriterTests;
 
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using Microsoft.Extensions.Options;
 
@@ -12,7 +11,6 @@ public sealed class WhenWriteIsCalled
     private const string Extension = "txt";
     private const string Name = "example";
     private const string PathValue = "Models";
-    private const string RootPath = "Root";
 
     [Fact]
     public async Task GivenFilesThenContentIsWritten()
@@ -20,31 +18,32 @@ public sealed class WhenWriteIsCalled
         // Arrange
         File testFile = new(Content, Extension, Name, PathValue);
         IAsyncEnumerable<File> files = CreateFiles(testFile);
-        IFileSystem fileSystem = new InMemoryFileSystem(RootPath);
+        var fileSystem = new InMemoryFileSystem();
         IOptionsSnapshot<FileSystemWriter.Options> optionsSnapshot = CreateOptionsSnapshot();
         IWriter writer = new FileSystemWriter(fileSystem, optionsSnapshot);
         await using var stream = new MemoryStream();
-        string expectedPath = fileSystem.GetFullPath(Path.Combine(RootPath, testFile.FilePath));
+        string expectedPath = fileSystem.GetFullPath(Path.Combine(Environment.CurrentDirectory, testFile.FilePath));
         string? expectedDirectory = fileSystem.GetDirectoryName(expectedPath);
 
         // Act
         await writer.Write(files, stream, CancellationToken.None);
 
         // Assert
-        InMemoryFileSystem inMemoryFileSystem = (InMemoryFileSystem)fileSystem;
-        bool isFound = inMemoryFileSystem.TryGetFileContent(expectedPath, out byte[]? fileContent);
+        bool isFound = fileSystem.TryGetFileContent(expectedPath, out byte[]? fileContent);
         isFound.ShouldBeTrue();
-        fileContent.ShouldNotBeNull();
+        _ = fileContent.ShouldNotBeNull();
         Encoding.UTF8.GetString(fileContent).ShouldBe(Content);
-        expectedDirectory.ShouldNotBeNull();
-        inMemoryFileSystem.CreatedDirectories.ShouldContain(expectedDirectory);
+        _ = expectedDirectory.ShouldNotBeNull();
+        fileSystem.CreatedDirectories.ShouldContain(expectedDirectory);
     }
 
     private static IOptionsSnapshot<FileSystemWriter.Options> CreateOptionsSnapshot()
     {
-        IOptionsSnapshot<FileSystemWriter.Options> optionsSnapshot = Substitute.For<IOptionsSnapshot<FileSystemWriter.Options>>();
-        optionsSnapshot.Value.Returns(new FileSystemWriter.Options(BufferSize));
-        return optionsSnapshot;
+        IOptionsSnapshot<FileSystemWriter.Options> options = Substitute.For<IOptionsSnapshot<FileSystemWriter.Options>>();
+
+        _ = options.Value.Returns(new FileSystemWriter.Options(BufferSize));
+
+        return options;
     }
 
     private static async IAsyncEnumerable<File> CreateFiles(params File[] files)
@@ -52,75 +51,8 @@ public sealed class WhenWriteIsCalled
         foreach (File file in files)
         {
             yield return file;
+
             await Task.Yield();
         }
-    }
-}
-
-internal sealed class InMemoryFileSystem
-    : IFileSystem
-{
-    private readonly Dictionary<string, byte[]> fileContents = new(StringComparer.Ordinal);
-    private readonly string rootPath;
-
-    public InMemoryFileSystem(string rootPath)
-    {
-        this.rootPath = rootPath;
-    }
-
-    public HashSet<string> CreatedDirectories { get; } = new(StringComparer.Ordinal);
-
-    public void CreateDirectory(string path)
-    {
-        _ = CreatedDirectories.Add(path);
-    }
-
-    public Stream CreateFileStream(string path, int bufferSize)
-    {
-        return new InMemoryFileStream(path, bufferSize, fileContents);
-    }
-
-    public string GetCurrentDirectory()
-    {
-        return rootPath;
-    }
-
-    public string? GetDirectoryName(string path)
-    {
-        return Path.GetDirectoryName(path);
-    }
-
-    public string GetFullPath(string path)
-    {
-        return Path.GetFullPath(path, rootPath);
-    }
-
-    public bool TryGetFileContent(string path, out byte[]? fileContent)
-    {
-        return fileContents.TryGetValue(path, out fileContent);
-    }
-}
-
-internal sealed class InMemoryFileStream
-    : MemoryStream
-{
-    private readonly string path;
-    private readonly Dictionary<string, byte[]> fileContents;
-
-    public InMemoryFileStream(string path, int bufferSize, Dictionary<string, byte[]> fileContents)
-        : base(bufferSize)
-    {
-        this.path = path;
-        this.fileContents = fileContents;
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            fileContents[path] = ToArray();
-        }
-
-        base.Dispose(disposing);
     }
 }

--- a/src/MooVC.Modelling.Tests/FileTests/WhenFileNameIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileTests/WhenFileNameIsCalled.cs
@@ -1,0 +1,23 @@
+namespace MooVC.Modelling.FileTests;
+
+public sealed class WhenFileNameIsCalled
+{
+    private const string Content = "content";
+    private const string Extension = "txt";
+    private const string Name = "example";
+    private const string PathValue = "Models";
+
+    [Fact]
+    public void GivenNameAndExtensionThenFileNameIsReturned()
+    {
+        // Arrange
+        File file = new(Content, Extension, Name, PathValue);
+        string expectedFileName = string.Concat(Name, ".", Extension);
+
+        // Act
+        string fileName = file.FileName;
+
+        // Assert
+        fileName.ShouldBe(expectedFileName);
+    }
+}

--- a/src/MooVC.Modelling.Tests/FileTests/WhenFilePathIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileTests/WhenFilePathIsCalled.cs
@@ -1,0 +1,25 @@
+namespace MooVC.Modelling.FileTests;
+
+using System.IO;
+
+public sealed class WhenFilePathIsCalled
+{
+    private const string Content = "content";
+    private const string Extension = "txt";
+    private const string Name = "example";
+    private const string PathValue = "Models";
+
+    [Fact]
+    public void GivenFileInformationThenFilePathIsReturned()
+    {
+        // Arrange
+        File file = new(Content, Extension, Name, PathValue);
+        string expectedFilePath = Path.Combine(PathValue, string.Concat(Name, ".", Extension));
+
+        // Act
+        string filePath = file.FilePath;
+
+        // Assert
+        filePath.ShouldBe(expectedFilePath);
+    }
+}

--- a/src/MooVC.Modelling.Tests/FileTests/WhenFilePathIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileTests/WhenFilePathIsCalled.cs
@@ -1,7 +1,5 @@
 namespace MooVC.Modelling.FileTests;
 
-using System.IO;
-
 public sealed class WhenFilePathIsCalled
 {
     private const string Content = "content";

--- a/src/MooVC.Modelling.Tests/GeneratorTests/WhenGenerateIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/GeneratorTests/WhenGenerateIsCalled.cs
@@ -1,0 +1,64 @@
+namespace MooVC.Modelling.GeneratorTests;
+
+using System.Collections.Generic;
+using Graphify;
+using Microsoft.Extensions.DependencyInjection;
+
+public sealed class WhenGenerateIsCalled
+{
+    private const string Content = "content";
+    private const string Extension = "txt";
+    private const string Name = "example";
+    private const string PathValue = "Models";
+
+    [Fact]
+    public async Task GivenNavigatorThenFilesAreReturned()
+    {
+        // Arrange
+        TestModel model = new();
+        File expectedFile = new(Content, Extension, Name, PathValue);
+        IAsyncEnumerable<File> files = CreateFiles(expectedFile);
+        INavigator<TestModel> navigator = Substitute.For<INavigator<TestModel>>();
+        _ = navigator
+            .Navigate<File>(model, Arg.Any<CancellationToken>())
+            .Returns(files);
+
+        ServiceCollection services = new();
+        _ = services.AddSingleton(navigator);
+        IServiceProvider provider = services.BuildServiceProvider();
+        IGenerator<TestModel> generator = new Generator<TestModel>(provider);
+
+        // Act
+        IReadOnlyList<File> results = await Materialize(generator.Generate(model, CancellationToken.None));
+
+        // Assert
+        results.Count.ShouldBe(1);
+        results[0].ShouldBe(expectedFile);
+        _ = navigator.Received(1).Navigate<File>(model, Arg.Any<CancellationToken>());
+    }
+
+    private static async IAsyncEnumerable<File> CreateFiles(params File[] files)
+    {
+        foreach (File file in files)
+        {
+            yield return file;
+            await Task.Yield();
+        }
+    }
+
+    private static async Task<IReadOnlyList<File>> Materialize(IAsyncEnumerable<File> files)
+    {
+        List<File> results = new();
+
+        await foreach (File file in files)
+        {
+            results.Add(file);
+        }
+
+        return results;
+    }
+
+    private sealed class TestModel
+    {
+    }
+}

--- a/src/MooVC.Modelling.Tests/GeneratorTests/WhenGenerateIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/GeneratorTests/WhenGenerateIsCalled.cs
@@ -1,6 +1,7 @@
 namespace MooVC.Modelling.GeneratorTests;
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Graphify;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,6 +20,7 @@ public sealed class WhenGenerateIsCalled
         File expectedFile = new(Content, Extension, Name, PathValue);
         IAsyncEnumerable<File> files = CreateFiles(expectedFile);
         INavigator<TestModel> navigator = Substitute.For<INavigator<TestModel>>();
+
         _ = navigator
             .Navigate<File>(model, Arg.Any<CancellationToken>())
             .Returns(files);
@@ -48,7 +50,7 @@ public sealed class WhenGenerateIsCalled
 
     private static async Task<IReadOnlyList<File>> Materialize(IAsyncEnumerable<File> files)
     {
-        List<File> results = new();
+        List<File> results = [];
 
         await foreach (File file in files)
         {
@@ -58,7 +60,6 @@ public sealed class WhenGenerateIsCalled
         return results;
     }
 
-    private sealed class TestModel
-    {
-    }
+    [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Class is empty for the purposes of the test.")]
+    public sealed class TestModel;
 }

--- a/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
+++ b/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
+++ b/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
@@ -1,1 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+</Project>

--- a/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
+++ b/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 </Project>

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
@@ -32,7 +32,7 @@ public sealed class WhenAddFileSystemWriterIsCalled
         IFileSystem fileSystem = provider.GetRequiredService<IFileSystem>();
 
         // Assert
-        writer.ShouldBeOfType<FileSystemWriter>();
-        fileSystem.ShouldNotBeNull();
+        _ = writer.ShouldBeOfType<FileSystemWriter>();
+        _ = fileSystem.ShouldNotBeNull();
     }
 }

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
@@ -1,9 +1,14 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 public sealed class WhenAddFileSystemWriterIsCalled
 {
+    private const int CustomBufferSize = 8192;
     private const string FileSystemKey = "FileSystem";
 
     [Fact]
@@ -30,9 +35,35 @@ public sealed class WhenAddFileSystemWriterIsCalled
         using ServiceProvider provider = services.BuildServiceProvider();
         IWriter writer = provider.GetRequiredKeyedService<IWriter>(FileSystemKey);
         IFileSystem fileSystem = provider.GetRequiredService<IFileSystem>();
+        IOptionsSnapshot<FileSystemWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
 
         // Assert
         _ = writer.ShouldBeOfType<FileSystemWriter>();
         _ = fileSystem.ShouldNotBeNull();
+        options.Value.BufferSize.ShouldBe(FileSystemWriter.Options.Default.BufferSize);
+    }
+
+    [Fact]
+    public void GivenConfigurationThenOptionsAreBound()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            { $"{FileSystemWriter.Options.SectionName}:{nameof(FileSystemWriter.Options.BufferSize)}", CustomBufferSize.ToString(CultureInfo.InvariantCulture) },
+        };
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        ServiceCollection services = new();
+
+        // Act
+        _ = services.AddFileSystemWriter(configuration);
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsSnapshot<FileSystemWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
+
+        // Assert
+        options.Value.BufferSize.ShouldBe(CustomBufferSize);
     }
 }

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
@@ -1,0 +1,38 @@
+namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
+
+using Microsoft.Extensions.DependencyInjection;
+
+public sealed class WhenAddFileSystemWriterIsCalled
+{
+    private const string FileSystemKey = "FileSystem";
+
+    [Fact]
+    public void GivenNullServicesThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        IServiceCollection services = null!;
+
+        // Act
+        Action action = () => services.AddFileSystemWriter();
+
+        // Assert
+        _ = action.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenServicesThenWriterIsRegistered()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        _ = services.AddFileSystemWriter();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IWriter writer = provider.GetRequiredKeyedService<IWriter>(FileSystemKey);
+        IFileSystem fileSystem = provider.GetRequiredService<IFileSystem>();
+
+        // Assert
+        writer.ShouldBeOfType<FileSystemWriter>();
+        fileSystem.ShouldNotBeNull();
+    }
+}

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddGeneratorIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddGeneratorIsCalled.cs
@@ -1,5 +1,6 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Diagnostics.CodeAnalysis;
 using Graphify;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -32,10 +33,9 @@ public sealed class WhenAddGeneratorIsCalled
         IGenerator<TestModel> generator = provider.GetRequiredService<IGenerator<TestModel>>();
 
         // Assert
-        generator.ShouldBeOfType<Generator<TestModel>>();
+        _ = generator.ShouldBeOfType<Generator<TestModel>>();
     }
 
-    private sealed class TestModel
-    {
-    }
+    [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Class is empty for the purposes of the test.")]
+    public sealed class TestModel;
 }

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddGeneratorIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddGeneratorIsCalled.cs
@@ -1,0 +1,41 @@
+namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
+
+using Graphify;
+using Microsoft.Extensions.DependencyInjection;
+
+public sealed class WhenAddGeneratorIsCalled
+{
+    [Fact]
+    public void GivenNullServicesThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        IServiceCollection services = null!;
+
+        // Act
+        Action action = () => services.AddGenerator();
+
+        // Assert
+        _ = action.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenServicesThenGeneratorIsRegistered()
+    {
+        // Arrange
+        INavigator<TestModel> navigator = Substitute.For<INavigator<TestModel>>();
+        ServiceCollection services = new();
+        _ = services.AddSingleton(navigator);
+
+        // Act
+        _ = services.AddGenerator();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IGenerator<TestModel> generator = provider.GetRequiredService<IGenerator<TestModel>>();
+
+        // Assert
+        generator.ShouldBeOfType<Generator<TestModel>>();
+    }
+
+    private sealed class TestModel
+    {
+    }
+}

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
@@ -1,0 +1,35 @@
+namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
+
+using Graphify;
+using Microsoft.Extensions.DependencyInjection;
+
+public sealed class WhenAddModellingIsCalled
+{
+    private const string FileSystemKey = "FileSystem";
+    private const string ZipKey = "Zip";
+
+    [Fact]
+    public void GivenServicesThenDependenciesAreRegistered()
+    {
+        // Arrange
+        INavigator<TestModel> navigator = Substitute.For<INavigator<TestModel>>();
+        ServiceCollection services = new();
+        _ = services.AddSingleton(navigator);
+
+        // Act
+        _ = services.AddModelling();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IGenerator<TestModel> generator = provider.GetRequiredService<IGenerator<TestModel>>();
+        IWriter fileSystemWriter = provider.GetRequiredKeyedService<IWriter>(FileSystemKey);
+        IWriter zipWriter = provider.GetRequiredKeyedService<IWriter>(ZipKey);
+
+        // Assert
+        generator.ShouldBeOfType<Generator<TestModel>>();
+        fileSystemWriter.ShouldBeOfType<FileSystemWriter>();
+        zipWriter.ShouldBeOfType<ZipWriter>();
+    }
+
+    private sealed class TestModel
+    {
+    }
+}

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
@@ -1,11 +1,18 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO.Compression;
 using Graphify;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 public sealed class WhenAddModellingIsCalled
 {
+    private const int CustomBufferSize = 2048;
+    private const CompressionLevel CustomCompressionLevel = CompressionLevel.NoCompression;
     private const string FileSystemKey = "FileSystem";
     private const string ZipKey = "Zip";
 
@@ -23,11 +30,42 @@ public sealed class WhenAddModellingIsCalled
         IGenerator<TestModel> generator = provider.GetRequiredService<IGenerator<TestModel>>();
         IWriter fileSystemWriter = provider.GetRequiredKeyedService<IWriter>(FileSystemKey);
         IWriter zipWriter = provider.GetRequiredKeyedService<IWriter>(ZipKey);
+        IOptionsSnapshot<FileSystemWriter.Options> fileSystemOptions = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
+        IOptionsSnapshot<ZipWriter.Options> zipOptions = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
 
         // Assert
         _ = generator.ShouldBeOfType<Generator<TestModel>>();
         _ = fileSystemWriter.ShouldBeOfType<FileSystemWriter>();
         _ = zipWriter.ShouldBeOfType<ZipWriter>();
+        fileSystemOptions.Value.BufferSize.ShouldBe(FileSystemWriter.Options.Default.BufferSize);
+        zipOptions.Value.Compression.ShouldBe(ZipWriter.Options.Default.Compression);
+    }
+
+    [Fact]
+    public void GivenConfigurationThenOptionsAreBound()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            { $"{FileSystemWriter.Options.SectionName}:{nameof(FileSystemWriter.Options.BufferSize)}", CustomBufferSize.ToString(CultureInfo.InvariantCulture) },
+            { $"{ZipWriter.Options.SectionName}:{nameof(ZipWriter.Options.Compression)}", CustomCompressionLevel.ToString() },
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        INavigator<TestModel> navigator = Substitute.For<INavigator<TestModel>>();
+        ServiceCollection services = new();
+        _ = services.AddSingleton(navigator);
+
+        // Act
+        _ = services.AddModelling(configuration);
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsSnapshot<FileSystemWriter.Options> fileSystemOptions = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
+        IOptionsSnapshot<ZipWriter.Options> zipOptions = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
+
+        // Assert
+        fileSystemOptions.Value.BufferSize.ShouldBe(CustomBufferSize);
+        zipOptions.Value.Compression.ShouldBe(CustomCompressionLevel);
     }
 
     [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Class is empty for the purposes of the test.")]

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
@@ -1,5 +1,6 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Diagnostics.CodeAnalysis;
 using Graphify;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,12 +25,11 @@ public sealed class WhenAddModellingIsCalled
         IWriter zipWriter = provider.GetRequiredKeyedService<IWriter>(ZipKey);
 
         // Assert
-        generator.ShouldBeOfType<Generator<TestModel>>();
-        fileSystemWriter.ShouldBeOfType<FileSystemWriter>();
-        zipWriter.ShouldBeOfType<ZipWriter>();
+        _ = generator.ShouldBeOfType<Generator<TestModel>>();
+        _ = fileSystemWriter.ShouldBeOfType<FileSystemWriter>();
+        _ = zipWriter.ShouldBeOfType<ZipWriter>();
     }
 
-    private sealed class TestModel
-    {
-    }
+    [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Class is empty for the purposes of the test.")]
+    public sealed class TestModel;
 }

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
@@ -31,6 +31,6 @@ public sealed class WhenAddZipWriterIsCalled
         IWriter writer = provider.GetRequiredKeyedService<IWriter>(ZipKey);
 
         // Assert
-        writer.ShouldBeOfType<ZipWriter>();
+        _ = writer.ShouldBeOfType<ZipWriter>();
     }
 }

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
@@ -1,9 +1,14 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Collections.Generic;
+using System.IO.Compression;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 public sealed class WhenAddZipWriterIsCalled
 {
+    private const CompressionLevel CustomCompressionLevel = CompressionLevel.NoCompression;
     private const string ZipKey = "Zip";
 
     [Fact]
@@ -29,8 +34,32 @@ public sealed class WhenAddZipWriterIsCalled
         _ = services.AddZipWriter();
         using ServiceProvider provider = services.BuildServiceProvider();
         IWriter writer = provider.GetRequiredKeyedService<IWriter>(ZipKey);
+        IOptionsSnapshot<ZipWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
 
         // Assert
         _ = writer.ShouldBeOfType<ZipWriter>();
+        options.Value.Compression.ShouldBe(ZipWriter.Options.Default.Compression);
+    }
+
+    [Fact]
+    public void GivenConfigurationThenOptionsAreBound()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            { $"{ZipWriter.Options.SectionName}:{nameof(ZipWriter.Options.Compression)}", CustomCompressionLevel.ToString() },
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        ServiceCollection services = new();
+
+        // Act
+        _ = services.AddZipWriter(configuration);
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsSnapshot<ZipWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
+
+        // Assert
+        options.Value.Compression.ShouldBe(CustomCompressionLevel);
     }
 }

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
+
+using Microsoft.Extensions.DependencyInjection;
+
+public sealed class WhenAddZipWriterIsCalled
+{
+    private const string ZipKey = "Zip";
+
+    [Fact]
+    public void GivenNullServicesThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        IServiceCollection services = null!;
+
+        // Act
+        Action action = () => services.AddZipWriter();
+
+        // Assert
+        _ = action.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenServicesThenWriterIsRegistered()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        _ = services.AddZipWriter();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IWriter writer = provider.GetRequiredKeyedService<IWriter>(ZipKey);
+
+        // Assert
+        writer.ShouldBeOfType<ZipWriter>();
+    }
+}

--- a/src/MooVC.Modelling.Tests/ZipWriterOptionsTests/WhenDefaultIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ZipWriterOptionsTests/WhenDefaultIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Modelling.ZipWriterOptionsTests;
+
+using System.IO.Compression;
+
+public sealed class WhenDefaultIsCalled
+{
+    [Fact]
+    public void GivenDefaultThenCompressionIsOptimal()
+    {
+        // Arrange
+        // Act
+        ZipWriter.Options options = ZipWriter.Options.Default;
+
+        // Assert
+        options.Compression.ShouldBe(CompressionLevel.Optimal);
+    }
+}

--- a/src/MooVC.Modelling.Tests/ZipWriterTests/WhenWriteIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ZipWriterTests/WhenWriteIsCalled.cs
@@ -1,0 +1,57 @@
+namespace MooVC.Modelling.ZipWriterTests;
+
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+public sealed class WhenWriteIsCalled
+{
+    private const string Content = "Hello, MooVC!";
+    private const string Extension = "txt";
+    private const string Name = "example";
+    private const string PathValue = "Models";
+
+    [Fact]
+    public async Task GivenFilesThenArchiveContainsEntry()
+    {
+        // Arrange
+        File testFile = new(Content, Extension, Name, PathValue);
+        IAsyncEnumerable<File> files = CreateFiles(testFile);
+        IOptionsSnapshot<ZipWriter.Options> optionsSnapshot = CreateOptionsSnapshot();
+        IWriter writer = new ZipWriter(optionsSnapshot);
+        await using var stream = new MemoryStream();
+        string expectedEntryPath = testFile.FilePath
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/');
+
+        // Act
+        await writer.Write(files, stream, CancellationToken.None);
+
+        // Assert
+        stream.Position = 0;
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+        ZipArchiveEntry entry = archive.Entries.Single();
+        entry.FullName.ShouldBe(expectedEntryPath);
+        await using Stream entryStream = entry.Open();
+        using var reader = new StreamReader(entryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: false);
+        string entryContent = await reader.ReadToEndAsync();
+        entryContent.ShouldBe(Content);
+    }
+
+    private static IOptionsSnapshot<ZipWriter.Options> CreateOptionsSnapshot()
+    {
+        IOptionsSnapshot<ZipWriter.Options> optionsSnapshot = Substitute.For<IOptionsSnapshot<ZipWriter.Options>>();
+        optionsSnapshot.Value.Returns(new ZipWriter.Options(CompressionLevel.NoCompression));
+        return optionsSnapshot;
+    }
+
+    private static async IAsyncEnumerable<File> CreateFiles(params File[] files)
+    {
+        foreach (File file in files)
+        {
+            yield return file;
+            await Task.Yield();
+        }
+    }
+}

--- a/src/MooVC.Modelling/FileSystem.cs
+++ b/src/MooVC.Modelling/FileSystem.cs
@@ -2,9 +2,14 @@ namespace MooVC.Modelling;
 
 using System.IO;
 
-internal sealed class SystemFileSystem
+public sealed class FileSystem
     : IFileSystem
 {
+    public string GetCurrentDirectory()
+    {
+        return Directory.GetCurrentDirectory();
+    }
+
     public void CreateDirectory(string path)
     {
         _ = Directory.CreateDirectory(path);
@@ -19,11 +24,6 @@ internal sealed class SystemFileSystem
             FileShare.None,
             bufferSize: bufferSize,
             useAsync: true);
-    }
-
-    public string GetCurrentDirectory()
-    {
-        return Directory.GetCurrentDirectory();
     }
 
     public string? GetDirectoryName(string path)

--- a/src/MooVC.Modelling/FileSystemWriter.Options.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.Options.cs
@@ -4,6 +4,13 @@ public partial class FileSystemWriter
 {
     public sealed record Options(int BufferSize)
     {
+        public const string SectionName = nameof(FileSystemWriter);
+
         public static readonly Options Default = new(4096);
+
+        public Options()
+            : this(Default.BufferSize)
+        {
+        }
     }
 }

--- a/src/MooVC.Modelling/FileSystemWriter.Options.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.Options.cs
@@ -1,6 +1,6 @@
 namespace MooVC.Modelling;
 
-internal partial class FileSystemWriter
+public partial class FileSystemWriter
 {
     public sealed record Options(int BufferSize)
     {

--- a/src/MooVC.Modelling/FileSystemWriter.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
-internal sealed partial class FileSystemWriter(IFileSystem fileSystem, IOptionsSnapshot<FileSystemWriter.Options> options)
+public sealed partial class FileSystemWriter(IFileSystem fileSystem, IOptionsSnapshot<FileSystemWriter.Options> options)
     : IWriter
 {
     public async Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken)

--- a/src/MooVC.Modelling/FileSystemWriter.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
-internal sealed partial class FileSystemWriter(IOptionsSnapshot<FileSystemWriter.Options> options)
+internal sealed partial class FileSystemWriter(IFileSystem fileSystem, IOptionsSnapshot<FileSystemWriter.Options> options)
     : IWriter
 {
     public async Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken)
@@ -26,11 +26,11 @@ internal sealed partial class FileSystemWriter(IOptionsSnapshot<FileSystemWriter
         }
     }
 
-    private static string ResolveRootPath(Stream stream)
+    private string ResolveRootPath(Stream stream)
     {
         if (stream is FileStream fileStream)
         {
-            string? directoryPath = Path.GetDirectoryName(fileStream.Name);
+            string? directoryPath = fileSystem.GetDirectoryName(fileStream.Name);
 
             if (!string.IsNullOrWhiteSpace(directoryPath))
             {
@@ -38,28 +38,22 @@ internal sealed partial class FileSystemWriter(IOptionsSnapshot<FileSystemWriter
             }
         }
 
-        return Directory.GetCurrentDirectory();
+        return fileSystem.GetCurrentDirectory();
     }
 
     private async Task Write(File file, string rootPath, CancellationToken cancellationToken)
     {
-        string filePath = Path.GetFullPath(Path.Combine(rootPath, file.FilePath));
-        string? directoryPath = Path.GetDirectoryName(filePath);
+        string filePath = fileSystem.GetFullPath(Path.Combine(rootPath, file.FilePath));
+        string? directoryPath = fileSystem.GetDirectoryName(filePath);
 
         if (!string.IsNullOrWhiteSpace(directoryPath))
         {
-            _ = Directory.CreateDirectory(directoryPath);
+            fileSystem.CreateDirectory(directoryPath);
         }
 
         byte[] contentBytes = Encoding.UTF8.GetBytes(file.Content);
 
-        await using var stream = new FileStream(
-            filePath,
-            FileMode.Create,
-            FileAccess.Write,
-            FileShare.None,
-            bufferSize: options.Value.BufferSize,
-            useAsync: true);
+        await using Stream stream = fileSystem.CreateFileStream(filePath, options.Value.BufferSize);
 
         await stream
             .WriteAsync(contentBytes, cancellationToken)

--- a/src/MooVC.Modelling/IFileSystem.cs
+++ b/src/MooVC.Modelling/IFileSystem.cs
@@ -1,0 +1,16 @@
+namespace MooVC.Modelling;
+
+using System.IO;
+
+internal interface IFileSystem
+{
+    void CreateDirectory(string path);
+
+    Stream CreateFileStream(string path, int bufferSize);
+
+    string GetCurrentDirectory();
+
+    string? GetDirectoryName(string path);
+
+    string GetFullPath(string path);
+}

--- a/src/MooVC.Modelling/IFileSystem.cs
+++ b/src/MooVC.Modelling/IFileSystem.cs
@@ -2,13 +2,13 @@ namespace MooVC.Modelling;
 
 using System.IO;
 
-internal interface IFileSystem
+public interface IFileSystem
 {
+    string GetCurrentDirectory();
+
     void CreateDirectory(string path);
 
     Stream CreateFileStream(string path, int bufferSize);
-
-    string GetCurrentDirectory();
 
     string? GetDirectoryName(string path);
 

--- a/src/MooVC.Modelling/IWriter.cs
+++ b/src/MooVC.Modelling/IWriter.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-internal interface IWriter
+public interface IWriter
 {
     Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken);
 }

--- a/src/MooVC.Modelling/MooVC.Modelling.csproj
+++ b/src/MooVC.Modelling/MooVC.Modelling.csproj
@@ -8,6 +8,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MooVC\MooVC.csproj" />

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
@@ -1,7 +1,9 @@
 namespace MooVC.Modelling;
 
 using Ardalis.GuardClauses;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
@@ -12,7 +14,26 @@ public static partial class ServiceCollectionExtensions
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
 
+        return services.PerformAddFileSystemWriter(default);
+    }
+
+    public static IServiceCollection AddFileSystemWriter(this IServiceCollection services, IConfiguration configuration)
+    {
+        _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
+        _ = Guard.Against.Null(configuration, message: ConfigurationRequired);
+
+        return services.PerformAddFileSystemWriter(configuration);
+    }
+
+    private static IServiceCollection PerformAddFileSystemWriter(this IServiceCollection services, IConfiguration? configuration)
+    {
         return services
+            .AddOptions<FileSystemWriter.Options>()
+            .ForkOn(
+                _ => configuration is null,
+                builder => builder,
+                builder => builder.Bind(configuration!.GetSection(FileSystemWriter.Options.SectionName)))
+            .Services
             .AddSingleton<IFileSystem, FileSystem>()
             .AddKeyedTransient<IWriter, FileSystemWriter>(FileSystemServiceKey);
     }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
@@ -2,6 +2,7 @@ namespace MooVC.Modelling;
 
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
@@ -11,6 +12,8 @@ public static partial class ServiceCollectionExtensions
     public static IServiceCollection AddFileSystemWriter(this IServiceCollection services)
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
+
+        _ = services.TryAddSingleton<IFileSystem, SystemFileSystem>();
 
         return services.AddKeyedTransient<IWriter, FileSystemWriter>(FileSystemServiceKey);
     }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
@@ -2,7 +2,6 @@ namespace MooVC.Modelling;
 
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
@@ -13,8 +12,8 @@ public static partial class ServiceCollectionExtensions
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
 
-        _ = services.TryAddSingleton<IFileSystem, SystemFileSystem>();
-
-        return services.AddKeyedTransient<IWriter, FileSystemWriter>(FileSystemServiceKey);
+        return services
+            .AddSingleton<IFileSystem, FileSystem>()
+            .AddKeyedTransient<IWriter, FileSystemWriter>(FileSystemServiceKey);
     }
 }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
@@ -1,5 +1,6 @@
 ﻿namespace MooVC.Modelling;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 public static partial class ServiceCollectionExtensions
@@ -10,5 +11,13 @@ public static partial class ServiceCollectionExtensions
             .AddGenerator()
             .AddFileSystemWriter()
             .AddZipWriter();
+    }
+
+    public static IServiceCollection AddModelling(this IServiceCollection services, IConfiguration configuration)
+    {
+        return services
+            .AddGenerator()
+            .AddFileSystemWriter(configuration)
+            .AddZipWriter(configuration);
     }
 }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
@@ -1,7 +1,9 @@
 ﻿namespace MooVC.Modelling;
 
 using Ardalis.GuardClauses;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
@@ -12,6 +14,26 @@ public static partial class ServiceCollectionExtensions
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
 
-        return services.AddKeyedTransient<IWriter, ZipWriter>(ZipServiceKey);
+        return services.PerformAddZipWriter(default);
+    }
+
+    public static IServiceCollection AddZipWriter(this IServiceCollection services, IConfiguration configuration)
+    {
+        _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
+        _ = Guard.Against.Null(configuration, message: ConfigurationRequired);
+
+        return services.PerformAddZipWriter(configuration);
+    }
+
+    private static IServiceCollection PerformAddZipWriter(this IServiceCollection services, IConfiguration? configuration)
+    {
+        return services
+            .AddOptions<ZipWriter.Options>()
+            .ForkOn(
+                _ => configuration is null,
+                builder => builder,
+                builder => builder.Bind(configuration!.GetSection(ZipWriter.Options.SectionName)))
+             .Services
+            .AddKeyedTransient<IWriter, ZipWriter>(ZipServiceKey);
     }
 }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.Designer.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace MooVC.Modelling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The configuration for modelling options must be provided..
+        /// </summary>
+        internal static string ConfigurationRequired {
+            get {
+                return ResourceManager.GetString("ConfigurationRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The collection to which the modelling registrations are to be added must be provided..
         /// </summary>
         internal static string ServiceCollectionRequired {

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.resx
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.resx
@@ -120,4 +120,7 @@
   <data name="ServiceCollectionRequired" xml:space="preserve">
     <value>The collection to which the modelling registrations are to be added must be provided.</value>
   </data>
+  <data name="ConfigurationRequired" xml:space="preserve">
+    <value>The configuration for modelling options must be provided.</value>
+  </data>
 </root>

--- a/src/MooVC.Modelling/SystemFileSystem.cs
+++ b/src/MooVC.Modelling/SystemFileSystem.cs
@@ -1,0 +1,38 @@
+namespace MooVC.Modelling;
+
+using System.IO;
+
+internal sealed class SystemFileSystem
+    : IFileSystem
+{
+    public void CreateDirectory(string path)
+    {
+        _ = Directory.CreateDirectory(path);
+    }
+
+    public Stream CreateFileStream(string path, int bufferSize)
+    {
+        return new FileStream(
+            path,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: bufferSize,
+            useAsync: true);
+    }
+
+    public string GetCurrentDirectory()
+    {
+        return Directory.GetCurrentDirectory();
+    }
+
+    public string? GetDirectoryName(string path)
+    {
+        return Path.GetDirectoryName(path);
+    }
+
+    public string GetFullPath(string path)
+    {
+        return Path.GetFullPath(path);
+    }
+}

--- a/src/MooVC.Modelling/ZipWriter.Options.cs
+++ b/src/MooVC.Modelling/ZipWriter.Options.cs
@@ -6,6 +6,13 @@ public partial class ZipWriter
 {
     public sealed record Options(CompressionLevel Compression)
     {
+        public const string SectionName = nameof(ZipWriter);
+
         public static readonly Options Default = new(CompressionLevel.Optimal);
+
+        public Options()
+            : this(Default.Compression)
+        {
+        }
     }
 }

--- a/src/MooVC.Modelling/ZipWriter.Options.cs
+++ b/src/MooVC.Modelling/ZipWriter.Options.cs
@@ -2,7 +2,7 @@
 
 using System.IO.Compression;
 
-internal partial class ZipWriter
+public partial class ZipWriter
 {
     public sealed record Options(CompressionLevel Compression)
     {

--- a/src/MooVC.Modelling/ZipWriter.cs
+++ b/src/MooVC.Modelling/ZipWriter.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
-internal sealed partial class ZipWriter(IOptionsSnapshot<ZipWriter.Options> options)
+public sealed partial class ZipWriter(IOptionsSnapshot<ZipWriter.Options> options)
     : IWriter
 {
     public async Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken)

--- a/src/MooVC/ObjectExtensions.ForkOn.cs
+++ b/src/MooVC/ObjectExtensions.ForkOn.cs
@@ -13,30 +13,25 @@ public static partial class ObjectExtensions
     /// Facilitates branching logic based on a predicate evaluation.
     /// </summary>
     /// <typeparam name="T">The type upon which the logic is being applied.</typeparam>
+    /// <typeparam name="TResult">The type returned following the Fork operation.</typeparam>
     /// <param name="subject">The instance upon which the logic is being applied.</param>
     /// <param name="predicate">The condition that determines which path to take.</param>
     /// <param name="true">The path to be taken when <paramref name="predicate"/> yields <see langword="true"/>.</param>
     /// <param name="false">The path to be taken when <paramref name="predicate"/> yields <see langword="false"/>.</param>
     /// <remarks>At least one of the optional arguments, <paramref name="true"/> or <paramref name="false"/> must be provided.</remarks>
     /// <returns>The <paramref name="subject"/> instance following application of the appropriate path.</returns>
-    public static T ForkOn<T>(this T subject, Predicate<T> predicate, Func<T, T>? @true = default, Func<T, T>? @false = default)
+    public static TResult ForkOn<T, TResult>(this T subject, Predicate<T> predicate, Func<T, TResult> @true, Func<T, TResult> @false)
     {
         _ = Guard.Against.Null(subject, message: ForkOnSubjectRequired);
         _ = Guard.Against.Null(predicate, message: ForkOnPredicateRequired);
-        _ = Guard.Against.InvalidInput(@true, nameof(@true), _ => @true is not null || @false is not null, message: ForkOnPathsRequired);
+        _ = Guard.Against.Null(@true, message: ForkOnPathsRequired);
+        _ = Guard.Against.Null(@false, message: ForkOnPathsRequired);
 
         if (predicate(subject))
         {
-            if (@true is not null)
-            {
-                return @true(subject);
-            }
-        }
-        else if (@false is not null)
-        {
-            return @false(subject);
+            return @true(subject);
         }
 
-        return subject;
+        return @false(subject);
     }
 }


### PR DESCRIPTION
### Motivation

- Add unit test coverage for the classes and extension methods in `MooVC.Modelling`.  
- Make `FileSystemWriter` testable without touching the real filesystem by introducing an abstraction for file operations.  
- Ensure DI registration supports the new abstraction while preserving the existing runtime behavior.

### Description

- Introduce an `IFileSystem` abstraction and a `SystemFileSystem` implementation to encapsulate filesystem operations used by the writer.  
- Refactor `FileSystemWriter` to accept `IFileSystem` and replace direct uses of `Directory`, `Path`, and `FileStream` with calls to the injected `IFileSystem`.  
- Register `SystemFileSystem` in DI with `TryAddSingleton<IFileSystem, SystemFileSystem>()` and keep registering `FileSystemWriter` via the keyed transient helper.  
- Add a new test project `src/MooVC.Modelling.Tests` and tests covering `File`, `FileSystemWriter` (with an in-memory file system), `ZipWriter`, `Generator`, and the `ServiceCollectionExtensions` helpers, plus small in-memory helpers (`InMemoryFileSystem`/`InMemoryFileStream`) used by the tests.

### Testing

- Attempted to run the test suite with `dotnet test`, but the command failed in this environment because the .NET SDK is not available (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979fdceb920832f82d08ed506608f8b)