### PR TITLE
Add IConfiguration overloads to bind writer options in DI registrations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,10 +12,12 @@
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="[3.11.0,3.12.0)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.4.0,4.5.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Monify" Version="1.3.2" />

--- a/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
+++ b/src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 </Project>

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
@@ -51,9 +51,11 @@ public sealed class WhenAddFileSystemWriterIsCalled
         {
             { $"{FileSystemWriter.Options.SectionName}:{nameof(FileSystemWriter.Options.BufferSize)}", CustomBufferSize.ToString(CultureInfo.InvariantCulture) },
         };
+
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(settings)
             .Build();
+
         ServiceCollection services = new();
 
         // Act

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddFileSystemWriterIsCalled.cs
@@ -1,9 +1,14 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 public sealed class WhenAddFileSystemWriterIsCalled
 {
+    private const int CustomBufferSize = 8192;
     private const string FileSystemKey = "FileSystem";
 
     [Fact]
@@ -30,9 +35,33 @@ public sealed class WhenAddFileSystemWriterIsCalled
         using ServiceProvider provider = services.BuildServiceProvider();
         IWriter writer = provider.GetRequiredKeyedService<IWriter>(FileSystemKey);
         IFileSystem fileSystem = provider.GetRequiredService<IFileSystem>();
+        IOptionsSnapshot<FileSystemWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
 
         // Assert
         _ = writer.ShouldBeOfType<FileSystemWriter>();
         _ = fileSystem.ShouldNotBeNull();
+        options.Value.BufferSize.ShouldBe(FileSystemWriter.Options.Default.BufferSize);
+    }
+
+    [Fact]
+    public void GivenConfigurationThenOptionsAreBound()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            { $"{FileSystemWriter.Options.SectionName}:{nameof(FileSystemWriter.Options.BufferSize)}", CustomBufferSize.ToString(CultureInfo.InvariantCulture) },
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        ServiceCollection services = new();
+
+        // Act
+        _ = services.AddFileSystemWriter(configuration);
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsSnapshot<FileSystemWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
+
+        // Assert
+        options.Value.BufferSize.ShouldBe(CustomBufferSize);
     }
 }

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddModellingIsCalled.cs
@@ -1,11 +1,18 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO.Compression;
 using Graphify;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 public sealed class WhenAddModellingIsCalled
 {
+    private const int CustomBufferSize = 2048;
+    private const CompressionLevel CustomCompressionLevel = CompressionLevel.NoCompression;
     private const string FileSystemKey = "FileSystem";
     private const string ZipKey = "Zip";
 
@@ -23,11 +30,42 @@ public sealed class WhenAddModellingIsCalled
         IGenerator<TestModel> generator = provider.GetRequiredService<IGenerator<TestModel>>();
         IWriter fileSystemWriter = provider.GetRequiredKeyedService<IWriter>(FileSystemKey);
         IWriter zipWriter = provider.GetRequiredKeyedService<IWriter>(ZipKey);
+        IOptionsSnapshot<FileSystemWriter.Options> fileSystemOptions = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
+        IOptionsSnapshot<ZipWriter.Options> zipOptions = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
 
         // Assert
         _ = generator.ShouldBeOfType<Generator<TestModel>>();
         _ = fileSystemWriter.ShouldBeOfType<FileSystemWriter>();
         _ = zipWriter.ShouldBeOfType<ZipWriter>();
+        fileSystemOptions.Value.BufferSize.ShouldBe(FileSystemWriter.Options.Default.BufferSize);
+        zipOptions.Value.Compression.ShouldBe(ZipWriter.Options.Default.Compression);
+    }
+
+    [Fact]
+    public void GivenConfigurationThenOptionsAreBound()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            { $"{FileSystemWriter.Options.SectionName}:{nameof(FileSystemWriter.Options.BufferSize)}", CustomBufferSize.ToString(CultureInfo.InvariantCulture) },
+            { $"{ZipWriter.Options.SectionName}:{nameof(ZipWriter.Options.Compression)}", CustomCompressionLevel.ToString() },
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        INavigator<TestModel> navigator = Substitute.For<INavigator<TestModel>>();
+        ServiceCollection services = new();
+        _ = services.AddSingleton(navigator);
+
+        // Act
+        _ = services.AddModelling(configuration);
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsSnapshot<FileSystemWriter.Options> fileSystemOptions = provider.GetRequiredService<IOptionsSnapshot<FileSystemWriter.Options>>();
+        IOptionsSnapshot<ZipWriter.Options> zipOptions = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
+
+        // Assert
+        fileSystemOptions.Value.BufferSize.ShouldBe(CustomBufferSize);
+        zipOptions.Value.Compression.ShouldBe(CustomCompressionLevel);
     }
 
     [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Class is empty for the purposes of the test.")]

--- a/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/ServiceCollectionExtensionsTests/WhenAddZipWriterIsCalled.cs
@@ -1,9 +1,14 @@
 namespace MooVC.Modelling.ServiceCollectionExtensionsTests;
 
+using System.Collections.Generic;
+using System.IO.Compression;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 public sealed class WhenAddZipWriterIsCalled
 {
+    private const CompressionLevel CustomCompressionLevel = CompressionLevel.NoCompression;
     private const string ZipKey = "Zip";
 
     [Fact]
@@ -29,8 +34,32 @@ public sealed class WhenAddZipWriterIsCalled
         _ = services.AddZipWriter();
         using ServiceProvider provider = services.BuildServiceProvider();
         IWriter writer = provider.GetRequiredKeyedService<IWriter>(ZipKey);
+        IOptionsSnapshot<ZipWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
 
         // Assert
         _ = writer.ShouldBeOfType<ZipWriter>();
+        options.Value.Compression.ShouldBe(ZipWriter.Options.Default.Compression);
+    }
+
+    [Fact]
+    public void GivenConfigurationThenOptionsAreBound()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            { $"{ZipWriter.Options.SectionName}:{nameof(ZipWriter.Options.Compression)}", CustomCompressionLevel.ToString() },
+        };
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        ServiceCollection services = new();
+
+        // Act
+        _ = services.AddZipWriter(configuration);
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsSnapshot<ZipWriter.Options> options = provider.GetRequiredService<IOptionsSnapshot<ZipWriter.Options>>();
+
+        // Assert
+        options.Value.Compression.ShouldBe(CustomCompressionLevel);
     }
 }

--- a/src/MooVC.Modelling/FileSystemWriter.Options.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.Options.cs
@@ -4,6 +4,13 @@ public partial class FileSystemWriter
 {
     public sealed record Options(int BufferSize)
     {
+        public const string SectionName = nameof(FileSystemWriter);
+
         public static readonly Options Default = new(4096);
+
+        public Options()
+            : this(Default.BufferSize)
+        {
+        }
     }
 }

--- a/src/MooVC.Modelling/MooVC.Modelling.csproj
+++ b/src/MooVC.Modelling/MooVC.Modelling.csproj
@@ -8,6 +8,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MooVC\MooVC.csproj" />

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
@@ -1,6 +1,7 @@
 namespace MooVC.Modelling;
 
 using Ardalis.GuardClauses;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
@@ -13,6 +14,21 @@ public static partial class ServiceCollectionExtensions
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
 
         return services
+            .AddOptions<FileSystemWriter.Options>()
+            .AddSingleton<IFileSystem, FileSystem>()
+            .AddKeyedTransient<IWriter, FileSystemWriter>(FileSystemServiceKey);
+    }
+
+    public static IServiceCollection AddFileSystemWriter(this IServiceCollection services, IConfiguration configuration)
+    {
+        _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
+        _ = Guard.Against.Null(configuration, message: ConfigurationRequired);
+
+        var optionsBuilder = services
+            .AddOptions<FileSystemWriter.Options>()
+            .Bind(configuration.GetSection(FileSystemWriter.Options.SectionName));
+
+        return optionsBuilder.Services
             .AddSingleton<IFileSystem, FileSystem>()
             .AddKeyedTransient<IWriter, FileSystemWriter>(FileSystemServiceKey);
     }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
@@ -1,6 +1,9 @@
 ﻿namespace MooVC.Modelling;
 
+using Ardalis.GuardClauses;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
 {
@@ -10,5 +13,16 @@ public static partial class ServiceCollectionExtensions
             .AddGenerator()
             .AddFileSystemWriter()
             .AddZipWriter();
+    }
+
+    public static IServiceCollection AddModelling(this IServiceCollection services, IConfiguration configuration)
+    {
+        _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
+        _ = Guard.Against.Null(configuration, message: ConfigurationRequired);
+
+        return services
+            .AddGenerator()
+            .AddFileSystemWriter(configuration)
+            .AddZipWriter(configuration);
     }
 }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
@@ -1,9 +1,7 @@
 ﻿namespace MooVC.Modelling;
 
-using Ardalis.GuardClauses;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
 {
@@ -17,9 +15,6 @@ public static partial class ServiceCollectionExtensions
 
     public static IServiceCollection AddModelling(this IServiceCollection services, IConfiguration configuration)
     {
-        _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
-        _ = Guard.Against.Null(configuration, message: ConfigurationRequired);
-
         return services
             .AddGenerator()
             .AddFileSystemWriter(configuration)

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
@@ -1,6 +1,7 @@
 ﻿namespace MooVC.Modelling;
 
 using Ardalis.GuardClauses;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
@@ -12,6 +13,21 @@ public static partial class ServiceCollectionExtensions
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
 
-        return services.AddKeyedTransient<IWriter, ZipWriter>(ZipServiceKey);
+        return services
+            .AddOptions<ZipWriter.Options>()
+            .AddKeyedTransient<IWriter, ZipWriter>(ZipServiceKey);
+    }
+
+    public static IServiceCollection AddZipWriter(this IServiceCollection services, IConfiguration configuration)
+    {
+        _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
+        _ = Guard.Against.Null(configuration, message: ConfigurationRequired);
+
+        var optionsBuilder = services
+            .AddOptions<ZipWriter.Options>()
+            .Bind(configuration.GetSection(ZipWriter.Options.SectionName));
+
+        return optionsBuilder.Services
+            .AddKeyedTransient<IWriter, ZipWriter>(ZipServiceKey);
     }
 }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
@@ -3,6 +3,7 @@
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
@@ -13,9 +14,7 @@ public static partial class ServiceCollectionExtensions
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
 
-        return services
-            .AddOptions<ZipWriter.Options>()
-            .AddKeyedTransient<IWriter, ZipWriter>(ZipServiceKey);
+        return services.PerformAddZipWriter(default);
     }
 
     public static IServiceCollection AddZipWriter(this IServiceCollection services, IConfiguration configuration)
@@ -23,11 +22,18 @@ public static partial class ServiceCollectionExtensions
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
         _ = Guard.Against.Null(configuration, message: ConfigurationRequired);
 
-        var optionsBuilder = services
-            .AddOptions<ZipWriter.Options>()
-            .Bind(configuration.GetSection(ZipWriter.Options.SectionName));
+        return services.PerformAddZipWriter(configuration);
+    }
 
-        return optionsBuilder.Services
+    private static IServiceCollection PerformAddZipWriter(this IServiceCollection services, IConfiguration? configuration)
+    {
+        return services
+            .AddOptions<ZipWriter.Options>()
+            .ForkOn(
+                _ => configuration is null,
+                builder => builder,
+                builder => builder.Bind(configuration!.GetSection(ZipWriter.Options.SectionName)))
+             .Services
             .AddKeyedTransient<IWriter, ZipWriter>(ZipServiceKey);
     }
 }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.Designer.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace MooVC.Modelling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The configuration for modelling options must be provided..
+        /// </summary>
+        internal static string ConfigurationRequired {
+            get {
+                return ResourceManager.GetString("ConfigurationRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The collection to which the modelling registrations are to be added must be provided..
         /// </summary>
         internal static string ServiceCollectionRequired {

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.resx
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.Resources.resx
@@ -120,4 +120,7 @@
   <data name="ServiceCollectionRequired" xml:space="preserve">
     <value>The collection to which the modelling registrations are to be added must be provided.</value>
   </data>
+  <data name="ConfigurationRequired" xml:space="preserve">
+    <value>The configuration for modelling options must be provided.</value>
+  </data>
 </root>

--- a/src/MooVC.Modelling/ZipWriter.Options.cs
+++ b/src/MooVC.Modelling/ZipWriter.Options.cs
@@ -6,6 +6,13 @@ public partial class ZipWriter
 {
     public sealed record Options(CompressionLevel Compression)
     {
+        public const string SectionName = nameof(ZipWriter);
+
         public static readonly Options Default = new(CompressionLevel.Optimal);
+
+        public Options()
+            : this(Default.Compression)
+        {
+        }
     }
 }

--- a/src/MooVC/ObjectExtensions.ForkOn.cs
+++ b/src/MooVC/ObjectExtensions.ForkOn.cs
@@ -13,30 +13,25 @@ public static partial class ObjectExtensions
     /// Facilitates branching logic based on a predicate evaluation.
     /// </summary>
     /// <typeparam name="T">The type upon which the logic is being applied.</typeparam>
+    /// <typeparam name="TResult">The type returned following the Fork operation.</typeparam>
     /// <param name="subject">The instance upon which the logic is being applied.</param>
     /// <param name="predicate">The condition that determines which path to take.</param>
     /// <param name="true">The path to be taken when <paramref name="predicate"/> yields <see langword="true"/>.</param>
     /// <param name="false">The path to be taken when <paramref name="predicate"/> yields <see langword="false"/>.</param>
     /// <remarks>At least one of the optional arguments, <paramref name="true"/> or <paramref name="false"/> must be provided.</remarks>
     /// <returns>The <paramref name="subject"/> instance following application of the appropriate path.</returns>
-    public static T ForkOn<T>(this T subject, Predicate<T> predicate, Func<T, T>? @true = default, Func<T, T>? @false = default)
+    public static TResult ForkOn<T, TResult>(this T subject, Predicate<T> predicate, Func<T, TResult> @true, Func<T, TResult> @false)
     {
         _ = Guard.Against.Null(subject, message: ForkOnSubjectRequired);
         _ = Guard.Against.Null(predicate, message: ForkOnPredicateRequired);
-        _ = Guard.Against.InvalidInput(@true, nameof(@true), _ => @true is not null || @false is not null, message: ForkOnPathsRequired);
+        _ = Guard.Against.Null(@true, message: ForkOnPathsRequired);
+        _ = Guard.Against.Null(@false, message: ForkOnPathsRequired);
 
         if (predicate(subject))
         {
-            if (@true is not null)
-            {
-                return @true(subject);
-            }
-        }
-        else if (@false is not null)
-        {
-            return @false(subject);
+            return @true(subject);
         }
 
-        return subject;
+        return @false(subject);
     }
 }


### PR DESCRIPTION
### Motivation

- Allow consumers to bind writer options from an `IConfiguration` source when registering modelling services so options can be provided from config files or environment settings. 
- Surface a descriptive resource for missing configuration and validate option-binding scenarios in unit tests.

### Description

- Added `SectionName` constants and parameterless constructors to `FileSystemWriter.Options` and `ZipWriter.Options` so options can be activated and referenced by configuration section name. 
- Added overloads `AddFileSystemWriter(this IServiceCollection, IConfiguration)` and `AddZipWriter(this IServiceCollection, IConfiguration)` that call `.AddOptions<T>().Bind(configuration.GetSection(...))` and keep existing service registrations. 
- Added `AddModelling(this IServiceCollection, IConfiguration)` that composes the configuration-aware registrations for generator and writers. 
- Added a `ConfigurationRequired` resource string and guards to validate provided `IConfiguration`, and expanded tests to assert default registration and configuration binding.

### Testing

- Added/updated unit tests: `WhenAddFileSystemWriterIsCalled`, `WhenAddZipWriterIsCalled`, and `WhenAddModellingIsCalled` to verify default option availability and that configuration values are bound to `IOptionsSnapshot<T>`; these tests were added to the test project but not executed in this environment. 
- `dotnet test` was not run here because the .NET SDK was unavailable in the environment, so automated tests were not executed in CI from this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a23f4dfec832fad1fa7b817e7a284)