### PR TITLE
Refactor Snippet to capture Options at construction

### DIFF
--- a/src/MooVC.Syntax.CSharp/Concepts/Definition.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/Definition.cs
@@ -94,20 +94,20 @@
             if (!usings.IsEmpty)
             {
                 type = type
-                    .Prepend(options.Snippets, Environment.NewLine)
-                    .Prepend(options.Snippets, usings);
+                    .Prepend(Environment.NewLine)
+                    .Prepend(usings);
             }
 
             if (options.Namespace.IsBlock)
             {
-                return type.Block(options.Snippets, @namespace);
+                return type.Block(@namespace);
             }
 
             @namespace = @namespace
                 .Append(';')
                 .Append(Environment.NewLine);
 
-            return type.Stack(options.Snippets, @namespace);
+            return type.Stack(@namespace);
         }
 
         /// <summary>

--- a/src/MooVC.Syntax.CSharp/Concepts/Interface.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/Interface.cs
@@ -55,9 +55,9 @@
                 .ToImmutableArray()
                 .ToSnippet(new Method.Options { Implied = Scope.Public, Snippets = options });
 
-            Snippet body = Snippet.Blank.Combine(options, events, properties, indexers, methods);
+            Snippet body = Snippet.From(options, string.Empty).Combine(events, properties, indexers, methods);
 
-            return body.Block(options, signature);
+            return body.Block(signature);
         }
 
         private Snippet GetSignature(Snippet.Options options)
@@ -72,10 +72,10 @@
             if (!clauses.IsEmpty)
             {
                 return clauses
-                    .Shift(options)
-                    .Prepend(options, Environment.NewLine)
-                    .Prepend(options, signature)
-                    .Prepend(options, attributes);
+                    .Shift()
+                    .Prepend(Environment.NewLine)
+                    .Prepend(signature)
+                    .Prepend(attributes);
             }
 
             return Snippet.From(options, signature);

--- a/src/MooVC.Syntax.CSharp/Concepts/Reference.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/Reference.cs
@@ -126,11 +126,11 @@
             var operators = Operators.ToSnippet(options, this);
             var properties = Properties.ToSnippet(Property.Options.Default.WithSnippets(options));
             var methods = Methods.ToSnippet(Method.Options.Default.WithSnippets(options));
-            Snippet body = Snippet.Blank.Combine(options, fields, constructors, events, properties, indexers, operators, methods);
+            Snippet body = Snippet.From(options, string.Empty).Combine(fields, constructors, events, properties, indexers, operators, methods);
 
             return body
-                .Block(options, signature)
-                .Prepend(options, attributes);
+                .Block(signature)
+                .Prepend(attributes);
         }
 
         private Snippet GetSignature(Snippet.Options options)
@@ -151,9 +151,9 @@
             if (!clauses.IsEmpty)
             {
                 return clauses
-                    .Shift(options)
-                    .Prepend(options, Environment.NewLine)
-                    .Prepend(options, signature);
+                    .Shift()
+                    .Prepend(Environment.NewLine)
+                    .Prepend(signature);
             }
 
             return Snippet.From(options, signature);

--- a/src/MooVC.Syntax.CSharp/Concepts/Struct.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/Struct.cs
@@ -103,10 +103,10 @@
             var operators = Operators.ToSnippet(options, this);
             var properties = Properties.ToSnippet(Property.Options.Default.WithSnippets(options));
             var methods = Methods.ToSnippet(Method.Options.Default.WithSnippets(options));
-            Snippet body = Snippet.Blank.Combine(options, fields, constructors, events, indexers, properties, operators, methods);
+            Snippet body = Snippet.From(options, string.Empty).Combine(fields, constructors, events, indexers, properties, operators, methods);
 
             return body
-                .Block(options, signature)
+                .Block(signature)
                 .Prepend(attributes);
         }
 
@@ -128,9 +128,9 @@
             if (!clauses.IsEmpty)
             {
                 return clauses
-                    .Shift(options)
-                    .Prepend(options, Environment.NewLine)
-                    .Prepend(options, signature);
+                    .Shift()
+                    .Prepend(Environment.NewLine)
+                    .Prepend(signature);
             }
 
             return Snippet.From(options, signature);

--- a/src/MooVC.Syntax.CSharp/Concepts/TypeExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/TypeExtensions.ToSnippet.cs
@@ -29,7 +29,7 @@
                 .Select(type => type.ToSnippet(options))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options, content);
+            return Snippet.From(options, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Attribute.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Attribute.cs
@@ -154,7 +154,7 @@
                 .Select(argument => argument.ToSnippet(declaration))
                 .ToArray();
 
-            Snippet syntax = separator.Combine(options, arguments);
+            Snippet syntax = separator.Combine(arguments);
 
             return value.Append($"({syntax})");
         }

--- a/src/MooVC.Syntax.CSharp/Members/AttributeExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/AttributeExtensions.ToSnippet.cs
@@ -27,7 +27,7 @@
                 .OrderBy(attribute => attribute.Name)
                 .Select(attribute => Snippet.From(options, attribute))
                 .ToImmutableArray()
-                .Stack(options);
+                .Stack();
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Constructor.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Constructor.cs
@@ -150,7 +150,7 @@ namespace MooVC.Syntax.CSharp.Members
 
             return Snippet
                 .From(options, signature)
-                .Prepend(options, attributes);
+                .Prepend(attributes);
         }
 
         private string ToSnippet(Name name, Snippet.Options options)
@@ -164,7 +164,7 @@ namespace MooVC.Syntax.CSharp.Members
 
             Snippet signature = GetSignature(name, options);
 
-            return Body.Block(options, signature);
+            return Body.Block(signature);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/ConstructorExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/ConstructorExtensions.ToSnippet.cs
@@ -31,7 +31,7 @@
                 .Select(method => method.ToSnippet(options, type))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options, content);
+            return Snippet.From(options, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/DirectiveExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/DirectiveExtensions.ToSnippet.cs
@@ -37,7 +37,7 @@
                 .ThenBy(directive => directive.Rendering)
                 .Select(directive => Snippet.From(options, directive.Rendering))
                 .ToImmutableArray()
-                .Stack(options);
+                .Stack();
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Event.Methods.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Event.Methods.cs
@@ -113,7 +113,7 @@
                     return Snippet.From($"{add} {remove}");
                 }
 
-                return remove.Stack(options, add);
+                return remove.Stack(add);
             }
 
             private static Snippet Format(string keyword, Snippet.Options options, Snippet snippet)
@@ -123,7 +123,7 @@
                     return Snippet.From($"{keyword};");
                 }
 
-                return snippet.Block(options, opening: Snippet.From(keyword));
+                return snippet.Block(opening: Snippet.From(keyword));
             }
         }
     }

--- a/src/MooVC.Syntax.CSharp/Members/Event.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Event.cs
@@ -140,7 +140,7 @@
                     .WithInline(inline => Snippet.BlockOptions.InlineStyle.SingleLineBraces));
             }
 
-            return methods.Block(snippets, Snippet.From(snippets, signature));
+            return Snippet.From(snippets, methods.ToString()).Block(Snippet.From(snippets, signature));
         }
 
         /// <summary>

--- a/src/MooVC.Syntax.CSharp/Members/EventExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/EventExtensions.ToSnippet.cs
@@ -29,7 +29,7 @@
                 .Select(@event => @event.ToSnippet(options))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options.Snippets, content);
+            return Snippet.From(options.Snippets, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/FieldExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/FieldExtensions.ToSnippet.cs
@@ -30,7 +30,7 @@
                 .ThenBy(field => field.Name)
                 .Select(field => field.ToSnippet(options))
                 .ToImmutableArray()
-                .Stack(options);
+                .Stack();
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Indexer.Methods.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Indexer.Methods.cs
@@ -101,7 +101,7 @@
                 {
                     Snippet remove = Format("set", options, Set);
 
-                    add = remove.Stack(options, add);
+                    add = remove.Stack(add);
                 }
 
                 return add;
@@ -114,7 +114,7 @@
                     return $"{keyword};";
                 }
 
-                return snippet.Block(options, opening: Snippet.From(options, keyword));
+                return snippet.Block(opening: Snippet.From(options, keyword));
             }
         }
     }

--- a/src/MooVC.Syntax.CSharp/Members/Indexer.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Indexer.cs
@@ -132,7 +132,7 @@
                     .WithInline(inline => Snippet.BlockOptions.InlineStyle.SingleLineBraces));
             }
 
-            return methods.Block(snippets, signature);
+            return Snippet.From(snippets, methods.ToString()).Block(signature);
         }
 
         /// <summary>

--- a/src/MooVC.Syntax.CSharp/Members/IndexerExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/IndexerExtensions.ToSnippet.cs
@@ -31,7 +31,7 @@
                 .Select(indexer => indexer.ToSnippet(options))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options.Snippets, content);
+            return Snippet.From(options.Snippets, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Method.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Method.cs
@@ -150,8 +150,8 @@ namespace MooVC.Syntax.CSharp.Members
             }
 
             return Body
-                .Block(options.Snippets, signature)
-                .Prepend(options.Snippets, attributes);
+                .Block(signature)
+                .Prepend(attributes);
         }
 
         /// <summary>
@@ -204,9 +204,9 @@ namespace MooVC.Syntax.CSharp.Members
             if (!clauses.IsEmpty)
             {
                 return clauses
-                    .Shift(options.Snippets)
-                    .Prepend(options.Snippets, Environment.NewLine)
-                    .Prepend(options.Snippets, signature);
+                    .Shift()
+                    .Prepend(Environment.NewLine)
+                    .Prepend(signature);
             }
 
             return Snippet.From(options.Snippets, signature);

--- a/src/MooVC.Syntax.CSharp/Members/MethodExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/MethodExtensions.ToSnippet.cs
@@ -33,7 +33,7 @@
                 .Select(method => method.ToSnippet(options))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options.Snippets, content);
+            return Snippet.From(options.Snippets, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Members/Property.Methods.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Property.Methods.cs
@@ -120,7 +120,7 @@ namespace MooVC.Syntax.CSharp.Members
                     return Snippet.From(options, $"{get} {set}");
                 }
 
-                return set.Stack(options, get);
+                return set.Stack(get);
             }
 
             private static Snippet Format(string keyword, Snippet.Options options, Snippet snippet, Scope scope = default)
@@ -134,7 +134,7 @@ namespace MooVC.Syntax.CSharp.Members
                     ? keyword
                     : $"{scope} {keyword}";
 
-                return snippet.Block(options, opening: Snippet.From(keyword));
+                return snippet.Block(opening: Snippet.From(keyword));
             }
         }
     }

--- a/src/MooVC.Syntax.CSharp/Members/Property.cs
+++ b/src/MooVC.Syntax.CSharp/Members/Property.cs
@@ -147,14 +147,14 @@
                     .WithInline(inline => Snippet.BlockOptions.InlineStyle.SingleLineBraces));
             }
 
-            signature = behaviours.Block(body, signature);
+            signature = Snippet.From(body, behaviours.ToString()).Block(signature);
 
             if (!Default.IsEmpty)
             {
-                signature = signature.Append(body, $" = {Default}");
+                signature = Snippet.From(body, signature.ToString()).Append($" = {Default}");
             }
 
-            return signature.Prepend(options.Snippets, attributes);
+            return signature.Prepend(attributes);
         }
 
         /// <summary>

--- a/src/MooVC.Syntax.CSharp/Members/PropertyExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Members/PropertyExtensions.ToSnippet.cs
@@ -33,7 +33,7 @@
                 .Select(property => property.ToSnippet(options))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options.Snippets, content);
+            return Snippet.From(options.Snippets, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/Binary.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/Binary.cs
@@ -118,7 +118,7 @@
             var type = declaration.ToSnippet(options);
             var signature = Snippet.From(options, $"{scope} static {type} operator {@operator}({type} left, {type} right)");
 
-            return Body.Block(options, signature);
+            return Body.Block(signature);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/BinaryExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/BinaryExtensions.ToSnippet.cs
@@ -30,7 +30,7 @@
                 .Select(binary => binary.ToSnippet(options, type))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options, content);
+            return Snippet.From(options, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/Comparison.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/Comparison.cs
@@ -118,7 +118,7 @@
             var type = declaration.ToSnippet(options);
             var signature = Snippet.From(options, $"{scope} static bool operator {@operator}({type} left, {type} right)");
 
-            return Body.Block(options, signature);
+            return Body.Block(signature);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/ComparisonExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/ComparisonExtensions.ToSnippet.cs
@@ -30,7 +30,7 @@
                 .Select(comparison => comparison.ToSnippet(options, type))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options, content);
+            return Snippet.From(options, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/Conversion.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/Conversion.cs
@@ -164,7 +164,7 @@
             string scope = Scope;
             var signature = Snippet.From($"{scope} static {mode} operator {result}({input} subject)");
 
-            return Body.Block(options, signature);
+            return Body.Block(signature);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/ConversionExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/ConversionExtensions.ToSnippet.cs
@@ -32,7 +32,7 @@
                 .Select(conversion => conversion.ToSnippet(options, type))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options, content);
+            return Snippet.From(options, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/Operators.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/Operators.cs
@@ -97,7 +97,7 @@
             var conversions = Conversions.ToSnippet(options, type);
             var unaries = Unaries.ToSnippet(options, type);
 
-            return Snippet.Blank.Combine(options, binaries, comparisons, conversions, unaries);
+            return Snippet.From(options, string.Empty).Combine(binaries, comparisons, conversions, unaries);
         }
 
         /// <summary>

--- a/src/MooVC.Syntax.CSharp/Operators/Unary.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/Unary.cs
@@ -120,7 +120,7 @@
             var type = declaration.ToSnippet(options);
             var signature = Snippet.From(options, $"{scope} static {type} operator {@operator}({type} {name})");
 
-            return Body.Block(options, signature);
+            return Body.Block(signature);
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Operators/UnaryExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax.CSharp/Operators/UnaryExtensions.ToSnippet.cs
@@ -31,7 +31,7 @@
                 .Select(unary => unary.ToSnippet(options, type))
                 .ToArray();
 
-            return Snippet.Blank.Combine(options, content);
+            return Snippet.From(options, string.Empty).Combine(content);
         }
     }
 }

--- a/src/MooVC.Syntax.Tests/Elements/SnippetExtensionsTests/WhenStackIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Elements/SnippetExtensionsTests/WhenStackIsCalled.cs
@@ -16,7 +16,7 @@ public sealed class WhenStackIsCalled
         var snippets = ImmutableArray.Create(snippet);
 
         // Act
-        Snippet result = snippets.Stack(Snippet.Options.Default);
+        Snippet result = snippets.Stack();
 
         // Assert
         result.ShouldBeSameAs(snippet);
@@ -33,7 +33,7 @@ public sealed class WhenStackIsCalled
         string expected = string.Join(Environment.NewLine, FirstLine, SecondLine, ThirdLine);
 
         // Act
-        Snippet result = snippets.Stack(Snippet.Options.Default);
+        Snippet result = snippets.Stack();
 
         // Assert
         result.ToString().ShouldBe(expected);

--- a/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenAppendIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenAppendIsCalled.cs
@@ -8,21 +8,6 @@ public sealed class WhenAppendIsCalled
     private const string Phi = "phi";
 
     [Fact]
-    public void GivenNullOptionsAndValuesThenThrows()
-    {
-        // Arrange
-        var subject = Snippet.From(Alpha);
-        Snippet.Options? options = default;
-
-        // Act
-        ArgumentNullException exception = Should.Throw<ArgumentNullException>(
-            () => _ = subject.Append(options!, Beta));
-
-        // Assert
-        exception.ParamName.ShouldBe(nameof(options));
-    }
-
-    [Fact]
     public void GivenStringValuesThenTheyAreAppended()
     {
         // Arrange

--- a/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenBlockIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenBlockIsCalled.cs
@@ -7,20 +7,6 @@ public sealed class WhenBlockIsCalled
     private static readonly ImmutableArray<string> lines = ["if (condition)", "return true;"];
 
     [Fact]
-    public void GivenNullOptionsThenThrows()
-    {
-        // Arrange
-        var subject = new Snippet(lines);
-        Snippet.Options? options = default;
-
-        // Act
-        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = subject.Block(options!));
-
-        // Assert
-        exception.ParamName.ShouldBe(nameof(options));
-    }
-
-    [Fact]
     public void GivenNoOpeningThenTheWholeSnippetIsBlocked()
     {
         // Arrange
@@ -34,7 +20,7 @@ public sealed class WhenBlockIsCalled
         var subject = new Snippet(lines);
 
         // Act
-        Snippet result = subject.Block(Snippet.Options.Default);
+        Snippet result = subject.Block();
 
         // Assert
         string text = result.ToString();
@@ -52,16 +38,15 @@ public sealed class WhenBlockIsCalled
             }
             """;
 
-        var subject = Snippet.From("return true;");
-        var opening = Snippet.From("if (condition)");
-
         Snippet.Options options = new Snippet.Options()
             .WithBlock(block => block
                 .WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces)
                 .WithStyle(Snippet.BlockOptions.StyleType.Allman));
+        var subject = Snippet.From(options, "return true;");
+        var opening = Snippet.From("if (condition)");
 
         // Act
-        Snippet result = subject.Block(options, opening);
+        Snippet result = subject.Block(opening);
 
         // Assert
         string text = result.ToString();
@@ -79,16 +64,15 @@ public sealed class WhenBlockIsCalled
             }
             """;
 
-        var subject = Snippet.From("return true;");
-        var opening = Snippet.From("if (condition)");
-
         Snippet.Options options = new Snippet.Options()
             .WithBlock(block => block
                 .WithInline(Snippet.BlockOptions.InlineStyle.MultiLineBraces)
                 .WithStyle(Snippet.BlockOptions.StyleType.KAndR));
+        var subject = Snippet.From(options, "return true;");
+        var opening = Snippet.From("if (condition)");
 
         // Act
-        Snippet result = subject.Block(options, opening);
+        Snippet result = subject.Block(opening);
 
         // Assert
         string text = result.ToString();
@@ -102,15 +86,14 @@ public sealed class WhenBlockIsCalled
         // Arrange
         const string expected = "get => value;";
 
-        var subject = Snippet.From("value;");
-        var opening = Snippet.From("get");
-
         Snippet.Options options = new Snippet.Options()
             .WithBlock(block => block
                 .WithInline(Snippet.BlockOptions.InlineStyle.Lambda));
+        var subject = Snippet.From(options, "value;");
+        var opening = Snippet.From("get");
 
         // Act
-        Snippet result = subject.Block(options, opening);
+        Snippet result = subject.Block(opening);
 
         // Assert
         string text = result.ToString();
@@ -124,15 +107,14 @@ public sealed class WhenBlockIsCalled
         // Arrange
         const string expected = "get { value; }";
 
-        var subject = Snippet.From("value;");
-        var opening = Snippet.From("get");
-
         Snippet.Options options = new Snippet.Options()
             .WithBlock(block => block
                 .WithInline(Snippet.BlockOptions.InlineStyle.SingleLineBraces));
+        var subject = Snippet.From(options, "value;");
+        var opening = Snippet.From("get");
 
         // Act
-        Snippet result = subject.Block(options, opening);
+        Snippet result = subject.Block(opening);
 
         // Assert
         string text = result.ToString();

--- a/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenPrependIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenPrependIsCalled.cs
@@ -8,21 +8,6 @@ public sealed class WhenPrependIsCalled
     private const string Phi = "phi";
 
     [Fact]
-    public void GivenNullOptionsAndValuesThenThrows()
-    {
-        // Arrange
-        var subject = Snippet.From(Alpha);
-        Snippet.Options? options = default;
-
-        // Act
-        ArgumentNullException exception = Should.Throw<ArgumentNullException>(
-            () => _ = subject.Prepend(options!, Beta));
-
-        // Assert
-        exception.ParamName.ShouldBe(nameof(options));
-    }
-
-    [Fact]
     public void GivenStringValuesThenTheyArePrepended()
     {
         // Arrange

--- a/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenShiftIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Elements/SnippetTests/WhenShiftIsCalled.cs
@@ -7,21 +7,7 @@ public sealed class WhenShiftIsCalled
     private static readonly ImmutableArray<string> lines = ["if (condition)", "return true;"];
 
     [Fact]
-    public void GivenNullOptionsThenThrows()
-    {
-        // Arrange
-        var subject = new Snippet(lines);
-        Snippet.Options? options = default;
-
-        // Act
-        ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => _ = subject.Shift(options!));
-
-        // Assert
-        exception.ParamName.ShouldBe(nameof(options));
-    }
-
-    [Fact]
-    public void GivenOptionsThenLinesAreShifted()
+    public void GivenOptionsFromConstructionThenLinesAreShifted()
     {
         // Arrange
         const string expected = """
@@ -29,14 +15,14 @@ public sealed class WhenShiftIsCalled
             	return true;
             """;
 
-        const string whitespace = "\t";
-        var subject = new Snippet(lines);
+        const string whitespace = "	";
 
         Snippet.Options options = new Snippet.Options()
             .WithWhitespace(whitespace);
+        var subject = new Snippet(options, lines);
 
         // Act
-        Snippet result = subject.Shift(options);
+        Snippet result = subject.Shift();
 
         // Assert
         string text = result.ToString();

--- a/src/MooVC.Syntax/Elements/QualifierExtensions.ToSnippet.cs
+++ b/src/MooVC.Syntax/Elements/QualifierExtensions.ToSnippet.cs
@@ -26,7 +26,7 @@
                 .OrderBy(@using => @using)
                 .Select(@using => @using.ToSnippet(options))
                 .ToImmutableArray()
-                .Stack(options);
+                .Stack();
         }
     }
 }

--- a/src/MooVC.Syntax/Elements/Snippet.cs
+++ b/src/MooVC.Syntax/Elements/Snippet.cs
@@ -24,26 +24,40 @@
         /// <summary>
         /// Represents the blank for the Snippet.
         /// </summary>
-        public static readonly Snippet Blank = new Snippet(new string[] { string.Empty }.ToImmutableArray());
+        public static readonly Snippet Blank = new Snippet(Options.Default, new string[] { string.Empty }.ToImmutableArray());
 
         /// <summary>
         /// Gets the empty instance.
         /// </summary>
-        public static readonly Snippet Empty = new Snippet(ImmutableArray<string>.Empty);
+        public static readonly Snippet Empty = new Snippet(Options.Default, ImmutableArray<string>.Empty);
 
         private const int SingleLine = 1;
+        private readonly Options _options;
 
         /// <summary>
         /// Initializes a new instance of the Snippet class.
         /// </summary>
         /// <param name="value">The value.</param>
         internal Snippet(ImmutableArray<string> value)
+            : this(Options.Default, value)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Snippet class.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="value">The value.</param>
+        internal Snippet(Options options, ImmutableArray<string> value)
+        {
+            _ = Guard.Against.Null(options, message: FromOptionsRequired.Format(nameof(Options), nameof(value)));
+
             if (value.IsDefault)
             {
                 value = ImmutableArray<string>.Empty;
             }
 
+            _options = options;
             _value = value;
         }
 
@@ -118,7 +132,7 @@
 
             if (values.Length == 0 || (values.Length == 1 && string.IsNullOrEmpty(values[0])))
             {
-                return Empty;
+                return new Snippet(options, ImmutableArray<string>.Empty);
             }
 
             ImmutableArray<string>.Builder builder = ImmutableArray.CreateBuilder<string>(values.Length);
@@ -133,7 +147,7 @@
                 }
             }
 
-            return builder.ToImmutable();
+            return new Snippet(options, builder.ToImmutable());
         }
 
         /// <summary>
@@ -158,7 +172,7 @@
 
             builder.Add(string.Concat(_value[last], value));
 
-            return builder.ToImmutable();
+            return new Snippet(_options, builder.ToImmutable());
         }
 
         /// <summary>
@@ -168,18 +182,7 @@
         /// <returns>The snippet.</returns>
         public Snippet Append(params string[] values)
         {
-            return Append(Options.Default, values);
-        }
-
-        /// <summary>
-        /// Performs the append operation for the syntax element.
-        /// </summary>
-        /// <param name="options">The options.</param>
-        /// <param name="values">The values.</param>
-        /// <returns>The snippet.</returns>
-        public Snippet Append(Options options, params string[] values)
-        {
-            return Combine(options, _value, values, (original, appended) => original.Concat(appended));
+            return Combine(_options, _value, values, (original, appended) => original.Concat(appended));
         }
 
         /// <summary>
@@ -195,23 +198,22 @@
         /// <summary>
         /// Performs the block operation for the syntax element.
         /// </summary>
-        /// <param name="options">The options.</param>
         /// <returns>The snippet.</returns>
-        public Snippet Block(Options options)
+        public Snippet Block()
         {
-            return Block(options, Empty);
+            return Block(Empty);
         }
 
         /// <summary>
         /// Performs the block operation for the syntax element.
         /// </summary>
-        /// <param name="options">The options.</param>
         /// <param name="opening">The opening.</param>
         /// <returns>The snippet.</returns>
-        public Snippet Block(Options options, Snippet opening)
+        public Snippet Block(Snippet opening)
         {
-            _ = Guard.Against.Null(options, message: BlockOptionsRequired);
             _ = Guard.Against.Null(opening, message: BlockOpeningRequired);
+
+            Options options = _options;
 
             const int MaximumAdditionalLinesRequiredForBlock = 2;
 
@@ -238,7 +240,7 @@
                         blocked[index - 1] = string.Concat(blocked[index - 1], $" {options.Block.Markers.Opening} {_value[0]} {options.Block.Markers.Closing}");
                     }
 
-                    return new Snippet(ImmutableArray.Create(blocked, 0, index));
+                    return new Snippet(options, ImmutableArray.Create(blocked, 0, index));
                 }
 
                 if (options.Block.Style.IsKAndR && openingLines > 0)
@@ -266,7 +268,7 @@
 
                 blocked[index] = options.Block.Markers.Closing;
 
-                return new Snippet(ImmutableArray.Create(blocked, 0, index + 1));
+                return new Snippet(options, ImmutableArray.Create(blocked, 0, index + 1));
             }
             finally
             {
@@ -281,25 +283,13 @@
         /// <returns>The snippet.</returns>
         public Snippet Combine(params Snippet[] values)
         {
-            return Combine(Options.Default, values);
-        }
-
-        /// <summary>
-        /// Performs the combine operation for the syntax element.
-        /// </summary>
-        /// <param name="options">The options.</param>
-        /// <param name="values">The values.</param>
-        /// <returns>The snippet.</returns>
-        public Snippet Combine(Options options, params Snippet[] values)
-        {
-            _ = Guard.Against.Null(options, message: CombineOptionsRequired);
             _ = Guard.Against.Null(values, message: CombineSnippetsRequired);
 
             values = StripEmptySnippets(values);
 
             if (values.Length == 0)
             {
-                return Empty;
+                return new Snippet(_options, ImmutableArray<string>.Empty);
             }
 
             if (values.Length == 1)
@@ -319,18 +309,7 @@
         /// <returns>The snippet.</returns>
         public Snippet Prepend(params string[] values)
         {
-            return Prepend(Options.Default, values);
-        }
-
-        /// <summary>
-        /// Performs the prepend operation for the syntax element.
-        /// </summary>
-        /// <param name="options">The options.</param>
-        /// <param name="values">The values.</param>
-        /// <returns>The snippet.</returns>
-        public Snippet Prepend(Options options, params string[] values)
-        {
-            return Combine(options, _value, values, (original, prepended) => prepended.Concat(original));
+            return Combine(_options, _value, values, (original, prepended) => prepended.Concat(original));
         }
 
         /// <summary>
@@ -346,11 +325,10 @@
         /// <summary>
         /// Performs the shift operation for the syntax element.
         /// </summary>
-        /// <param name="options">The options.</param>
         /// <returns>The snippet.</returns>
-        public Snippet Shift(Options options)
+        public Snippet Shift()
         {
-            _ = Guard.Against.Null(options, message: ShiftOptionsRequired);
+            Options options = _options;
 
             string[] shifted = ArrayPool<string>.Shared.Rent(Lines);
 
@@ -370,7 +348,7 @@
                     shifted[index] = current;
                 }
 
-                return new Snippet(ImmutableArray.Create(shifted, 0, Lines));
+                return new Snippet(options, ImmutableArray.Create(shifted, 0, Lines));
             }
             finally
             {
@@ -381,15 +359,13 @@
         /// <summary>
         /// Performs the stack operation for the syntax element.
         /// </summary>
-        /// <param name="options">The options.</param>
         /// <param name="top">The top.</param>
         /// <returns>The snippet.</returns>
-        public Snippet Stack(Options options, Snippet top)
+        public Snippet Stack(Snippet top)
         {
-            _ = Guard.Against.Null(options, message: StackOptionsRequired);
             _ = Guard.Against.Null(top, message: StackTopRequired.Format(nameof(Snippet), nameof(Stack)));
 
-            return Prepend(options, top);
+            return Prepend(top);
         }
 
         /// <summary>
@@ -445,7 +421,7 @@
             }
         }
 
-        private static ImmutableArray<string> Combine(
+        private static Snippet Combine(
             Options options,
             Snippet original,
             string[] values,
@@ -460,7 +436,7 @@
                     snippets[index] = From(options, values[index]);
                 }
 
-                return Combine(original, snippets.Take(values.Length), combine);
+                return Combine(options, original, snippets.Take(values.Length), combine);
             }
             finally
             {
@@ -468,7 +444,8 @@
             }
         }
 
-        private static ImmutableArray<string> Combine(
+        private static Snippet Combine(
+            Options options,
             Snippet original,
             IEnumerable<Snippet> values,
             Func<IEnumerable<string>, IEnumerable<string>, IEnumerable<string>> combine)
@@ -476,7 +453,7 @@
             IEnumerable<string> first = original._value.Select(value => value);
             IEnumerable<string> second = values.SelectMany(snippet => snippet._value.Select(value => value));
 
-            return combine(first, second).ToImmutableArray();
+            return new Snippet(options, combine(first, second).ToImmutableArray());
         }
 
         private static Snippet[] StripEmptySnippets(Snippet[] values)
@@ -519,9 +496,9 @@
                     }
                 }
 
-                return combined
+                return new Snippet(_options, combined
                     .Take(index)
-                    .ToImmutableArray();
+                    .ToImmutableArray());
             }
             finally
             {

--- a/src/MooVC.Syntax/Elements/SnippetExtensions.Stack.cs
+++ b/src/MooVC.Syntax/Elements/SnippetExtensions.Stack.cs
@@ -1,8 +1,6 @@
 ﻿namespace MooVC.Syntax.Elements
 {
     using System.Collections.Immutable;
-    using Ardalis.GuardClauses;
-    using static MooVC.Syntax.Elements.SnippetExtensions_Resources;
 
     /// <summary>
     /// Represents a syntax element snippet extensions.
@@ -13,12 +11,9 @@
         /// Performs the stack operation for the syntax element.
         /// </summary>
         /// <param name="snippets">The snippets.</param>
-        /// <param name="options">The options.</param>
         /// <returns>The snippet.</returns>
-        public static Snippet Stack(this ImmutableArray<Snippet> snippets, Snippet.Options options)
+        public static Snippet Stack(this ImmutableArray<Snippet> snippets)
         {
-            _ = Guard.Against.Null(options, message: OptionsRequired.Format(nameof(Snippet.Options), nameof(snippets)));
-
             if (snippets.IsDefaultOrEmpty)
             {
                 return Snippet.Empty;
@@ -33,7 +28,7 @@
 
             for (int index = 1; index < snippets.Length; index++)
             {
-                stacked = snippets[index].Stack(options, stacked);
+                stacked = snippets[index].Stack(stacked);
             }
 
             return stacked;


### PR DESCRIPTION
### Motivation

- Reduce repetition by capturing `Snippet.Options` on construction so instance methods don't need an `Options` parameter.
- Ensure newly-created `Snippet` instances preserve the originating `Options` so formatting behavior stays consistent across operations.

### Description

- Added a readonly `_options` field and a new constructor `Snippet(Options options, ImmutableArray<string> value)` and made the parameterless constructor delegate to it so all instances carry `Options`.
- Kept `Snippet.From(...)` as the single API that accepts explicit `Options`, and updated it to return `Snippet` instances that hold the provided `Options`.
- Removed `Snippet.Options` parameters from instance methods (`Append`, `Prepend`, `Block`, `Shift`, `Stack`, `Combine`) so they use the captured `_options`; adjusted internal helper methods to create new `Snippet` instances with the correct `Options`.
- Updated `SnippetExtensions.Stack` to drop the `Options` parameter and updated call sites across the C# syntax generation code to construct/seed snippets with `Snippet.From(options, ...)` where an options-bound root snippet is required, and adjusted tests to the new API shape.

### Testing

- Attempted to run `dotnet test` but the environment lacks the `dotnet` CLI so the test suite could not be executed (error: `bash: command not found: dotnet`).
- Ran repository checks (`git diff --check`) and repository-wide search/updates to ensure no lingering `Options` parameters remained in instance calls, which returned no whitespace or obvious patch issues.
- Updated unit tests to the new API (tests modified to construct `Snippet` with options where needed), but they were not executed due to the missing `dotnet` tooling.
- Performed local code edits and searches to ensure new snippets created inside methods preserve options and that extension methods are adjusted to the new signatures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1a195888832f8e82974424e2c973)