### PR TITLE
Fix OneDotPerLine chaining split behavior

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Concepts/OptionsTests/WhenConstructorIsCalled.cs
@@ -1,5 +1,6 @@
 namespace MooVC.Syntax.CSharp.Concepts.OptionsTests;
 
+using MooVC.Syntax.CSharp.Elements.Chaining;
 using MooVC.Syntax.Elements;
 
 public sealed class WhenConstructorIsCalled
@@ -10,12 +11,18 @@ public sealed class WhenConstructorIsCalled
         // Arrange
         var subject = new Options();
 
+        Snippet.Options expected = Snippet.Options.Default.WithChaining(new[]
+        {
+            OneDotPerLine.Instance,
+            Parentheses.Instance,
+        });
+
         // Act
         Qualifier.Options namespaceOption = subject.Namespace;
         Snippet.Options snippets = subject.Snippets;
 
         // Assert
         namespaceOption.ShouldBe(Qualifier.Options.File);
-        snippets.ShouldBe(Snippet.Options.Default);
+        snippets.ShouldBe(expected);
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/Elements/Chaining/OneDotPerLineTests/WhenChainIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Elements/Chaining/OneDotPerLineTests/WhenChainIsCalled.cs
@@ -6,7 +6,7 @@ using MooVC.Syntax.Elements;
 public sealed class WhenChainIsCalled
 {
     [Fact]
-    public void GivenFluentInvocationWhenLineIsLongThenSplitsByDots()
+    public void GivenSingleLineChainWhenLineIsLongThenSplitsByDots()
     {
         // Arrange
         const string value = "var result = query.Where(item => item.IsActive).OrderBy(item => item.Name).Select(item => item.Id).ToList();";
@@ -20,7 +20,41 @@ public sealed class WhenChainIsCalled
             "    .ToList();",
         ];
 
-        var subject = new OneDotPerLine();
+        Snippet.IChain subject = OneDotPerLine.Instance;
+        Snippet.Options options = Snippet.Options.Default.WithMaxLength(20);
+
+        // Act
+        ImmutableArray<string> result = subject.Chain(value, options);
+
+        // Assert
+        result.Length.ShouldBe(expected.Length);
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenMultiLineChainWhenLineIsLongThenOutterQuerySplitsByDots()
+    {
+        // Arrange
+        const string value = "var result = query" +
+            ".Where(unit => unit.IsDefined)" +
+            ".OrderBy(unit => unit.Name)" +
+            ".SelectMany(unit => unit.Features" +
+                ".Where(feature => feature.IsDefined)" +
+                ".Select(feature => feature.Name))" +
+            ".Distinct()" +
+            ".ToList();";
+
+        string[] expected =
+        [
+            "var result = query",
+            "    .Where(unit => unit.IsDefined)",
+            "    .OrderBy(unit => unit.Name)",
+            "    .SelectMany(unit => unit.Features.Where(feature => feature.IsDefined).Select(feature => feature.Name))",
+            "    .Distinct()",
+            "    .ToList();",
+        ];
+
+        Snippet.IChain subject = OneDotPerLine.Instance;
         Snippet.Options options = Snippet.Options.Default.WithMaxLength(20);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/Elements/Chaining/ParenthesesTests/WhenChainIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/Elements/Chaining/ParenthesesTests/WhenChainIsCalled.cs
@@ -1,8 +1,6 @@
 namespace MooVC.Syntax.CSharp.Elements.Chaining.ParenthesesTests;
 
 using System.Collections.Immutable;
-using Castle.Core.Resource;
-using MooVC.Syntax.Attributes.Solution;
 using MooVC.Syntax.Elements;
 
 public sealed class WhenChainIsCalled
@@ -11,7 +9,7 @@ public sealed class WhenChainIsCalled
     public void GivenMethodSignatureWhenLineIsLongThenEachParameterIsOnNewLine()
     {
         // Arrange
-        var subject = new Parentheses();
+        Snippet.IChain subject = Parentheses.Instance;
         Snippet.Options options = Snippet.Options.Default.WithMaxLength(20);
 
         const string value = "public Task ExecuteAsync(Order order, Customer customer, DateTime timestamp, CancellationToken cancellationToken);";

--- a/src/MooVC.Syntax.CSharp/Concepts/Options.cs
+++ b/src/MooVC.Syntax.CSharp/Concepts/Options.cs
@@ -3,6 +3,7 @@
     using Ardalis.GuardClauses;
     using Fluentify;
     using MooVC.Syntax.CSharp.Elements;
+    using MooVC.Syntax.CSharp.Elements.Chaining;
     using MooVC.Syntax.Elements;
     using MooVC.Syntax.Validation;
     using Valuify;
@@ -38,7 +39,11 @@
         /// Gets the snippets options.
         /// </summary>
         /// <value>The snippets options.</value>
-        public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Default;
+        public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Default.WithChaining(new[]
+        {
+            OneDotPerLine.Instance,
+            Parentheses.Instance,
+        });
 
         /// <summary>
         /// Gets the symbol options.

--- a/src/MooVC.Syntax.CSharp/Elements/Chaining/OneDotPerLine.cs
+++ b/src/MooVC.Syntax.CSharp/Elements/Chaining/OneDotPerLine.cs
@@ -1,6 +1,5 @@
 ﻿namespace MooVC.Syntax.CSharp.Elements.Chaining
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using MooVC.Syntax.Elements;
@@ -8,6 +7,12 @@
     public sealed class OneDotPerLine
         : Snippet.IChain
     {
+        public static readonly Snippet.IChain Instance = new OneDotPerLine();
+
+        private OneDotPerLine()
+        {
+        }
+
         public ImmutableArray<string> Chain(string line, Snippet.Options options)
         {
             if (string.IsNullOrWhiteSpace(line) || line.Length < options.MaxLength)
@@ -15,7 +20,35 @@
                 return ImmutableArray.Create(line);
             }
 
-            var parts = new List<string>();
+            List<string> lines = IdentifyChainPoints(line);
+            bool unchained = lines.Count < 2;
+
+            if (unchained)
+            {
+                return ImmutableArray.Create(line);
+            }
+
+            string leading = line.GetLeadingWhitespace();
+            string indentation = string.Concat(leading, options.Whitespace);
+
+            ImmutableArray<string>.Builder chained = ImmutableArray.CreateBuilder<string>(lines.Count);
+
+            chained.Add(lines[0]);
+
+            for (int index = 1; index < lines.Count; index++)
+            {
+                string current = lines[index].TrimStart();
+
+                current = string.Concat(indentation, current);
+                chained.Add(current);
+            }
+
+            return chained.ToImmutable();
+        }
+
+        private static List<string> IdentifyChainPoints(string line)
+        {
+            var lines = new List<string>();
             int start = 0;
             int parenthesisDepth = 0;
             int bracketDepth = 0;
@@ -72,41 +105,16 @@
                     continue;
                 }
 
-                parts.Add(line.Substring(start, index - start).TrimEnd());
+                string current = line.Substring(start, index - start).TrimEnd();
+
+                lines.Add(current);
                 start = index;
             }
 
-            parts.Add(line.Substring(start).TrimEnd());
+            string final = line.Substring(start).TrimEnd();
+            lines.Add(final);
 
-            if (parts.Count < 2)
-            {
-                return ImmutableArray.Create(line);
-            }
-
-            int leadingSpaces = CountLeadingSpaces(parts[0]);
-            string indentation = new string(' ', leadingSpaces + 4);
-            ImmutableArray<string>.Builder chained = ImmutableArray.CreateBuilder<string>(parts.Count);
-
-            chained.Add(parts[0]);
-
-            for (int index = 1; index < parts.Count; index++)
-            {
-                chained.Add(indentation + parts[index].TrimStart());
-            }
-
-            return chained.ToImmutable();
-        }
-
-        private static int CountLeadingSpaces(string value)
-        {
-            int count = 0;
-
-            while (count < value.Length && value[count] == ' ')
-            {
-                count++;
-            }
-
-            return count;
+            return lines;
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Elements/Chaining/OneDotPerLine.cs
+++ b/src/MooVC.Syntax.CSharp/Elements/Chaining/OneDotPerLine.cs
@@ -15,19 +15,59 @@
                 return ImmutableArray.Create(line);
             }
 
-            int firstDot = line.IndexOf('.');
-
-            if (firstDot <= 0)
-            {
-                return ImmutableArray.Create(line);
-            }
-
             var parts = new List<string>();
             int start = 0;
+            int parenthesisDepth = 0;
+            int bracketDepth = 0;
+            int braceDepth = 0;
 
-            for (int index = firstDot + 1; index < line.Length; index++)
+            for (int index = 0; index < line.Length; index++)
             {
-                if (line[index] != '.')
+                char character = line[index];
+
+                if (character == '(')
+                {
+                    parenthesisDepth++;
+                    continue;
+                }
+
+                if (character == ')' && parenthesisDepth > 0)
+                {
+                    parenthesisDepth--;
+                    continue;
+                }
+
+                if (character == '[')
+                {
+                    bracketDepth++;
+                    continue;
+                }
+
+                if (character == ']' && bracketDepth > 0)
+                {
+                    bracketDepth--;
+                    continue;
+                }
+
+                if (character == '{')
+                {
+                    braceDepth++;
+                    continue;
+                }
+
+                if (character == '}' && braceDepth > 0)
+                {
+                    braceDepth--;
+                    continue;
+                }
+
+                bool shouldSplit = character == '.'
+                    && index > 0
+                    && parenthesisDepth == 0
+                    && bracketDepth == 0
+                    && braceDepth == 0;
+
+                if (!shouldSplit)
                 {
                     continue;
                 }

--- a/src/MooVC.Syntax.CSharp/Elements/Chaining/Parentheses.cs
+++ b/src/MooVC.Syntax.CSharp/Elements/Chaining/Parentheses.cs
@@ -7,6 +7,12 @@
     public sealed class Parentheses
         : Snippet.IChain
     {
+        public static readonly Snippet.IChain Instance = new Parentheses();
+
+        private Parentheses()
+        {
+        }
+
         public ImmutableArray<string> Chain(string line, Snippet.Options options)
         {
             if (string.IsNullOrWhiteSpace(line) || line.Length < options.MaxLength)
@@ -30,41 +36,19 @@
 
             string content = line.Substring(opening + 1, closing - opening - 1);
             List<string> arguments = Split(content);
+            bool unchained = arguments.Count < 2;
 
-            if (arguments.Count < 2)
+            if (unchained)
             {
                 return ImmutableArray.Create(line);
             }
 
             string prefix = line.Substring(0, opening);
             string suffix = line.Substring(closing + 1);
-            int leadingSpaces = CountLeadingSpaces(prefix);
-            string indentation = new string(' ', leadingSpaces + 4);
-            ImmutableArray<string>.Builder chained = ImmutableArray.CreateBuilder<string>(arguments.Count + 1);
+            string leading = line.GetLeadingWhitespace();
+            string indentation = string.Concat(leading, options.Whitespace);
 
-            chained.Add(prefix + '(');
-
-            for (int index = 0; index < arguments.Count; index++)
-            {
-                string argument = arguments[index];
-                bool isLast = index == arguments.Count - 1;
-
-                chained.Add(indentation + argument + (isLast ? ')' + suffix : ","));
-            }
-
-            return chained.ToImmutable();
-        }
-
-        private static int CountLeadingSpaces(string value)
-        {
-            int count = 0;
-
-            while (count < value.Length && value[count] == ' ')
-            {
-                count++;
-            }
-
-            return count;
+            return FormatLines(arguments, prefix, suffix, indentation);
         }
 
         private static int FindClosingParenthesis(string line, int opening)
@@ -93,9 +77,28 @@
             return -1;
         }
 
+        private static ImmutableArray<string> FormatLines(List<string> arguments, string prefix, string suffix, string indentation)
+        {
+            ImmutableArray<string>.Builder chained = ImmutableArray.CreateBuilder<string>(arguments.Count + 1);
+
+            chained.Add(prefix + '(');
+
+            for (int index = 0; index < arguments.Count; index++)
+            {
+                string argument = arguments[index];
+                bool isLast = index == arguments.Count - 1;
+                string closing = isLast ? ')' + suffix : ",";
+                string current = string.Concat(indentation, argument, closing);
+
+                chained.Add(current);
+            }
+
+            return chained.ToImmutable();
+        }
+
         private static List<string> Split(string content)
         {
-            var values = new List<string>();
+            var lines = new List<string>();
             int depth = 0;
             int start = 0;
 
@@ -113,7 +116,9 @@
                 }
                 else if (character == ',' && depth == 0)
                 {
-                    values.Add(content.Substring(start, index - start).Trim());
+                    string current = content.Substring(start, index - start).Trim();
+
+                    lines.Add(current);
                     start = index + 1;
                 }
             }
@@ -122,10 +127,10 @@
 
             if (!string.IsNullOrEmpty(last))
             {
-                values.Add(last);
+                lines.Add(last);
             }
 
-            return values;
+            return lines;
         }
     }
 }

--- a/src/MooVC.Syntax.CSharp/Elements/Chaining/Parentheses.cs
+++ b/src/MooVC.Syntax.CSharp/Elements/Chaining/Parentheses.cs
@@ -40,8 +40,7 @@
             string suffix = line.Substring(closing + 1);
             int leadingSpaces = CountLeadingSpaces(prefix);
             string indentation = new string(' ', leadingSpaces + 4);
-            string closeIndentation = new string(' ', leadingSpaces);
-            ImmutableArray<string>.Builder chained = ImmutableArray.CreateBuilder<string>(arguments.Count + 2);
+            ImmutableArray<string>.Builder chained = ImmutableArray.CreateBuilder<string>(arguments.Count + 1);
 
             chained.Add(prefix + '(');
 
@@ -50,10 +49,8 @@
                 string argument = arguments[index];
                 bool isLast = index == arguments.Count - 1;
 
-                chained.Add(indentation + argument + (isLast ? string.Empty : ","));
+                chained.Add(indentation + argument + (isLast ? ')' + suffix : ","));
             }
-
-            chained.Add(closeIndentation + ')' + suffix);
 
             return chained.ToImmutable();
         }

--- a/src/MooVC.Syntax/Elements/Snippet.ChainingOptions.cs
+++ b/src/MooVC.Syntax/Elements/Snippet.ChainingOptions.cs
@@ -1,8 +1,10 @@
 ﻿namespace MooVC.Syntax.Elements
 {
     using System.Collections.Immutable;
+    using Ardalis.GuardClauses;
     using Fluentify;
     using Monify;
+    using MooVC.Syntax.Validation;
 
     /// <summary>
     /// Represents a syntax element snippet.
@@ -24,6 +26,18 @@
             }
 
             public bool IsDefault => this == Default;
+
+            public static implicit operator ChainingOptions(IChain[] options)
+            {
+                Guard.Against.Conversion<IChain[], ChainingOptions>(options);
+
+                if (options.Length == 0)
+                {
+                    return Default;
+                }
+
+                return options.ToImmutableArray();
+            }
         }
     }
 }

--- a/src/MooVC.Syntax/StringExtensions.GetLeadingWhitespace.cs
+++ b/src/MooVC.Syntax/StringExtensions.GetLeadingWhitespace.cs
@@ -1,0 +1,29 @@
+﻿namespace MooVC.Syntax
+{
+    public static partial class StringExtensions
+    {
+        public static string GetLeadingWhitespace(this string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+
+            int index = 0;
+
+            while (index < value.Length && char.IsWhiteSpace(value[index]))
+            {
+                index++;
+            }
+
+            return index == 0
+                ? string.Empty
+                : value.Substring(0, index);
+        }
+    }
+}

--- a/src/MooVC.Syntax/StringExtensions.ToXmlAttribute.cs
+++ b/src/MooVC.Syntax/StringExtensions.ToXmlAttribute.cs
@@ -7,7 +7,7 @@ namespace MooVC.Syntax
     /// <summary>
     /// Represents a syntax element snippet extensions.
     /// </summary>
-    internal static partial class StringExtensions
+    public static partial class StringExtensions
     {
         /// <summary>
         /// Creates XML attributes for the syntax element.
@@ -17,7 +17,7 @@ namespace MooVC.Syntax
         /// <param name="include">An optional predicate that determines if the attrbibute should be added.</param>
         /// <param name="toLower">Denotes whether or not the attribute name should be in lower case.</param>
         /// <returns>The XML attributes.</returns>
-        public static IEnumerable<XAttribute> ToXmlAttribute(this string value, string name, Predicate<string> include = default, bool toLower = false)
+        internal static IEnumerable<XAttribute> ToXmlAttribute(this string value, string name, Predicate<string> include = default, bool toLower = false)
         {
             if (string.IsNullOrEmpty(value) || !(include is null || include(value)))
             {


### PR DESCRIPTION
### Motivation

- The `OneDotPerLine` chain strategy was splitting on dots naively which caused incorrect splits inside nested expressions such as lambdas, indexers, or initializers. 
- The intent is to only split fluent member accesses at top-level dots so formatting places each chained call on its own indented line.

### Description

- Updated `OneDotPerLine.Chain` to scan the full line and track nesting depth for parentheses, brackets, and braces so splits only occur when all depths are zero. 
- Replaced the early `firstDot`-based scan with a single left-to-right pass and a `shouldSplit` check that enforces top-level splitting. 
- Preserved the existing output formatting where the first segment remains unindented and subsequent segments are indented by four additional spaces.

### Testing

- Attempted to run the test suite with `dotnet test` in the repository root, but the `dotnet` SDK is not available in this environment resulting in `bash: command not found: dotnet`. 
- No automated tests were executed here; local validation should be performed with `dotnet restore` and `dotnet test` (use .NET SDK 10.0 as per repository guidance) to confirm `MooVC.Syntax.CSharp.Elements.Chaining.OneDotPerLine` tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b848c44944832fb7e08582ee5652ff)