### PR TITLE
Add TestableSerializer and unit tests for Serializer behavior and validation

### DIFF
--- a/src/MooVC.Tests/Serialization/SerializerTests/TestableSerializer.cs
+++ b/src/MooVC.Tests/Serialization/SerializerTests/TestableSerializer.cs
@@ -1,0 +1,36 @@
+﻿namespace MooVC.Serialization.SerializerTests;
+
+using System.IO;
+using MooVC.Compression;
+
+public sealed class TestableSerializer
+    : Serializer
+{
+    private readonly Func<Stream, object>? _onDeserialize;
+    private readonly Func<object, Stream, Task>? _onSerialize;
+
+    public TestableSerializer(
+        int bufferSize = DefaultBufferSize,
+        ICompressor? compressor = default,
+        Func<Stream, object>? onDeserialize = default,
+        Func<object, Stream, Task>? onSerialize = default)
+        : base(bufferSize: bufferSize, compressor: compressor)
+    {
+        _onDeserialize = onDeserialize;
+        _onSerialize = onSerialize;
+    }
+
+    protected override Task<T> PerformDeserialize<T>(Stream source, CancellationToken cancellationToken)
+    {
+        object output = _onDeserialize?.Invoke(source)
+            ?? throw new InvalidOperationException("Deserializer callback is required.");
+
+        return Task.FromResult((T)output);
+    }
+
+    protected override Task PerformSerialize<T>(T instance, Stream target, CancellationToken cancellationToken)
+    {
+        return _onSerialize?.Invoke(instance!, target)
+            ?? throw new InvalidOperationException("Serializer callback is required.");
+    }
+}

--- a/src/MooVC.Tests/Serialization/SerializerTests/WhenDeserializeIsCalled.cs
+++ b/src/MooVC.Tests/Serialization/SerializerTests/WhenDeserializeIsCalled.cs
@@ -1,0 +1,112 @@
+﻿namespace MooVC.Serialization.SerializerTests;
+
+using System.IO;
+using System.Text;
+using MooVC.Compression;
+
+public sealed class WhenDeserializeIsCalled
+{
+    private static readonly byte[] SourceData = Encoding.UTF8.GetBytes("Something something dark side...");
+    private const string Expected = "Something something dark side...";
+
+    [Test]
+    public async Task GivenACompressorThenDecompressAsyncIsInvoked()
+    {
+        // Arrange
+        ICompressor compressor = Substitute.For<ICompressor>();
+
+        _ = compressor
+            .Decompress(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(async info =>
+            {
+                Stream source = info.Arg<Stream>();
+                using var copied = new MemoryStream();
+                await source.CopyToAsync(copied, CancellationToken.None);
+                copied.Position = 0;
+                return copied;
+            });
+
+        var serializer = new TestableSerializer(
+            compressor: compressor,
+            onDeserialize: _ => Expected);
+
+        using var source = new MemoryStream(SourceData);
+
+        // Act
+        _ = await serializer.Deserialize<string>(source, CancellationToken.None);
+
+        // Assert
+        _ = await compressor.Received(1).Decompress(Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GivenNoCompressorThenSourceDataIsProvidedToDeserializer()
+    {
+        // Arrange
+        using var source = new MemoryStream(SourceData);
+        var serializer = new TestableSerializer(
+            onDeserialize: input =>
+            {
+                using var copied = new MemoryStream();
+                input.CopyTo(copied);
+                return Encoding.UTF8.GetString(copied.ToArray());
+            });
+
+        // Act
+        string deserialized = await serializer.Deserialize<string>(source, CancellationToken.None);
+
+        // Assert
+        _ = await Assert.That(deserialized).IsEqualTo(Expected);
+    }
+
+    [Test]
+    public async Task GivenDataThenDataDeserializationIsRequested()
+    {
+        // Arrange
+        bool wasInvoked = false;
+
+        var serializer = new TestableSerializer(
+            onDeserialize: _ =>
+            {
+                wasInvoked = true;
+                return Expected;
+            });
+
+        // Act
+        string deserialized = await serializer.Deserialize<string>(SourceData, CancellationToken.None);
+
+        // Assert
+        _ = await Assert.That(wasInvoked).IsTrue();
+        _ = await Assert.That(deserialized).IsEqualTo(Expected);
+    }
+
+    [Test]
+    public async Task GivenNullDataThenThrowsArgumentNullException()
+    {
+        // Arrange
+        var serializer = new TestableSerializer(onDeserialize: _ => Expected);
+        IEnumerable<byte>? data = default;
+
+        // Act
+        Func<Task> act = async () => await serializer.Deserialize<string>(data!, CancellationToken.None);
+
+        // Assert
+        ArgumentNullException exception = await Assert.That(act).Throws<ArgumentNullException>().And.IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo(nameof(data));
+    }
+
+    [Test]
+    public async Task GivenNullSourceThenThrowsArgumentNullException()
+    {
+        // Arrange
+        var serializer = new TestableSerializer(onDeserialize: _ => Expected);
+        Stream? source = default;
+
+        // Act
+        Func<Task> act = async () => await serializer.Deserialize<string>(source!, CancellationToken.None);
+
+        // Assert
+        ArgumentNullException exception = await Assert.That(act).Throws<ArgumentNullException>().And.IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo(nameof(source));
+    }
+}

--- a/src/MooVC.Tests/Serialization/SerializerTests/WhenSerializeIsCalled.cs
+++ b/src/MooVC.Tests/Serialization/SerializerTests/WhenSerializeIsCalled.cs
@@ -1,0 +1,91 @@
+﻿namespace MooVC.Serialization.SerializerTests;
+
+using System.IO;
+using System.Text;
+using MooVC.Compression;
+
+public sealed class WhenSerializeIsCalled
+{
+    private static readonly byte[] SerializedPayload = Encoding.UTF8.GetBytes("Some payload.");
+    private const string Instance = "Something something dark side...";
+
+    [Test]
+    public async Task GivenACompressorThenCompressAsyncIsInvoked()
+    {
+        // Arrange
+        ICompressor compressor = Substitute.For<ICompressor>();
+
+        _ = compressor
+            .Compress(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(async info =>
+            {
+                Stream source = info.Arg<Stream>();
+                using var copied = new MemoryStream();
+                await source.CopyToAsync(copied, CancellationToken.None);
+                copied.Position = 0;
+                return copied;
+            });
+
+        var serializer = new TestableSerializer(
+            compressor: compressor,
+            onSerialize: async (_, target) => await target.WriteAsync(SerializedPayload, CancellationToken.None));
+
+        // Act
+        IEnumerable<byte> serialized = await serializer.Serialize(Instance, CancellationToken.None);
+
+        // Assert
+        _ = await compressor.Received(1).Compress(Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+        _ = await Assert.That(serialized).IsEquivalentTo(SerializedPayload);
+    }
+
+    [Test]
+    public async Task GivenNoCompressorThenSerializedDataIsCopiedToTheTargetStream()
+    {
+        // Arrange
+        using var target = new MemoryStream();
+        var serializer = new TestableSerializer(
+            onSerialize: async (_, stream) => await stream.WriteAsync(SerializedPayload, CancellationToken.None));
+
+        // Act
+        await serializer.Serialize(Instance, target, CancellationToken.None);
+
+        // Assert
+        _ = await Assert.That(target.ToArray()).IsEquivalentTo(SerializedPayload);
+    }
+
+    [Test]
+    public async Task GivenAStreamThenStreamSerializationIsRequested()
+    {
+        // Arrange
+        bool wasInvoked = false;
+
+        var serializer = new TestableSerializer(
+            onSerialize: (_, _) =>
+            {
+                wasInvoked = true;
+                return Task.CompletedTask;
+            });
+        using var stream = new MemoryStream();
+
+        // Act
+        await serializer.Serialize(Instance, stream, CancellationToken.None);
+
+        // Assert
+        _ = await Assert.That(wasInvoked).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenNullStreamThenThrowsArgumentNullException()
+    {
+        // Arrange
+        var serializer = new TestableSerializer(onSerialize: (_, _) => Task.CompletedTask);
+        Stream? target = default;
+
+        // Act
+        Func<Task> act = async () => await serializer.Serialize(Instance, target!, CancellationToken.None);
+
+        // Assert
+        ArgumentNullException exception = await Assert.That(act).Throws<ArgumentNullException>().And.IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo(nameof(target));
+    }
+}

--- a/src/MooVC.Tests/Serialization/SerializerTests/WhenSerializerIsConstructed.cs
+++ b/src/MooVC.Tests/Serialization/SerializerTests/WhenSerializerIsConstructed.cs
@@ -1,0 +1,21 @@
+﻿namespace MooVC.Serialization.SerializerTests;
+
+public sealed class WhenSerializerIsConstructed
+{
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task GivenANegativeOrZeroBufferSizeThenThrowsArgumentOutOfRangeException(int bufferSize)
+    {
+        // Act
+        Func<Task> act = () =>
+        {
+            _ = new TestableSerializer(bufferSize: bufferSize);
+            return Task.CompletedTask;
+        };
+
+        // Assert
+        ArgumentOutOfRangeException exception = await Assert.That(act).Throws<ArgumentOutOfRangeException>().And.IsNotNull();
+        _ = await Assert.That(exception.ParamName).IsEqualTo(nameof(bufferSize));
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a testable implementation of `Serializer` to allow deterministic and injectable serialize/deserialize behavior in unit tests.
- Verify that optional compression behavior via `ICompressor` is invoked when present and that raw streams/data are forwarded when absent.
- Ensure argument validation and buffer-size validation on the `Serializer` surface behave as expected.

### Description
- Add `TestableSerializer` which inherits `Serializer` and accepts delegate callbacks for `PerformSerialize` and `PerformDeserialize` to drive test scenarios.
- Add `WhenDeserializeIsCalled` tests that assert decompression is invoked when a compressor is provided, that raw source data is passed to the deserializer when no compressor is present, and that null-argument cases throw `ArgumentNullException`.
- Add `WhenSerializeIsCalled` tests that assert compression is invoked when a compressor is provided, that serialized bytes are copied to target streams when no compressor is present, that stream serialization is requested, and that null target streams throw `ArgumentNullException`.
- Add `WhenSerializerIsConstructed` tests that assert passing zero or negative `bufferSize` throws `ArgumentOutOfRangeException`.

### Testing
- Ran the unit test suite for the added tests using `dotnet test` for the `MooVC.Tests` project and observed that all new tests executed successfully.
- Verified assertions for compressor invocation, data round-tripping, and argument/parameter validation all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c466b99f18832fa8d300cbc97e6327)