### PR TITLE
Add XML documentation headers in MooVC.Modelling

### DIFF
--- a/src/MooVC.Modelling/File.cs
+++ b/src/MooVC.Modelling/File.cs
@@ -2,9 +2,22 @@
 
 using static System.IO.Path;
 
+/// <summary>
+/// Represents a file to be written by a modelling writer.
+/// </summary>
+/// <param name="Content">The file content.</param>
+/// <param name="Extension">The file extension.</param>
+/// <param name="Name">The file name without extension.</param>
+/// <param name="Path">The file path relative to the output root.</param>
 public sealed record File(string Content, string Extension, string Name, string Path)
 {
+    /// <summary>
+    /// Gets the file name including the extension.
+    /// </summary>
     public string FileName => string.Concat(Name, ".", Extension);
 
+    /// <summary>
+    /// Gets the file path including the file name.
+    /// </summary>
     public string FilePath => Combine(Path, FileName);
 }

--- a/src/MooVC.Modelling/FileSystem.cs
+++ b/src/MooVC.Modelling/FileSystem.cs
@@ -2,19 +2,36 @@ namespace MooVC.Modelling;
 
 using System.IO;
 
+/// <summary>
+/// Provides file system operations for modelling writers.
+/// </summary>
 public sealed class FileSystem
     : IFileSystem
 {
+    /// <summary>
+    /// Gets the current working directory.
+    /// </summary>
+    /// <returns>The current working directory.</returns>
     public string GetCurrentDirectory()
     {
         return Directory.GetCurrentDirectory();
     }
 
+    /// <summary>
+    /// Creates a directory at the provided path.
+    /// </summary>
+    /// <param name="path">The directory path to create.</param>
     public void CreateDirectory(string path)
     {
         _ = Directory.CreateDirectory(path);
     }
 
+    /// <summary>
+    /// Creates a writable file stream at the provided path.
+    /// </summary>
+    /// <param name="path">The file path to create.</param>
+    /// <param name="bufferSize">The buffer size to use.</param>
+    /// <returns>The file stream.</returns>
     public Stream CreateFileStream(string path, int bufferSize)
     {
         return new FileStream(
@@ -26,11 +43,21 @@ public sealed class FileSystem
             useAsync: true);
     }
 
+    /// <summary>
+    /// Gets the directory name for the provided path.
+    /// </summary>
+    /// <param name="path">The path to evaluate.</param>
+    /// <returns>The directory name, if available.</returns>
     public string? GetDirectoryName(string path)
     {
         return Path.GetDirectoryName(path);
     }
 
+    /// <summary>
+    /// Gets the full path for the provided path.
+    /// </summary>
+    /// <param name="path">The path to resolve.</param>
+    /// <returns>The full path.</returns>
     public string GetFullPath(string path)
     {
         return Path.GetFullPath(path);

--- a/src/MooVC.Modelling/FileSystemWriter.Options.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.Options.cs
@@ -2,12 +2,24 @@ namespace MooVC.Modelling;
 
 public partial class FileSystemWriter
 {
+    /// <summary>
+    /// Represents configuration options for <see cref="FileSystemWriter"/>.
+    /// </summary>
     public sealed record Options(int BufferSize)
     {
+        /// <summary>
+        /// Gets the configuration section name for these options.
+        /// </summary>
         public const string SectionName = nameof(FileSystemWriter);
 
+        /// <summary>
+        /// Gets the default options instance.
+        /// </summary>
         public static readonly Options Default = new(4096);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Options"/> record.
+        /// </summary>
         public Options()
             : this(Default.BufferSize)
         {

--- a/src/MooVC.Modelling/FileSystemWriter.cs
+++ b/src/MooVC.Modelling/FileSystemWriter.cs
@@ -8,9 +8,21 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
+/// <summary>
+/// Writes modelling files to the local file system.
+/// </summary>
+/// <param name="fileSystem">The file system abstraction to use.</param>
+/// <param name="options">The configured writer options.</param>
 public sealed partial class FileSystemWriter(IFileSystem fileSystem, IOptionsSnapshot<FileSystemWriter.Options> options)
     : IWriter
 {
+    /// <summary>
+    /// Writes the provided files to the target stream location.
+    /// </summary>
+    /// <param name="files">The files to write.</param>
+    /// <param name="stream">The stream associated with the output location.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
     public async Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken)
     {
         string rootPath = ResolveRootPath(stream);

--- a/src/MooVC.Modelling/Generator.cs
+++ b/src/MooVC.Modelling/Generator.cs
@@ -5,10 +5,21 @@ using System.Collections.Generic;
 using Graphify;
 using Microsoft.Extensions.DependencyInjection;
 
+/// <summary>
+/// Generates modelling files by navigating a model graph.
+/// </summary>
+/// <typeparam name="TModel">The model type.</typeparam>
+/// <param name="provider">The service provider used to resolve the navigator.</param>
 internal sealed class Generator<TModel>(IServiceProvider provider)
     : IGenerator<TModel>
     where TModel : class
 {
+    /// <summary>
+    /// Generates files for the provided model.
+    /// </summary>
+    /// <param name="model">The model to generate from.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The generated files.</returns>
     public IAsyncEnumerable<File> Generate(TModel model, CancellationToken cancellationToken)
     {
         INavigator<TModel> navigator = provider.GetRequiredService<INavigator<TModel>>();

--- a/src/MooVC.Modelling/IFileSystem.cs
+++ b/src/MooVC.Modelling/IFileSystem.cs
@@ -2,15 +2,42 @@ namespace MooVC.Modelling;
 
 using System.IO;
 
+/// <summary>
+/// Defines file system operations required by modelling writers.
+/// </summary>
 public interface IFileSystem
 {
+    /// <summary>
+    /// Gets the current working directory.
+    /// </summary>
+    /// <returns>The current working directory.</returns>
     string GetCurrentDirectory();
 
+    /// <summary>
+    /// Creates a directory at the provided path.
+    /// </summary>
+    /// <param name="path">The directory path to create.</param>
     void CreateDirectory(string path);
 
+    /// <summary>
+    /// Creates a writable file stream at the provided path.
+    /// </summary>
+    /// <param name="path">The file path to create.</param>
+    /// <param name="bufferSize">The buffer size to use.</param>
+    /// <returns>The file stream.</returns>
     Stream CreateFileStream(string path, int bufferSize);
 
+    /// <summary>
+    /// Gets the directory name for the provided path.
+    /// </summary>
+    /// <param name="path">The path to evaluate.</param>
+    /// <returns>The directory name, if available.</returns>
     string? GetDirectoryName(string path);
 
+    /// <summary>
+    /// Gets the full path for the provided path.
+    /// </summary>
+    /// <param name="path">The path to resolve.</param>
+    /// <returns>The full path.</returns>
     string GetFullPath(string path);
 }

--- a/src/MooVC.Modelling/IGenerator.cs
+++ b/src/MooVC.Modelling/IGenerator.cs
@@ -3,8 +3,18 @@
 using System.Collections.Generic;
 using System.Threading;
 
+/// <summary>
+/// Defines a generator for modelling files from a model instance.
+/// </summary>
+/// <typeparam name="TModel">The model type.</typeparam>
 public interface IGenerator<TModel>
     where TModel : class
 {
+    /// <summary>
+    /// Generates files for the provided model.
+    /// </summary>
+    /// <param name="model">The model to generate from.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The generated files.</returns>
     IAsyncEnumerable<File> Generate(TModel model, CancellationToken cancellationToken);
 }

--- a/src/MooVC.Modelling/IWriter.cs
+++ b/src/MooVC.Modelling/IWriter.cs
@@ -5,7 +5,17 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Defines a writer for modelling files.
+/// </summary>
 public interface IWriter
 {
+    /// <summary>
+    /// Writes the provided files to the target stream.
+    /// </summary>
+    /// <param name="files">The files to write.</param>
+    /// <param name="stream">The target stream.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
     Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken);
 }

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddFileSystemWriter.cs
@@ -10,6 +10,11 @@ public static partial class ServiceCollectionExtensions
 {
     private const string FileSystemServiceKey = "FileSystem";
 
+    /// <summary>
+    /// Adds the file system writer services with default options.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddFileSystemWriter(this IServiceCollection services)
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
@@ -17,6 +22,12 @@ public static partial class ServiceCollectionExtensions
         return services.PerformAddFileSystemWriter(default);
     }
 
+    /// <summary>
+    /// Adds the file system writer services using the provided configuration.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">The configuration to bind options from.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddFileSystemWriter(this IServiceCollection services, IConfiguration configuration)
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddGenerator.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddGenerator.cs
@@ -6,6 +6,11 @@ using static MooVC.Modelling.ServiceCollectionExtensions_Resources;
 
 public static partial class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds generator services for modelling.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddGenerator(this IServiceCollection services)
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddModelling.cs
@@ -3,8 +3,16 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
+/// <summary>
+/// Provides service collection extensions for modelling services.
+/// </summary>
 public static partial class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds modelling services with default configuration sources.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddModelling(this IServiceCollection services)
     {
         return services
@@ -13,6 +21,12 @@ public static partial class ServiceCollectionExtensions
             .AddZipWriter();
     }
 
+    /// <summary>
+    /// Adds modelling services using the provided configuration.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">The configuration to bind options from.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddModelling(this IServiceCollection services, IConfiguration configuration)
     {
         return services

--- a/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
+++ b/src/MooVC.Modelling/ServiceCollectionExtensions.AddZipWriter.cs
@@ -10,6 +10,11 @@ public static partial class ServiceCollectionExtensions
 {
     private const string ZipServiceKey = "Zip";
 
+    /// <summary>
+    /// Adds the zip writer services with default options.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddZipWriter(this IServiceCollection services)
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);
@@ -17,6 +22,12 @@ public static partial class ServiceCollectionExtensions
         return services.PerformAddZipWriter(default);
     }
 
+    /// <summary>
+    /// Adds the zip writer services using the provided configuration.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">The configuration to bind options from.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddZipWriter(this IServiceCollection services, IConfiguration configuration)
     {
         _ = Guard.Against.Null(services, message: ServiceCollectionRequired);

--- a/src/MooVC.Modelling/ZipWriter.Options.cs
+++ b/src/MooVC.Modelling/ZipWriter.Options.cs
@@ -4,12 +4,24 @@ using System.IO.Compression;
 
 public partial class ZipWriter
 {
+    /// <summary>
+    /// Represents configuration options for <see cref="ZipWriter"/>.
+    /// </summary>
     public sealed record Options(CompressionLevel Compression)
     {
+        /// <summary>
+        /// Gets the configuration section name for these options.
+        /// </summary>
         public const string SectionName = nameof(ZipWriter);
 
+        /// <summary>
+        /// Gets the default options instance.
+        /// </summary>
         public static readonly Options Default = new(CompressionLevel.Optimal);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Options"/> record.
+        /// </summary>
         public Options()
             : this(Default.Compression)
         {

--- a/src/MooVC.Modelling/ZipWriter.cs
+++ b/src/MooVC.Modelling/ZipWriter.cs
@@ -9,9 +9,20 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
+/// <summary>
+/// Writes modelling files to a zip archive.
+/// </summary>
+/// <param name="options">The configured writer options.</param>
 public sealed partial class ZipWriter(IOptionsSnapshot<ZipWriter.Options> options)
     : IWriter
 {
+    /// <summary>
+    /// Writes the provided files to the target stream as a zip archive.
+    /// </summary>
+    /// <param name="files">The files to write.</param>
+    /// <param name="stream">The target stream.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
     public async Task Write(IAsyncEnumerable<File> files, Stream stream, CancellationToken cancellationToken)
     {
         using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);


### PR DESCRIPTION
### Motivation

- Improve inline API documentation for the modelling components to clarify usage and intent of public types and members.
- Ensure public-facing modelling abstractions have XML docs to aid consumers and tooling such as IntelliSense.

### Description

- Added XML documentation comments to public types and members in the `MooVC.Modelling` assembly, including `File`, `FileSystem`, `FileSystemWriter`, `ZipWriter`, `Generator<TModel>`, the `Options` records, and the `IFileSystem`, `IGenerator<TModel>`, and `IWriter` interfaces.
- Documented service registration extension methods in `ServiceCollectionExtensions` overloads for modelling, file system writer, generator, and zip writer.
- Clarified purpose and parameters/returns for public methods and option records using standard XML doc tags on files such as `src/MooVC.Modelling/File.cs`, `src/MooVC.Modelling/FileSystem.cs`, `src/MooVC.Modelling/FileSystemWriter.cs`, `src/MooVC.Modelling/ZipWriter.cs`, and related `*.Options.cs` and `ServiceCollectionExtensions.*.cs` files.
- Kept the change documentation-only and aligned formatting with repository conventions (no behavior changes).

### Testing

- No automated tests were executed for this documentation-only change (`dotnet test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2e748974832fbc5234497dabc788)