### PR TITLE
Use target-typed new and simplify object creation across test project

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Argument.Options();
 
-        Argument.Options right = new Argument.Options()
+        Argument.Options right = new()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Argument.Options();
 
-        Argument.Options right = new()
+        var right = new Argument.Options()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsOptionsIsCalled
         // Arrange
         var left = new Argument.Options();
 
-        Argument.Options right = new()
+        var right = new Argument.Options()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsOptionsIsCalled
         // Arrange
         var left = new Argument.Options();
 
-        Argument.Options right = new Argument.Options()
+        Argument.Options right = new()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Argument.Options();
 
-        Argument.Options second = new Argument.Options()
+        Argument.Options second = new()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Argument.Options();
 
-        Argument.Options second = new()
+        var second = new Argument.Options()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Argument.Options();
 
-        Argument.Options right = new()
+        var right = new Argument.Options()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Argument.Options();
 
-        Argument.Options right = new Argument.Options()
+        Argument.Options right = new()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenImplicitOperatorToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenImplicitOperatorToSnippetIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenImplicitOperatorToSnippetIsCalled
         // Arrange
         var subject = new Argument
         {
-            Name = new Identifier(Name),
+            Name = new(Name),
             Value = Snippet.From(Content),
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenImplicitOperatorToStringIsCalled
         // Arrange
         var subject = new Argument
         {
-            Name = new Identifier(Name),
+            Name = new(Name),
             Value = Snippet.From(Content),
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenToSnippetIsCalled.cs
@@ -14,7 +14,7 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Argument
         {
             Modifier = Argument.Mode.Ref,
-            Name = new Identifier(Name),
+            Name = new(Name),
             Value = Snippet.From(Value),
         };
 
@@ -37,7 +37,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Argument
         {
-            Name = new Identifier(Name),
+            Name = new(Name),
             Value = Snippet.From(Value),
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ArgumentTests/WhenValidateIsCalled.cs
@@ -36,7 +36,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Argument
         {
-            Name = new Identifier(Name),
+            Name = new(Name),
             Value = Snippet.From($"line1{Environment.NewLine}line2"),
         };
 
@@ -75,7 +75,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Argument
         {
-            Name = new Identifier(Name),
+            Name = new(Name),
             Value = Snippet.From(Value),
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/AttributeTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/AttributeTestsData.cs
@@ -15,7 +15,8 @@ public static class AttributeTestsData
         return new Attribute
         {
             Arguments = provided,
-            Name = new() {
+            Name = new()
+            {
                 Name = name is null
                     ? Symbol.Moniker.Unnamed
                     : new Symbol.Moniker(name),

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/AttributeTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/AttributeTestsData.cs
@@ -15,8 +15,7 @@ public static class AttributeTestsData
         return new Attribute
         {
             Arguments = provided,
-            Name = new Symbol
-            {
+            Name = new() {
                 Name = name is null
                     ? Symbol.Moniker.Unnamed
                     : new Symbol.Moniker(name),

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/SpecifierTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/SpecifierTests/WhenEqualsObjectIsCalled.cs
@@ -34,7 +34,7 @@ public sealed class WhenEqualsObjectIsCalled
     public async Task GivenNonMatchingTypeThenReturnsFalse()
     {
         // Arrange
-        object value = new();
+        var value = new object();
         Attribute.Specifier subject = Attribute.Specifier.Class;
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenEqualityOperatorAttributeAttributeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenEqualityOperatorAttributeAttributeIsCalled.cs
@@ -21,10 +21,10 @@ public sealed class WhenEqualityOperatorAttributeAttributeIsCalled
     {
         // Arrange
         Attribute left = AttributeTestsData.Create(
-            arguments: new Argument { Name = new Identifier("Left"), Value = Snippet.From("value") });
+            arguments: new Argument { Name = new("Left"), Value = Snippet.From("value") });
 
         Attribute right = AttributeTestsData.Create(
-            arguments: new Argument { Name = new Identifier("Right"), Value = Snippet.From("value") });
+            arguments: new Argument { Name = new("Right"), Value = Snippet.From("value") });
 
         // Act
         bool resultLeftRight = left == right;

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenEqualsObjectIsCalled.cs
@@ -34,7 +34,7 @@ public sealed class WhenEqualsObjectIsCalled
     public async Task GivenNonMatchingTypeThenReturnsFalse()
     {
         // Arrange
-        object value = new();
+        var value = new object();
         Attribute subject = AttributeTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToSnippetIsCalled.cs
@@ -10,8 +10,7 @@ public sealed class WhenImplicitOperatorToSnippetIsCalled
         // Arrange
         var subject = new Attribute
         {
-            Name = new Symbol
-            {
+            Name = new() {
                 Name = Name,
             },
         };

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToSnippetIsCalled.cs
@@ -10,7 +10,8 @@ public sealed class WhenImplicitOperatorToSnippetIsCalled
         // Arrange
         var subject = new Attribute
         {
-            Name = new() {
+            Name = new()
+            {
                 Name = Name,
             },
         };

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -10,7 +10,8 @@ public sealed class WhenImplicitOperatorToStringIsCalled
         // Arrange
         var subject = new Attribute
         {
-            Name = new() {
+            Name = new()
+            {
                 Name = Name,
             },
         };

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -10,8 +10,7 @@ public sealed class WhenImplicitOperatorToStringIsCalled
         // Arrange
         var subject = new Attribute
         {
-            Name = new Symbol
-            {
+            Name = new() {
                 Name = Name,
             },
         };

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenToStringIsCalled.cs
@@ -13,7 +13,7 @@ public sealed class WhenToStringIsCalled
         Attribute attribute = AttributeTestsData.Create(
             arguments: new Argument
             {
-                Name = new Identifier(ArgumentName),
+                Name = new(ArgumentName),
                 Value = Snippet.From(ArgumentValue),
             });
 

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenValidateIsCalled.cs
@@ -13,7 +13,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var attribute = new Attribute
         {
-            Name = new Symbol { Name = AttributeTestsData.DefaultName },
+            Name = new() { Name = AttributeTestsData.DefaultName },
             Arguments =
             [
                 new Argument
@@ -43,7 +43,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var attribute = new Attribute
         {
-            Arguments = [new Argument { Name = new Identifier(ArgumentName), Value = Snippet.From("value") }],
+            Arguments = [new() { Name = new(ArgumentName), Value = Snippet.From("value") }],
         };
 
         var context = new ValidationContext(attribute);
@@ -81,7 +81,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         Attribute attribute = AttributeTestsData.Create(arguments: new Argument
         {
-            Name = new Identifier(ArgumentName),
+            Name = new(ArgumentName),
             Value = Snippet.From("value"),
         });
 

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenWithArgumentsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/WhenWithArgumentsIsCalled.cs
@@ -8,11 +8,11 @@ public sealed class WhenWithArgumentsIsCalled
         // Arrange
         Attribute original = AttributeTestsData.Create(arguments: new Argument
         {
-            Name = new Identifier("Original"),
+            Name = new("Original"),
             Value = Snippet.From("alpha"),
         });
 
-        Argument[] additional = [new Argument { Name = new Identifier("Updated"), Value = Snippet.From("beta") }];
+        Argument[] additional = [new() { Name = new("Updated"), Value = Snippet.From("beta") }];
 
         // Act
         Attribute result = original.WithArguments(additional);

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenAttributedWithIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenAttributedWithIsCalled.cs
@@ -10,12 +10,12 @@ public sealed class WhenAttributedWithIsCalled
         // Arrange
         Attribute[] existing =
         [
-            new Attribute { Name = new Symbol { Name = "Existing" } },
+            new Attribute { Name = new() { Name = "Existing" } },
         ];
 
         Attribute[] additional =
         [
-            new Attribute { Name = new Symbol { Name = "Additional" } },
+            new Attribute { Name = new() { Name = "Additional" } },
         ];
 
         Class original = ClassTestsData.Create(attributes: existing.ToImmutableArray());

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenConstructorIsCalled.cs
@@ -32,13 +32,13 @@ public sealed class WhenConstructorIsCalled
     public async Task GivenValuesThenPropertiesAreAssigned()
     {
         // Arrange
-        var attribute = new Attribute { Name = new Symbol { Name = AttributeName } };
+        var attribute = new Attribute { Name = new() { Name = AttributeName } };
         var constructor = new Constructor();
-        var @event = new Event { Name = new Name("Created") };
-        var field = new Field { Name = new Variable("_value"), Type = typeof(int) };
-        var indexer = new Indexer { Parameter = new Parameter { Name = "Item" } };
-        var method = new Method { Name = new Declaration { Name = "Execute" } };
-        var property = new Property { Name = new Name("Value"), Type = typeof(string) };
+        var @event = new Event { Name = new("Created") };
+        var field = new Field { Name = new("_value"), Type = typeof(int) };
+        var indexer = new Indexer { Parameter = new() { Name = "Item" } };
+        var method = new Method { Name = new() { Name = "Execute" } };
+        var property = new Property { Name = new("Value"), Type = typeof(string) };
 
         // Act
         Class subject = ClassTestsData.Create(
@@ -52,8 +52,8 @@ public sealed class WhenConstructorIsCalled
             isStatic: true,
             methods: [method],
             name: new Declaration { Name = ClassTestsData.DefaultName },
-            operators: new Operators { Conversions = [new Conversion { Target = Symbol.Undefined }] },
-            parameters: [new Parameter { Name = new Variable("input"), Type = typeof(string) }],
+            operators: new Operators { Conversions = [new() { Target = Symbol.Undefined }] },
+            parameters: [new Parameter { Name = new("input"), Type = typeof(string) }],
             properties: [property],
             scope: Scope.Internal);
 

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithEventsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithEventsIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenWithEventsIsCalled
     public async Task GivenEventsThenReturnsUpdatedInstance()
     {
         // Arrange
-        Event[] existing = [new Event { Name = new Name("Created") }];
-        Event[] additional = [new Event { Name = new Name("Updated") }];
+        Event[] existing = [new() { Name = new("Created") }];
+        Event[] additional = [new() { Name = new("Updated") }];
         Class original = ClassTestsData.Create(events: existing.ToImmutableArray());
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithFieldsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithFieldsIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenWithFieldsIsCalled
     public async Task GivenFieldsThenReturnsUpdatedInstance()
     {
         // Arrange
-        Field[] existing = [new Field { Name = new Variable("_first"), Type = typeof(int) }];
-        Field[] additional = [new Field { Name = new Variable("_second"), Type = typeof(string) }];
+        Field[] existing = [new() { Name = new("_first"), Type = typeof(int) }];
+        Field[] additional = [new() { Name = new("_second"), Type = typeof(string) }];
         Class original = ClassTestsData.Create(fields: existing.ToImmutableArray());
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithIndexersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithIndexersIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenWithIndexersIsCalled
     public async Task GivenIndexersThenReturnsUpdatedInstance()
     {
         // Arrange
-        Indexer[] existing = [new Indexer { Parameter = new Parameter { Name = "Item" } }];
-        Indexer[] additional = [new Indexer { Parameter = new Parameter { Name = "Entry" } }];
+        Indexer[] existing = [new() { Parameter = new() { Name = "Item" } }];
+        Indexer[] additional = [new() { Parameter = new() { Name = "Entry" } }];
         Class original = ClassTestsData.Create(indexers: existing.ToImmutableArray());
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithMethodsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithMethodsIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenWithMethodsIsCalled
     public async Task GivenMethodsThenReturnsUpdatedInstance()
     {
         // Arrange
-        Method[] existing = [new Method { Name = new Declaration { Name = "First" } }];
-        Method[] additional = [new Method { Name = new Declaration { Name = "Second" } }];
+        Method[] existing = [new() { Name = new() { Name = "First" } }];
+        Method[] additional = [new() { Name = new() { Name = "Second" } }];
         Class original = ClassTestsData.Create(methods: existing.ToImmutableArray());
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithOperatorsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithOperatorsIsCalled.cs
@@ -9,7 +9,7 @@ public sealed class WhenWithOperatorsIsCalled
         Class original = ClassTestsData.Create();
         var operators = new Operators
         {
-            Conversions = [new Conversion { Target = Symbol.Undefined }],
+            Conversions = [new() { Target = Symbol.Undefined }],
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithParametersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithParametersIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenWithParametersIsCalled
     public async Task GivenParametersThenReturnsUpdatedInstance()
     {
         // Arrange
-        Parameter[] existing = [new Parameter { Name = new Variable("value"), Type = typeof(int) }];
-        Parameter[] additional = [new Parameter { Name = new Variable("text"), Type = typeof(string) }];
+        Parameter[] existing = [new() { Name = new("value"), Type = typeof(int) }];
+        Parameter[] additional = [new() { Name = new("text"), Type = typeof(string) }];
         Class original = ClassTestsData.Create(parameters: existing.ToImmutableArray());
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithPropertiesIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ClassTests/WhenWithPropertiesIsCalled.cs
@@ -8,8 +8,8 @@ public sealed class WhenWithPropertiesIsCalled
     public async Task GivenPropertiesThenReturnsUpdatedInstance()
     {
         // Arrange
-        Property[] existing = [new Property { Name = new Name("First"), Type = typeof(int) }];
-        Property[] additional = [new Property { Name = new Name("Second"), Type = typeof(string) }];
+        Property[] existing = [new() { Name = new("First"), Type = typeof(int) }];
+        Property[] additional = [new() { Name = new("Second"), Type = typeof(string) }];
         Class original = ClassTestsData.Create(properties: existing.ToImmutableArray());
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenEqualityOperatorConstraintConstraintIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenEqualityOperatorConstraintConstraintIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorConstraintConstraintIsCalled
     public async Task GivenDifferentValuesThenReturnsFalse()
     {
         // Arrange
-        var left = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames(SymbolTestsData.DefaultName)) };
+        var left = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames(SymbolTestsData.DefaultName)) };
         var right = new Constraint { Nature = Nature.Class };
 
         // Act
@@ -36,8 +36,8 @@ public sealed class WhenEqualityOperatorConstraintConstraintIsCalled
     public async Task GivenEqualValuesThenReturnsTrue()
     {
         // Arrange
-        var left = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
-        var right = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
+        var left = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
+        var right = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
 
         // Act
         bool result = left == right;
@@ -51,7 +51,7 @@ public sealed class WhenEqualityOperatorConstraintConstraintIsCalled
     {
         // Arrange
         Constraint? left = default;
-        var right = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
+        var right = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
 
         // Act
         bool result = left == right;
@@ -64,7 +64,7 @@ public sealed class WhenEqualityOperatorConstraintConstraintIsCalled
     public async Task GivenLeftValueRightNullThenReturnsFalse()
     {
         // Arrange
-        var left = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
+        var left = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
         Constraint? right = default;
 
         // Act
@@ -78,7 +78,7 @@ public sealed class WhenEqualityOperatorConstraintConstraintIsCalled
     public async Task GivenSameReferenceThenReturnsTrue()
     {
         // Arrange
-        var first = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
+        var first = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
         Constraint second = first;
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenIsUnspecifiedIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenIsUnspecifiedIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenIsUnspecifiedIsCalled
         // Arrange
         var subject = new Constraint
         {
-            Base = new() { Name = "Result" },
+            Base = new Symbol { Name = "Result" },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenIsUnspecifiedIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenIsUnspecifiedIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenIsUnspecifiedIsCalled
         // Arrange
         var subject = new Constraint
         {
-            Base = new Symbol { Name = "Result" },
+            Base = new() { Name = "Result" },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenToStringIsCalled.cs
@@ -12,7 +12,7 @@ public sealed class WhenToStringIsCalled
         var constraint = new Constraint
         {
             Nature = Nature.Class,
-            Base = new() { Name = BaseName },
+            Base = new Symbol() { Name = BaseName },
             Interfaces = [new(new() { Name = InterfaceName })],
             New = New.Required,
         };
@@ -33,7 +33,7 @@ public sealed class WhenToStringIsCalled
         var constraint = new Constraint
         {
             Nature = Nature.Struct,
-            Base = new() { Name = BaseName },
+            Base = new Symbol() { Name = BaseName },
             Interfaces =
             [
                 new Implementation(new Declaration { Name = InterfaceName }),

--- a/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenToStringIsCalled.cs
@@ -12,8 +12,8 @@ public sealed class WhenToStringIsCalled
         var constraint = new Constraint
         {
             Nature = Nature.Class,
-            Base = new Symbol { Name = BaseName },
-            Interfaces = [new Implementation(new Declaration { Name = InterfaceName })],
+            Base = new() { Name = BaseName },
+            Interfaces = [new(new() { Name = InterfaceName })],
             New = New.Required,
         };
 
@@ -33,7 +33,7 @@ public sealed class WhenToStringIsCalled
         var constraint = new Constraint
         {
             Nature = Nature.Struct,
-            Base = new Symbol { Name = BaseName },
+            Base = new() { Name = BaseName },
             Interfaces =
             [
                 new Implementation(new Declaration { Name = InterfaceName }),

--- a/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenValidateIsCalled.cs
@@ -17,7 +17,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Base = new() { Name = InvalidName },
+            Base = new Symbol() { Name = InvalidName },
         };
 
         var context = new ValidationContext(constraint);
@@ -61,7 +61,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Base = new() { Name = InvalidName },
+            Base = new Symbol() { Name = InvalidName },
             Interfaces = [new(new() { Name = InvalidInterfaceName })],
         };
 
@@ -101,7 +101,7 @@ public sealed class WhenValidateIsCalled
         var constraint = new Constraint
         {
             Nature = Nature.Struct,
-            Base = new() { Name = BaseName },
+            Base = new Symbol() { Name = BaseName },
             Interfaces = [new(new() { Name = InterfaceName })],
             New = New.Required,
         };

--- a/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstraintTests/WhenValidateIsCalled.cs
@@ -17,7 +17,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Base = new Symbol { Name = InvalidName },
+            Base = new() { Name = InvalidName },
         };
 
         var context = new ValidationContext(constraint);
@@ -39,7 +39,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Interfaces = [new Implementation(new Declaration { Name = InvalidInterfaceName })],
+            Interfaces = [new(new() { Name = InvalidInterfaceName })],
         };
 
         var context = new ValidationContext(constraint);
@@ -61,8 +61,8 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Base = new Symbol { Name = InvalidName },
-            Interfaces = [new Implementation(new Declaration { Name = InvalidInterfaceName })],
+            Base = new() { Name = InvalidName },
+            Interfaces = [new(new() { Name = InvalidInterfaceName })],
         };
 
         var context = new ValidationContext(constraint);
@@ -101,8 +101,8 @@ public sealed class WhenValidateIsCalled
         var constraint = new Constraint
         {
             Nature = Nature.Struct,
-            Base = new Symbol { Name = BaseName },
-            Interfaces = [new Implementation(new Declaration { Name = InterfaceName })],
+            Base = new() { Name = BaseName },
+            Interfaces = [new(new() { Name = InterfaceName })],
             New = New.Required,
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/ConstructorTests/ConstructorTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ConstructorTests/ConstructorTestsData.cs
@@ -28,7 +28,7 @@ internal static class ConstructorTestsData
     {
         return new Class
         {
-            Declaration = new Declaration { Name = name ?? string.Empty },
+            Declaration = new() { Name = name ?? string.Empty },
         };
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/DeclarationTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/DeclarationTestsData.cs
@@ -17,7 +17,7 @@ internal static class DeclarationTestsData
 
         if (parameterNames?.Length > 0)
         {
-            declaration.Generics = [.. parameterNames.Select(parameter => new Generic { Name = parameter })];
+            declaration.Generics = [.. parameterNames.Select(parameter => new() { Name = parameter })];
         }
 
         return declaration;

--- a/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/DeclarationTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/DeclarationTestsData.cs
@@ -17,7 +17,7 @@ internal static class DeclarationTestsData
 
         if (parameterNames?.Length > 0)
         {
-            declaration.Generics = [.. parameterNames.Select(parameter => new() { Name = parameter })];
+            declaration.Generics = [.. parameterNames.Select(parameter => new Generic() { Name = parameter })];
         }
 
         return declaration;

--- a/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/WhenToStringIsCalled.cs
@@ -31,8 +31,8 @@ public sealed class WhenToStringIsCalled
             Name = Name,
             Generics =
             [
-                new Generic { Name = new Name(FirstParameterName) },
-                new Generic { Name = new Name(SecondParameterName) },
+                new Generic { Name = new(FirstParameterName) },
+                new Generic { Name = new(SecondParameterName) },
             ],
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/WhenValidateIsCalled.cs
@@ -14,7 +14,7 @@ public sealed class WhenValidateIsCalled
         var declaration = new Declaration
         {
             Name = Name,
-            Generics = [new Generic { Name = "Invalid Name" }],
+            Generics = [new() { Name = "Invalid Name" }],
         };
 
         var context = new ValidationContext(declaration);
@@ -36,7 +36,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var declaration = new Declaration
         {
-            Generics = [new Generic { Name = "T" }],
+            Generics = [new() { Name = "T" }],
         };
 
         var context = new ValidationContext(declaration);
@@ -75,7 +75,7 @@ public sealed class WhenValidateIsCalled
         var declaration = new Declaration
         {
             Name = Name,
-            Generics = [new Generic { Name = "T" }],
+            Generics = [new() { Name = "T" }],
         };
 
         var context = new ValidationContext(declaration);

--- a/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/WhenWithGenericsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DeclarationTests/WhenWithGenericsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenWithGenericsIsCalled
     {
         // Arrange
         Declaration original = DeclarationTestsData.Create(parameterNames: "T");
-        Generic[] additional = [new Generic { Name = new Name("U") }];
+        Generic[] additional = [new() { Name = new("U") }];
 
         // Act
         Declaration result = original.WithGenerics(additional);

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenEqualsObjectIsCalled.cs
@@ -80,7 +80,7 @@ public sealed class WhenEqualsObjectIsCalled
         return new Directive
         {
             Alias = alias,
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenEqualsObjectIsCalled.cs
@@ -38,7 +38,7 @@ public sealed class WhenEqualsObjectIsCalled
     {
         // Arrange
         Directive subject = Create();
-        object comparison = new();
+        var comparison = new object();
 
         // Act
         bool result = subject.Equals(comparison);

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenFromIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenFromIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenFromIsCalled
         // Arrange
         var original = new Directive
         {
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         var qualifier = new Qualifier(["MooVC", "Syntax", "CSharp"]);

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenGetHashCodeIsCalled.cs
@@ -10,14 +10,14 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Directive
         {
-            Alias = new Name(Alias),
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Alias = new(Alias),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         var second = new Directive
         {
-            Alias = new Name(Alias + "Alternative"),
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Alias = new(Alias + "Alternative"),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         // Act
@@ -34,14 +34,14 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Directive
         {
-            Alias = new Name(Alias),
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Alias = new(Alias),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         var second = new Directive
         {
-            Alias = new Name(Alias),
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Alias = new(Alias),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenIsStaticIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenIsStaticIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenIsStaticIsCalled
         // Arrange
         var original = new Directive
         {
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenIsSystemIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenIsSystemIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenIsSystemIsCalled
         // Arrange
         var subject = new Directive
         {
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         // Act
@@ -24,7 +24,7 @@ public sealed class WhenIsSystemIsCalled
         // Arrange
         var subject = new Directive
         {
-            Qualifier = new Qualifier(["System", "Linq"]),
+            Qualifier = new(["System", "Linq"]),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenKnownAsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenKnownAsIsCalled.cs
@@ -11,8 +11,8 @@ public sealed class WhenKnownAsIsCalled
         // Arrange
         var original = new Directive
         {
-            Alias = new Name(Alias),
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Alias = new(Alias),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenToSnippetIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Directive
         {
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         Snippet.Options? options = default;

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenToStringIsCalled.cs
@@ -10,8 +10,8 @@ public sealed class WhenToStringIsCalled
         // Arrange
         var subject = new Directive
         {
-            Alias = new Name(Alias),
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Alias = new(Alias),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         // Act
@@ -28,7 +28,7 @@ public sealed class WhenToStringIsCalled
         var subject = new Directive
         {
             IsStatic = true,
-            Qualifier = new Qualifier(["System", "Console"]),
+            Qualifier = new(["System", "Console"]),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/DirectiveTests/WhenValidateIsCalled.cs
@@ -14,8 +14,8 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Directive
         {
-            Alias = new Name(InvalidAlias),
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Alias = new(InvalidAlias),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         var context = new ValidationContext(subject);
@@ -37,7 +37,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Directive
         {
-            Qualifier = new Qualifier([Name.Unnamed, "Syntax"]),
+            Qualifier = new([Name.Unnamed, "Syntax"]),
         };
 
         var context = new ValidationContext(subject);
@@ -59,9 +59,9 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Directive
         {
-            Alias = new Name(Alias),
+            Alias = new(Alias),
             IsStatic = true,
-            Qualifier = new Qualifier(["System", "Console"]),
+            Qualifier = new(["System", "Console"]),
         };
 
         var context = new ValidationContext(subject);
@@ -99,7 +99,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Directive
         {
-            Qualifier = new Qualifier(["MooVC", "Syntax"]),
+            Qualifier = new(["MooVC", "Syntax"]),
         };
 
         var context = new ValidationContext(subject);

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/EventTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/EventTestsData.cs
@@ -13,7 +13,7 @@ internal static class EventTestsData
     {
         var subject = new Event
         {
-            Handler = new Symbol { Name = handler },
+            Handler = new() { Name = handler },
             Name = name,
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/MethodsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/MethodsTests/WhenEqualsObjectIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenEqualsObjectIsCalled
             Add = Snippet.From("value"),
         };
 
-        object target = new();
+        var target = new object();
 
         // Act
         bool result = subject.Equals(target);

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenConstructorIsCalled.cs
@@ -34,8 +34,8 @@ public sealed class WhenConstructorIsCalled
         var subject = new Event
         {
             Behaviours = behaviours,
-            Handler = new Symbol { Name = Handler },
-            Name = new Name(Name),
+            Handler = new() { Name = Handler },
+            Name = new(Name),
             Scope = Scope.Private,
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenEqualsObjectIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenEqualsObjectIsCalled
     {
         // Arrange
         Event subject = EventTestsData.Create();
-        object target = new();
+        var target = new object();
 
         // Act
         bool result = subject.Equals(target);

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenImplicitOperatorToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenImplicitOperatorToSnippetIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenImplicitOperatorToSnippetIsCalled
         // Arrange
         var subject = new Event
         {
-            Handler = new Symbol { Name = Handler },
+            Handler = new() { Name = Handler },
             Name = Name,
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenImplicitOperatorToStringIsCalled
         // Arrange
         var subject = new Event
         {
-            Handler = new Symbol { Name = Handler },
+            Handler = new() { Name = Handler },
             Name = Name,
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenToStringIsCalled.cs
@@ -38,8 +38,8 @@ public sealed class WhenToStringIsCalled
         // Arrange
         var subject = new Event
         {
-            Handler = new Symbol { Name = Handler },
-            Name = new Name(Name),
+            Handler = new() { Name = Handler },
+            Name = new(Name),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/EventTests/WhenValidateIsCalled.cs
@@ -11,8 +11,8 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Event
         {
-            Handler = new Symbol { Name = "Invalid Handler Name" },
-            Name = new Name(EventTestsData.DefaultName),
+            Handler = new() { Name = "Invalid Handler Name" },
+            Name = new(EventTestsData.DefaultName),
         };
 
         var context = new ValidationContext(subject);
@@ -50,7 +50,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var subject = new Event
         {
-            Handler = new Symbol { Name = EventTestsData.DefaultHandler },
+            Handler = new() { Name = EventTestsData.DefaultHandler },
         };
 
         var context = new ValidationContext(subject);

--- a/src/MooVC.Syntax.CSharp.Tests/FieldExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/FieldExtensionsTests/WhenToSnippetIsCalled.cs
@@ -78,7 +78,7 @@ public sealed class WhenToSnippetIsCalled
         {
             IsReadOnly = isReadOnly,
             IsStatic = isStatic,
-            Name = new Identifier(name),
+            Name = new(name),
             Scope = scope ?? Scope.Public,
             Type = typeof(string),
         };

--- a/src/MooVC.Syntax.CSharp.Tests/FieldTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/FieldTests/WhenConstructorIsCalled.cs
@@ -33,7 +33,7 @@ public sealed class WhenConstructorIsCalled
             Default = @default,
             IsReadOnly = false,
             IsStatic = true,
-            Name = new Identifier(FieldTestsData.DefaultName),
+            Name = new(FieldTestsData.DefaultName),
             Scope = Scope.Internal,
             Type = type,
         };

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenConstructorIsCalled.cs
@@ -23,13 +23,13 @@ public sealed class WhenConstructorIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Base = new Base(SymbolTestsData.CreateWithArgumentNames()),
+            Base = new(SymbolTestsData.CreateWithArgumentNames()),
         };
 
         // Act
         var subject = new Generic
         {
-            Name = new Name(ArgumentName),
+            Name = new(ArgumentName),
             Constraints = [constraint],
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualityOperatorArgumentArgumentIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualityOperatorArgumentArgumentIsCalled.cs
@@ -111,9 +111,9 @@ public sealed class WhenEqualityOperatorArgumentArgumentIsCalled
     {
         return new Generic
         {
-            Name = new Name(name),
+            Name = new(name),
             Constraints = constraint is null
-                ? [new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) }]
+                ? [new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) }]
                 : [constraint],
         };
     }

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualsArgumentIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualsArgumentIsCalled.cs
@@ -109,9 +109,9 @@ public sealed class WhenEqualsArgumentIsCalled
     {
         return new Generic
         {
-            Name = new Name(name),
+            Name = new(name),
             Constraints = constraint is null
-                ? [new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) }]
+                ? [new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) }]
                 : [constraint],
         };
     }

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualsObjectIsCalled.cs
@@ -81,8 +81,8 @@ public sealed class WhenEqualsObjectIsCalled
     {
         return new Generic
         {
-            Name = new Name(name),
-            Constraints = [new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) }],
+            Name = new(name),
+            Constraints = [new() { Base = new(SymbolTestsData.CreateWithArgumentNames()) }],
         };
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenEqualsObjectIsCalled.cs
@@ -39,7 +39,7 @@ public sealed class WhenEqualsObjectIsCalled
     public async Task GivenNonArgumentThenReturnsFalse()
     {
         // Arrange
-        object other = new();
+        var other = new object();
         Generic subject = Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenGetHashCodeIsCalled.cs
@@ -40,8 +40,8 @@ public sealed class WhenGetHashCodeIsCalled
     {
         return new Generic
         {
-            Name = new Name(name),
-            Constraints = [new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) }],
+            Name = new(name),
+            Constraints = [new() { Base = new(SymbolTestsData.CreateWithArgumentNames()) }],
         };
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -10,7 +10,7 @@ public sealed class WhenImplicitOperatorToStringIsCalled
         // Arrange
         var subject = new Generic
         {
-            Name = new Name(Name),
+            Name = new(Name),
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenInequalityOperatorArgumentArgumentIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenInequalityOperatorArgumentArgumentIsCalled.cs
@@ -82,8 +82,8 @@ public sealed class WhenInequalityOperatorArgumentArgumentIsCalled
     {
         return new Generic
         {
-            Name = new Name(name),
-            Constraints = [new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) }],
+            Name = new(name),
+            Constraints = [new() { Base = new(SymbolTestsData.CreateWithArgumentNames()) }],
         };
     }
 }

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenNamedIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenNamedIsCalled.cs
@@ -11,11 +11,11 @@ public sealed class WhenNamedIsCalled
     public async Task GivenValueThenReturnsNewInstanceWithUpdatedName()
     {
         // Arrange
-        var constraint = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
+        var constraint = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
 
         var original = new Generic
         {
-            Name = new Name(DefaultName),
+            Name = new(DefaultName),
             Constraints = [constraint],
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenToStringIsCalled.cs
@@ -10,11 +10,11 @@ public sealed class WhenToStringIsCalled
     public async Task GivenValueThenReturnsFormattedString()
     {
         // Arrange
-        var constraint = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
+        var constraint = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
 
         var subject = new Generic
         {
-            Name = new Name(Name),
+            Name = new(Name),
             Constraints = [constraint],
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenValidateIsCalled.cs
@@ -97,7 +97,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Base = new() { Name = "Base" },
+            Base = new Symbol() { Name = "Base" },
             Interfaces = [new(new() { Name = InterfaceName })],
             New = New.Required,
         };

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenValidateIsCalled.cs
@@ -15,7 +15,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Interfaces = [new Implementation(new Declaration { Name = InvalidInterfaceName })],
+            Interfaces = [new(new() { Name = InvalidInterfaceName })],
         };
 
         var subject = new Generic
@@ -97,8 +97,8 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var constraint = new Constraint
         {
-            Base = new Symbol { Name = "Base" },
-            Interfaces = [new Implementation(new Declaration { Name = InterfaceName })],
+            Base = new() { Name = "Base" },
+            Interfaces = [new(new() { Name = InterfaceName })],
             New = New.Required,
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenWithConstraintsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/GenericTests/WhenWithConstraintsIsCalled.cs
@@ -10,11 +10,11 @@ public sealed class WhenWithConstraintsIsCalled
     public async Task GivenAdditionalConstraintsThenReturnsNewInstanceWithCombinedValues()
     {
         // Arrange
-        var originalConstraint = new Constraint { Base = new Base(SymbolTestsData.CreateWithArgumentNames()) };
+        var originalConstraint = new Constraint { Base = new(SymbolTestsData.CreateWithArgumentNames()) };
 
         var original = new Generic
         {
-            Name = new Name(Name),
+            Name = new(Name),
             Constraints = [originalConstraint],
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenValidateIsCalled.cs
@@ -14,7 +14,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         Implementation subject = new Declaration
         {
-            Generics = [new Generic()],
+            Generics = [new()],
         };
 
         var context = new ValidationContext(subject);

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerExtensionsTests/WhenToSnippetIsCalled.cs
@@ -44,15 +44,15 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         Indexer publicVirtual = IndexerTestsData.Create(
             parameter: new Parameter { Name = "Beta", Type = typeof(Version) },
-            result: new Result { Type = new Symbol { Name = "int" } });
+            result: new Result { Type = new() { Name = "int" } });
 
         Indexer publicStatic = IndexerTestsData.Create(
             parameter: new Parameter { Name = "Alpha", Type = typeof(Version) },
-            result: new Result { Type = new Symbol { Name = "string" } });
+            result: new Result { Type = new() { Name = "string" } });
 
         Indexer protectedVirtual = IndexerTestsData.Create(
             parameter: new Parameter { Name = "Gamma", Type = typeof(Version) },
-            result: new Result { Type = new Symbol { Name = "int" } },
+            result: new Result { Type = new() { Name = "int" } },
             scope: Scope.Protected);
 
         publicVirtual.Extensibility = Extensibility.Virtual;

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/IndexerTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/IndexerTestsData.cs
@@ -17,12 +17,12 @@ internal static class IndexerTestsData
             Parameter = parameter ?? new Parameter
             {
                 Name = DefaultParameterName,
-                Type = new Symbol { Name = DefaultParameterType },
+                Type = new() { Name = DefaultParameterType },
             },
             Result = result ?? new Result
             {
                 Mode = Result.Modality.Synchronous,
-                Type = new Symbol { Name = DefaultResultType },
+                Type = new() { Name = DefaultResultType },
             },
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/MethodsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/MethodsTests/WhenEqualsObjectIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenEqualsObjectIsCalled
             Get = Snippet.From("value"),
         };
 
-        object target = new();
+        var target = new object();
 
         // Act
         bool result = subject.Equals(target);

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenAcceptsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenAcceptsIsCalled.cs
@@ -13,7 +13,7 @@ public sealed class WhenAcceptsIsCalled
         var parameter = new Parameter
         {
             Name = ParameterName,
-            Type = new Symbol { Name = IndexerTestsData.DefaultParameterType },
+            Type = new() { Name = IndexerTestsData.DefaultParameterType },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenConstructorIsCalled.cs
@@ -34,11 +34,13 @@ public sealed class WhenConstructorIsCalled
         var subject = new Indexer
         {
             Behaviours = behaviours,
-            Parameter = new() {
+            Parameter = new()
+            {
                 Name = ParameterName,
                 Type = new() { Name = ParameterType },
             },
-            Result = new() {
+            Result = new()
+            {
                 Mode = Result.Modality.Synchronous,
                 Type = new() { Name = ResultType },
             },

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenConstructorIsCalled.cs
@@ -34,15 +34,13 @@ public sealed class WhenConstructorIsCalled
         var subject = new Indexer
         {
             Behaviours = behaviours,
-            Parameter = new Parameter
-            {
+            Parameter = new() {
                 Name = ParameterName,
-                Type = new Symbol { Name = ParameterType },
+                Type = new() { Name = ParameterType },
             },
-            Result = new Result
-            {
+            Result = new() {
                 Mode = Result.Modality.Synchronous,
-                Type = new Symbol { Name = ResultType },
+                Type = new() { Name = ResultType },
             },
             Scope = Scope.Private,
         };
@@ -54,13 +52,13 @@ public sealed class WhenConstructorIsCalled
         _ = await Assert.That(subject.Parameter).IsEqualTo(new Parameter
         {
             Name = ParameterName,
-            Type = new Symbol { Name = ParameterType },
+            Type = new() { Name = ParameterType },
         });
 
         _ = await Assert.That(subject.Result).IsEqualTo(new Result
         {
             Mode = Result.Modality.Synchronous,
-            Type = new Symbol { Name = ResultType },
+            Type = new() { Name = ResultType },
         });
 
         _ = await Assert.That(subject.Scope).IsEqualTo(Scope.Private);

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenEqualityOperatorIndexerIndexerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenEqualityOperatorIndexerIndexerIsCalled.cs
@@ -46,7 +46,7 @@ public sealed class WhenEqualityOperatorIndexerIndexerIsCalled
             result: new Result
             {
                 Mode = Result.Modality.Synchronous,
-                Type = new Symbol { Name = "int" },
+                Type = new() { Name = "int" },
             });
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenEqualsIndexerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenEqualsIndexerIsCalled.cs
@@ -31,7 +31,7 @@ public sealed class WhenEqualsIndexerIsCalled
             result: new Result
             {
                 Mode = Result.Modality.Synchronous,
-                Type = new Symbol { Name = "int" },
+                Type = new() { Name = "int" },
             });
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenEqualsObjectIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenEqualsObjectIsCalled
     {
         // Arrange
         Indexer subject = IndexerTestsData.Create();
-        object target = new();
+        var target = new object();
 
         // Act
         bool result = subject.Equals(target);

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenGetHashCodeIsCalled.cs
@@ -32,7 +32,7 @@ public sealed class WhenGetHashCodeIsCalled
             result: new Result
             {
                 Mode = Result.Modality.Synchronous,
-                Type = new Symbol { Name = "int" },
+                Type = new() { Name = "int" },
             });
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenInequalityOperatorIndexerIndexerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenInequalityOperatorIndexerIndexerIsCalled.cs
@@ -47,7 +47,7 @@ public sealed class WhenInequalityOperatorIndexerIndexerIsCalled
             result: new Result
             {
                 Mode = Result.Modality.Synchronous,
-                Type = new Symbol { Name = "int" },
+                Type = new() { Name = "int" },
             });
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenReturnsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenReturnsIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenReturnsIsCalled
         var result = new Result
         {
             Mode = Result.Modality.Synchronous,
-            Type = new Symbol { Name = "int" },
+            Type = new() { Name = "int" },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/IndexerTests/WhenValidateIsCalled.cs
@@ -33,7 +33,7 @@ public sealed class WhenValidateIsCalled
             {
                 Default = Snippet.From($"first{Environment.NewLine}second"),
                 Name = IndexerTestsData.DefaultParameterName,
-                Type = new Symbol { Name = IndexerTestsData.DefaultParameterType },
+                Type = new() { Name = IndexerTestsData.DefaultParameterType },
             });
 
         var context = new ValidationContext(subject);

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenAttributedWithIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenAttributedWithIsCalled.cs
@@ -10,12 +10,12 @@ public sealed class WhenAttributedWithIsCalled
         // Arrange
         Attribute[] existing =
         [
-            new Attribute { Name = new Symbol { Name = "Existing" } },
+            new Attribute { Name = new() { Name = "Existing" } },
         ];
 
         Attribute[] additional =
         [
-            new Attribute { Name = new Symbol { Name = "Additional" } },
+            new Attribute { Name = new() { Name = "Additional" } },
         ];
 
         Interface original = InterfaceTestsData.Create(attributes: existing.ToImmutableArray());

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenConstructorIsCalled.cs
@@ -27,11 +27,11 @@ public sealed class WhenConstructorIsCalled
     public async Task GivenValuesThenPropertiesAreAssigned()
     {
         // Arrange
-        var attribute = new Attribute { Name = new Symbol { Name = AttributeName } };
-        var @event = new Event { Name = new Name("Created") };
-        var indexer = new Indexer { Parameter = new Parameter { Name = "Item" } };
-        var method = new Method { Name = new Declaration { Name = "Execute" } };
-        var property = new Property { Name = new Name("Value"), Type = typeof(string) };
+        var attribute = new Attribute { Name = new() { Name = AttributeName } };
+        var @event = new Event { Name = new("Created") };
+        var indexer = new Indexer { Parameter = new() { Name = "Item" } };
+        var method = new Method { Name = new() { Name = "Execute" } };
+        var property = new Property { Name = new("Value"), Type = typeof(string) };
 
         // Act
         Interface subject = InterfaceTestsData.Create(
@@ -41,7 +41,7 @@ public sealed class WhenConstructorIsCalled
             isPartial: true,
             methods: [method],
             name: new Declaration { Name = InterfaceTestsData.DefaultName },
-            operators: new Operators { Conversions = [new Conversion { Target = Symbol.Undefined }] },
+            operators: new Operators { Conversions = [new() { Target = Symbol.Undefined }] },
             properties: [property],
             scope: Scope.Internal);
 

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenToSnippetIsCalled.cs
@@ -26,7 +26,7 @@ public sealed class WhenToSnippetIsCalled
 
         var valueB = new Property
         {
-            Behaviours = new Property.Methods { Set = new() { Mode = Property.Methods.Setter.Modes.ReadOnly } },
+            Behaviours = new() { Set = new() { Mode = Property.Methods.Setter.Modes.ReadOnly } },
             Name = "ValueB",
             Type = typeof(int),
         };

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenToStringIsCalled.cs
@@ -20,8 +20,8 @@ public sealed class WhenToStringIsCalled
     {
         // Arrange
         var created = new Event { Name = "Created" };
-        var execute = new Method { Name = new Declaration { Name = "Execute" } };
-        var indexer = new Indexer { Parameter = new Parameter { Name = "item", Type = typeof(string) }, Result = typeof(int) };
+        var execute = new Method { Name = new() { Name = "Execute" } };
+        var indexer = new Indexer { Parameter = new() { Name = "item", Type = typeof(string) }, Result = typeof(int) };
         var valueA = new Property { Name = "ValueA", Type = typeof(string) };
 
         var valueB = new Property

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithEventsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithEventsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithEventsIsCalled
     public async Task GivenEventsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var @event = new Event { Name = new Name("Created") };
+        var @event = new Event { Name = new("Created") };
         Interface original = InterfaceTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithIndexersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithIndexersIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithIndexersIsCalled
     public async Task GivenIndexersThenReturnsUpdatedInstance()
     {
         // Arrange
-        var indexer = new Indexer { Parameter = new Parameter { Name = "Item" } };
+        var indexer = new Indexer { Parameter = new() { Name = "Item" } };
         Interface original = InterfaceTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithMethodsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithMethodsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithMethodsIsCalled
     public async Task GivenMethodsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var method = new Method { Name = new Declaration { Name = "Execute" } };
+        var method = new Method { Name = new() { Name = "Execute" } };
         Interface original = InterfaceTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithOperatorsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithOperatorsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithOperatorsIsCalled
     public async Task GivenOperatorsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var operators = new Operators { Conversions = [new Conversion { Target = Symbol.Undefined }] };
+        var operators = new Operators { Conversions = [new() { Target = Symbol.Undefined }] };
         Interface original = InterfaceTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithPropertiesIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/InterfaceTests/WhenWithPropertiesIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithPropertiesIsCalled
     public async Task GivenPropertiesThenReturnsUpdatedInstance()
     {
         // Arrange
-        var property = new Property { Name = new Name("Value"), Type = typeof(string) };
+        var property = new Property { Name = new("Value"), Type = typeof(string) };
         Interface original = InterfaceTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/MethodTests/MethodTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MethodTests/MethodTestsData.cs
@@ -24,7 +24,7 @@ internal static class MethodTestsData
             Result = result ?? new Result
             {
                 Mode = Result.Modality.Synchronous,
-                Type = new Symbol { Name = DefaultResultType },
+                Type = new() { Name = DefaultResultType },
             },
             Parameters = Create(parameters),
         };
@@ -52,7 +52,7 @@ internal static class MethodTestsData
                 new Parameter
                 {
                     Name = DefaultParameterName,
-                    Type = new Symbol { Name = DefaultParameterType },
+                    Type = new() { Name = DefaultParameterType },
                 },
             ];
         }

--- a/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenAcceptsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenAcceptsIsCalled.cs
@@ -12,8 +12,8 @@ public sealed class WhenAcceptsIsCalled
         [
             new Parameter
             {
-                Name = new Variable("other"),
-                Type = new Symbol { Name = MethodTestsData.DefaultParameterType },
+                Name = new("other"),
+                Type = new() { Name = MethodTestsData.DefaultParameterType },
             },
         ];
 

--- a/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenConstructorIsCalled.cs
@@ -27,20 +27,20 @@ public sealed class WhenConstructorIsCalled
         [
             new Parameter
             {
-                Name = new Identifier(MethodTestsData.DefaultParameterName),
-                Type = new Symbol { Name = MethodTestsData.DefaultParameterType },
+                Name = new(MethodTestsData.DefaultParameterName),
+                Type = new() { Name = MethodTestsData.DefaultParameterType },
             },
             new Parameter
             {
-                Name = new Identifier("other"),
-                Type = new Symbol { Name = "bool" },
+                Name = new("other"),
+                Type = new() { Name = "bool" },
             },
         ];
 
         var result = new Result
         {
             Mode = Result.Modality.Synchronous,
-            Type = new Symbol { Name = MethodTestsData.DefaultResultType },
+            Type = new() { Name = MethodTestsData.DefaultResultType },
         };
 
         const string body = "return value;";
@@ -49,7 +49,7 @@ public sealed class WhenConstructorIsCalled
         var subject = new Method
         {
             Body = Snippet.From(body),
-            Name = new Declaration { Name = MethodTestsData.DefaultName },
+            Name = new() { Name = MethodTestsData.DefaultName },
             Parameters = parameters,
             Result = result,
             Scope = Scope.Internal,

--- a/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenEqualsMethodIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenEqualsMethodIsCalled.cs
@@ -53,7 +53,7 @@ public sealed class WhenEqualsMethodIsCalled
         Method target = MethodTestsData.Create(result: new Result
         {
             Mode = Result.Modality.Synchronous,
-            Type = new Symbol { Name = "bool" },
+            Type = new() { Name = "bool" },
         });
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenReturnsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenReturnsIsCalled.cs
@@ -10,7 +10,7 @@ public sealed class WhenReturnsIsCalled
         var result = new Result
         {
             Mode = Result.Modality.Synchronous,
-            Type = new Symbol { Name = "bool" },
+            Type = new() { Name = "bool" },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MethodTests/WhenValidateIsCalled.cs
@@ -15,7 +15,7 @@ public sealed class WhenValidateIsCalled
             {
                 Default = Snippet.From($"first{Environment.NewLine}second"),
                 Name = MethodTestsData.DefaultParameterName,
-                Type = new Symbol { Name = MethodTestsData.DefaultParameterType },
+                Type = new() { Name = MethodTestsData.DefaultParameterType },
             },
         ]);
 
@@ -94,7 +94,7 @@ public sealed class WhenValidateIsCalled
                 new Parameter
                 {
                     Name = MethodTestsData.DefaultParameterName,
-                    Type = new Symbol { Name = MethodTestsData.DefaultParameterType },
+                    Type = new() { Name = MethodTestsData.DefaultParameterType },
                 },
             ],
             body: Snippet.From("return value;"));

--- a/src/MooVC.Syntax.CSharp.Tests/OperatorsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OperatorsTests/WhenEqualsObjectIsCalled.cs
@@ -34,7 +34,7 @@ public sealed class WhenEqualsObjectIsCalled
     public async Task GivenWrongTypeThenReturnsFalse()
     {
         // Arrange
-        object subject = new();
+        var subject = new object();
         Operators target = OperatorsSubjectData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/OperatorsTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OperatorsTestsData.cs
@@ -16,7 +16,7 @@ internal static class OperatorsTestsData
     {
         public TestType(string name, bool isUndefined)
         {
-            Declaration = new Declaration { Name = name };
+            Declaration = new() { Name = name };
             IsUndefined = isUndefined;
         }
 

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
     {
         // Arrange
         var left = new Options();
-        Options right = new().WithNamespace(Qualifier.Options.Block);
+        var right = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act
         bool result = left == right;

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
     {
         // Arrange
         var left = new Options();
-        Options right = new Options().WithNamespace(Qualifier.Options.Block);
+        Options right = new().WithNamespace(Qualifier.Options.Block);
 
         // Act
         bool result = left == right;

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenEqualsOptionsIsCalled
     {
         // Arrange
         var subject = new Options();
-        Options other = new Options().WithNamespace(Qualifier.Options.Block);
+        Options other = new().WithNamespace(Qualifier.Options.Block);
 
         // Act
         bool result = subject.Equals(other);

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenEqualsOptionsIsCalled
     {
         // Arrange
         var subject = new Options();
-        Options other = new().WithNamespace(Qualifier.Options.Block);
+        var other = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act
         bool result = subject.Equals(other);

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenGetHashCodeIsCalled
     {
         // Arrange
         var left = new Options();
-        Options right = new().WithNamespace(Qualifier.Options.Block);
+        var right = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act
         int leftHash = left.GetHashCode();

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenGetHashCodeIsCalled
     {
         // Arrange
         var left = new Options();
-        Options right = new Options().WithNamespace(Qualifier.Options.Block);
+        Options right = new().WithNamespace(Qualifier.Options.Block);
 
         // Act
         int leftHash = left.GetHashCode();

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
     {
         // Arrange
         var left = new Options();
-        Options right = new().WithNamespace(Qualifier.Options.Block);
+        var right = new Options().WithNamespace(Qualifier.Options.Block);
 
         // Act
         bool result = left != right;

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
     {
         // Arrange
         var left = new Options();
-        Options right = new Options().WithNamespace(Qualifier.Options.Block);
+        Options right = new().WithNamespace(Qualifier.Options.Block);
 
         // Act
         bool result = left != right;

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenIsDefaultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenIsDefaultIsCalled.cs
@@ -19,7 +19,7 @@ public sealed class WhenIsDefaultIsCalled
     public async Task GivenNonDefaultValuesThenReturnsFalse()
     {
         // Arrange
-        Options subject = new Options()
+        Options subject = new()
             .WithNamespace(Qualifier.Options.Block);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenIsDefaultIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenIsDefaultIsCalled.cs
@@ -19,7 +19,7 @@ public sealed class WhenIsDefaultIsCalled
     public async Task GivenNonDefaultValuesThenReturnsFalse()
     {
         // Arrange
-        Options subject = new()
+        var subject = new Options()
             .WithNamespace(Qualifier.Options.Block);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenWithSnippetsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenWithSnippetsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenWithSnippetsIsCalled
     {
         // Arrange
         var original = new Options();
-        Snippet.Options replacement = new Snippet.Options().WithWhitespace("	");
+        Snippet.Options replacement = new().WithWhitespace("	");
 
         // Act
         Options result = original.WithSnippets(replacement);

--- a/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenWithSnippetsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/OptionsTests/WhenWithSnippetsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenWithSnippetsIsCalled
     {
         // Arrange
         var original = new Options();
-        Snippet.Options replacement = new().WithWhitespace("	");
+        var replacement = new Snippet.Options().WithWhitespace("	");
 
         // Act
         Options result = original.WithSnippets(replacement);

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Parameter.Options();
 
-        Parameter.Options right = new Parameter.Options()
+        Parameter.Options right = new()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Parameter.Options();
 
-        Parameter.Options right = new()
+        var right = new Parameter.Options()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var left = new Parameter.Options();
 
-        Parameter.Options right = new()
+        var right = new Parameter.Options()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var left = new Parameter.Options();
 
-        Parameter.Options right = new Parameter.Options()
+        Parameter.Options right = new()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Parameter.Options();
 
-        Parameter.Options right = new Parameter.Options()
+        Parameter.Options right = new()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Parameter.Options();
 
-        Parameter.Options right = new()
+        var right = new Parameter.Options()
             .WithNaming(Variable.Options.Pascal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenAttributedWithIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenAttributedWithIsCalled.cs
@@ -10,7 +10,7 @@ public sealed class WhenAttributedWithIsCalled
         [
             new Attribute
             {
-                Name = new Symbol { Name = "Existing" },
+                Name = new() { Name = "Existing" },
             },
         ];
 
@@ -18,7 +18,7 @@ public sealed class WhenAttributedWithIsCalled
         [
             new Attribute
             {
-                Name = new Symbol { Name = "Additional" },
+                Name = new() { Name = "Additional" },
             },
         ];
 

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenEqualityOperatorParameterParameterIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenEqualityOperatorParameterParameterIsCalled.cs
@@ -20,8 +20,8 @@ public sealed class WhenEqualityOperatorParameterParameterIsCalled
     public async Task GivenDifferentAttributesThenReturnsFalse()
     {
         // Arrange
-        Parameter left = ParameterTestsData.Create(attributes: new Attribute { Name = new Symbol { Name = "Left" } });
-        Parameter right = ParameterTestsData.Create(attributes: new Attribute { Name = new Symbol { Name = "Right" } });
+        Parameter left = ParameterTestsData.Create(attributes: new Attribute { Name = new() { Name = "Left" } });
+        Parameter right = ParameterTestsData.Create(attributes: new Attribute { Name = new() { Name = "Right" } });
 
         // Act
         bool resultLeftRight = left == right;

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenEqualsParameterIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenEqualsParameterIsCalled.cs
@@ -22,8 +22,8 @@ public sealed class WhenEqualsParameterIsCalled
     public async Task GivenDifferentAttributesThenReturnsFalse()
     {
         // Arrange
-        Parameter left = ParameterTestsData.Create(attributes: new Attribute { Name = new Symbol { Name = "First" } });
-        Parameter right = ParameterTestsData.Create(attributes: new Attribute { Name = new Symbol { Name = "Second" } });
+        Parameter left = ParameterTestsData.Create(attributes: new Attribute { Name = new() { Name = "First" } });
+        Parameter right = ParameterTestsData.Create(attributes: new Attribute { Name = new() { Name = "Second" } });
 
         // Act
         bool result = left.Equals(right);

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenToStringIsCalled.cs
@@ -14,7 +14,7 @@ public sealed class WhenToStringIsCalled
         Parameter parameter = ParameterTestsData.Create(
             attributes: new Attribute
             {
-                Name = new Symbol { Name = AttributeName },
+                Name = new() { Name = AttributeName },
             },
             modifier: Parameter.Mode.Out);
 

--- a/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ParameterTests/WhenValidateIsCalled.cs
@@ -91,7 +91,7 @@ public sealed class WhenValidateIsCalled
             modifier: Parameter.Mode.Out,
             attributes: new Attribute
             {
-                Name = new Symbol { Name = AttributeName },
+                Name = new() { Name = AttributeName },
             });
 
         var context = new ValidationContext(parameter);

--- a/src/MooVC.Syntax.CSharp.Tests/PropertyTests/MethodsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/PropertyTests/MethodsTests/WhenToSnippetIsCalled.cs
@@ -22,7 +22,8 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Property.Methods
         {
             Get = Snippet.From("value;"),
-            Set = new() {
+            Set = new()
+            {
                 Mode = Property.Methods.Setter.Modes.ReadOnly,
             },
         };
@@ -41,7 +42,8 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Property.Methods
         {
             Get = Snippet.From("value;"),
-            Set = new() {
+            Set = new()
+            {
                 Behaviour = Snippet.From("_value = value;"),
                 Scope = Scope.Private,
             },

--- a/src/MooVC.Syntax.CSharp.Tests/PropertyTests/MethodsTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/PropertyTests/MethodsTests/WhenToSnippetIsCalled.cs
@@ -22,8 +22,7 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Property.Methods
         {
             Get = Snippet.From("value;"),
-            Set = new Property.Methods.Setter
-            {
+            Set = new() {
                 Mode = Property.Methods.Setter.Modes.ReadOnly,
             },
         };
@@ -42,8 +41,7 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Property.Methods
         {
             Get = Snippet.From("value;"),
-            Set = new Property.Methods.Setter
-            {
+            Set = new() {
                 Behaviour = Snippet.From("_value = value;"),
                 Scope = Scope.Private,
             },

--- a/src/MooVC.Syntax.CSharp.Tests/PropertyTests/MethodsTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/PropertyTests/MethodsTests/WhenToStringIsCalled.cs
@@ -23,7 +23,7 @@ public sealed class WhenToStringIsCalled
         var subject = new Property.Methods
         {
             Get = Snippet.From("value;"),
-            Set = new Property.Methods.Setter { Mode = Property.Methods.Setter.Modes.ReadOnly },
+            Set = new() { Mode = Property.Methods.Setter.Modes.ReadOnly },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/PropertyTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/PropertyTests/WhenConstructorIsCalled.cs
@@ -28,7 +28,8 @@ public sealed class WhenConstructorIsCalled
         var behaviours = new Property.Methods
         {
             Get = Snippet.From(DefaultValue),
-            Set = new() {
+            Set = new()
+            {
                 Behaviour = Snippet.From("value = input"),
                 Mode = Property.Methods.Setter.Modes.Init,
                 Scope = Scope.Private,

--- a/src/MooVC.Syntax.CSharp.Tests/PropertyTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/PropertyTests/WhenConstructorIsCalled.cs
@@ -28,8 +28,7 @@ public sealed class WhenConstructorIsCalled
         var behaviours = new Property.Methods
         {
             Get = Snippet.From(DefaultValue),
-            Set = new Property.Methods.Setter
-            {
+            Set = new() {
                 Behaviour = Snippet.From("value = input"),
                 Mode = Property.Methods.Setter.Modes.Init,
                 Scope = Scope.Private,
@@ -43,7 +42,7 @@ public sealed class WhenConstructorIsCalled
             Default = Snippet.From(DefaultValue),
             Name = PropertyName,
             Scope = Scope.Internal,
-            Type = new Symbol { Name = PropertyType },
+            Type = new() { Name = PropertyType },
         };
 
         // Assert

--- a/src/MooVC.Syntax.CSharp.Tests/PropertyTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/PropertyTests/WhenToSnippetIsCalled.cs
@@ -9,7 +9,7 @@ public sealed class WhenToSnippetIsCalled
         var behaviours = new Property.Methods
         {
             Get = Snippet.From("value;"),
-            Set = new Property.Methods.Setter { Mode = Property.Methods.Setter.Modes.ReadOnly },
+            Set = new() { Mode = Property.Methods.Setter.Modes.ReadOnly },
         };
 
         Property subject = PropertyTestsData.Create(behaviours: behaviours);

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenAttributedWithIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenAttributedWithIsCalled.cs
@@ -10,12 +10,12 @@ public sealed class WhenAttributedWithIsCalled
         // Arrange
         Attribute[] existing =
         [
-            new Attribute { Name = new Symbol { Name = "Existing" } },
+            new Attribute { Name = new() { Name = "Existing" } },
         ];
 
         Attribute[] additional =
         [
-            new Attribute { Name = new Symbol { Name = "Additional" } },
+            new Attribute { Name = new() { Name = "Additional" } },
         ];
 
         Record original = RecordTestsData.Create(attributes: existing.ToImmutableArray());

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenConstructorIsCalled.cs
@@ -31,13 +31,13 @@ public sealed class WhenConstructorIsCalled
     public async Task GivenValuesThenPropertiesAreAssigned()
     {
         // Arrange
-        var attribute = new Attribute { Name = new Symbol { Name = AttributeName } };
+        var attribute = new Attribute { Name = new() { Name = AttributeName } };
         var constructor = new Constructor();
-        var @event = new Event { Name = new Name("Created") };
-        var field = new Field { Name = new Variable("_value"), Type = typeof(int) };
-        var indexer = new Indexer { Parameter = new Parameter { Name = "Item" } };
-        var method = new Method { Name = new Declaration { Name = "Execute" } };
-        var property = new Property { Name = new Name("Value"), Type = typeof(string) };
+        var @event = new Event { Name = new("Created") };
+        var field = new Field { Name = new("_value"), Type = typeof(int) };
+        var indexer = new Indexer { Parameter = new() { Name = "Item" } };
+        var method = new Method { Name = new() { Name = "Execute" } };
+        var property = new Property { Name = new("Value"), Type = typeof(string) };
 
         // Act
         Record subject = RecordTestsData.Create(
@@ -50,8 +50,8 @@ public sealed class WhenConstructorIsCalled
             isPartial: true,
             methods: [method],
             name: new Declaration { Name = RecordTestsData.DefaultName },
-            operators: new Operators { Conversions = [new Conversion { Target = Symbol.Undefined }] },
-            parameters: [new Parameter { Name = new Variable("input"), Type = typeof(string) }],
+            operators: new Operators { Conversions = [new() { Target = Symbol.Undefined }] },
+            parameters: [new Parameter { Name = new("input"), Type = typeof(string) }],
             properties: [property],
             scope: Scope.Internal);
 

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenEqualsRecordIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenEqualsRecordIsCalled.cs
@@ -47,7 +47,7 @@ public sealed class WhenEqualsRecordIsCalled
     public async Task GivenSameReferenceThenReturnsTrue()
     {
         // Arrange
-        Record subject = RecordTestsData.Create(methods: [new Method { Name = new Declaration { Name = "Execute" } }]);
+        Record subject = RecordTestsData.Create(methods: [new Method { Name = new() { Name = "Execute" } }]);
 
         // Act
         bool result = subject.Equals(subject);

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenInequalityOperatorRecordRecordIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenInequalityOperatorRecordRecordIsCalled.cs
@@ -48,8 +48,8 @@ public sealed class WhenInequalityOperatorRecordRecordIsCalled
     public async Task GivenEqualValuesThenReturnsFalse()
     {
         // Arrange
-        Record left = RecordTestsData.Create(parameters: [new Parameter { Name = new Variable("input"), Type = typeof(string) }]);
-        Record right = RecordTestsData.Create(parameters: [new Parameter { Name = new Variable("input"), Type = typeof(string) }]);
+        Record left = RecordTestsData.Create(parameters: [new Parameter { Name = new("input"), Type = typeof(string) }]);
+        Record right = RecordTestsData.Create(parameters: [new Parameter { Name = new("input"), Type = typeof(string) }]);
 
         // Act
         bool resultLeftRight = left != right;

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenToStringIsCalled.cs
@@ -25,7 +25,7 @@ public sealed class WhenToStringIsCalled
             extensibility: Extensibility.Abstract,
             isPartial: true,
             name: new Declaration { Name = RecordTestsData.DefaultName },
-            parameters: [new Parameter { Name = new Variable("input"), Type = typeof(int) }],
+            parameters: [new Parameter { Name = new("input"), Type = typeof(int) }],
             scope: Scope.Internal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithEventsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithEventsIsCalled.cs
@@ -6,8 +6,8 @@ public sealed class WhenWithEventsIsCalled
     public async Task GivenEventsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var created = new Event { Name = new Name("Created") };
-        var updated = new Event { Name = new Name("Updated") };
+        var created = new Event { Name = new("Created") };
+        var updated = new Event { Name = new("Updated") };
         Record original = RecordTestsData.Create(events: [created]);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithFieldsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithFieldsIsCalled.cs
@@ -6,8 +6,8 @@ public sealed class WhenWithFieldsIsCalled
     public async Task GivenFieldsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var existing = new Field { Name = new Variable("_value"), Type = typeof(int) };
-        var appended = new Field { Name = new Variable("_other"), Type = typeof(int) };
+        var existing = new Field { Name = new("_value"), Type = typeof(int) };
+        var appended = new Field { Name = new("_other"), Type = typeof(int) };
         Record original = RecordTestsData.Create(fields: [existing]);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithIndexersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithIndexersIsCalled.cs
@@ -6,8 +6,8 @@ public sealed class WhenWithIndexersIsCalled
     public async Task GivenIndexersThenReturnsUpdatedInstance()
     {
         // Arrange
-        var existing = new Indexer { Parameter = new Parameter { Name = "Item" } };
-        var appended = new Indexer { Parameter = new Parameter { Name = "Other" } };
+        var existing = new Indexer { Parameter = new() { Name = "Item" } };
+        var appended = new Indexer { Parameter = new() { Name = "Other" } };
         Record original = RecordTestsData.Create(indexers: [existing]);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithMethodsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithMethodsIsCalled.cs
@@ -6,8 +6,8 @@ public sealed class WhenWithMethodsIsCalled
     public async Task GivenMethodsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var execute = new Method { Name = new Declaration { Name = "Execute" } };
-        var undo = new Method { Name = new Declaration { Name = "Undo" } };
+        var execute = new Method { Name = new() { Name = "Execute" } };
+        var undo = new Method { Name = new() { Name = "Undo" } };
         Record original = RecordTestsData.Create(methods: [execute]);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithOperatorsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithOperatorsIsCalled.cs
@@ -6,8 +6,8 @@ public sealed class WhenWithOperatorsIsCalled
     public async Task GivenOperatorsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var original = new Operators { Binaries = [new Binary { Scope = Scope.Public }] };
-        var updated = new Operators { Unaries = [new Unary { Scope = Scope.Internal }] };
+        var original = new Operators { Binaries = [new() { Scope = Scope.Public }] };
+        var updated = new Operators { Unaries = [new() { Scope = Scope.Internal }] };
         Record record = RecordTestsData.Create(operators: original);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithParametersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithParametersIsCalled.cs
@@ -6,8 +6,8 @@ public sealed class WhenWithParametersIsCalled
     public async Task GivenParametersThenReturnsUpdatedInstance()
     {
         // Arrange
-        var existing = new Parameter { Name = new Variable("first"), Type = typeof(string) };
-        var appended = new Parameter { Name = new Variable("second"), Type = typeof(int) };
+        var existing = new Parameter { Name = new("first"), Type = typeof(string) };
+        var appended = new Parameter { Name = new("second"), Type = typeof(int) };
         Record original = RecordTestsData.Create(parameters: [existing]);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithPropertiesIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/RecordTests/WhenWithPropertiesIsCalled.cs
@@ -6,8 +6,8 @@ public sealed class WhenWithPropertiesIsCalled
     public async Task GivenPropertiesThenReturnsUpdatedInstance()
     {
         // Arrange
-        var existing = new Property { Name = new Name("Value"), Type = typeof(string) };
-        var appended = new Property { Name = new Name("Other"), Type = typeof(int) };
+        var existing = new Property { Name = new("Value"), Type = typeof(string) };
+        var appended = new Property { Name = new("Other"), Type = typeof(int) };
         Record original = RecordTestsData.Create(properties: [existing]);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ReferenceTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ReferenceTests/WhenToSnippetIsCalled.cs
@@ -31,7 +31,8 @@ public sealed class WhenToSnippetIsCalled
         var subject = new TestReference
         {
             IsUndefinedValue = false,
-            Declaration = new() {
+            Declaration = new()
+            {
                 Name = TypeName,
                 Generics =
                 [

--- a/src/MooVC.Syntax.CSharp.Tests/ReferenceTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ReferenceTests/WhenToSnippetIsCalled.cs
@@ -31,8 +31,7 @@ public sealed class WhenToSnippetIsCalled
         var subject = new TestReference
         {
             IsUndefinedValue = false,
-            Declaration = new Declaration
-            {
+            Declaration = new() {
                 Name = TypeName,
                 Generics =
                 [
@@ -41,7 +40,7 @@ public sealed class WhenToSnippetIsCalled
             },
             Parameters =
             [
-                new Parameter { Name = new Identifier(ParameterName), Type = typeof(int) },
+                new Parameter { Name = new(ParameterName), Type = typeof(int) },
             ],
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/ReferenceTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ReferenceTests/WhenValidateIsCalled.cs
@@ -16,7 +16,7 @@ public sealed class WhenValidateIsCalled
         {
             IsUndefinedValue = false,
             Extensibility = Extensibility.Static,
-            Declaration = new Declaration { Name = TypeName },
+            Declaration = new() { Name = TypeName },
         };
         var validationContext = new ValidationContext(subject);
 

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/WhenAsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/WhenAsIsCalled.cs
@@ -13,7 +13,7 @@ public sealed class WhenAsIsCalled
         var subject = new Result
         {
             Mode = Result.Modality.Synchronous,
-            Type = new Symbol { Name = ValueType },
+            Type = new() { Name = ValueType },
         };
 
         // Act
@@ -30,7 +30,7 @@ public sealed class WhenAsIsCalled
         var subject = new Result
         {
             Mode = Result.Modality.Synchronous,
-            Type = new Symbol { Name = ValueType },
+            Type = new() { Name = ValueType },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/WhenToStringIsCalled.cs
@@ -12,7 +12,7 @@ public sealed class WhenToStringIsCalled
         {
             Modifier = Result.Kind.Ref,
             Mode = Result.Modality.Asynchronous,
-            Type = new Symbol { Name = ValueType },
+            Type = new() { Name = ValueType },
         };
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenAttributedWithIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenAttributedWithIsCalled.cs
@@ -10,12 +10,12 @@ public sealed class WhenAttributedWithIsCalled
         // Arrange
         Attribute[] existing =
         [
-            new Attribute { Name = new Symbol { Name = "Existing" } },
+            new Attribute { Name = new() { Name = "Existing" } },
         ];
 
         Attribute[] additional =
         [
-            new Attribute { Name = new Symbol { Name = "Additional" } },
+            new Attribute { Name = new() { Name = "Additional" } },
         ];
 
         Struct original = StructTestsData.Create(attributes: existing.ToImmutableArray());

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenConstructorIsCalled.cs
@@ -31,13 +31,13 @@ public sealed class WhenConstructorIsCalled
     public async Task GivenValuesThenPropertiesAreAssigned()
     {
         // Arrange
-        var attribute = new Attribute { Name = new Symbol { Name = AttributeName } };
+        var attribute = new Attribute { Name = new() { Name = AttributeName } };
         var constructor = new Constructor { Scope = Scope.Private };
-        var @event = new Event { Name = new Name("Created") };
-        var field = new Field { Name = new Variable("_value"), Type = typeof(int) };
-        var indexer = new Indexer { Parameter = new Parameter { Name = "Item" } };
-        var method = new Method { Name = new Declaration { Name = "Execute" } };
-        var property = new Property { Name = new Name("Value"), Type = typeof(string) };
+        var @event = new Event { Name = new("Created") };
+        var field = new Field { Name = new("_value"), Type = typeof(int) };
+        var indexer = new Indexer { Parameter = new() { Name = "Item" } };
+        var method = new Method { Name = new() { Name = "Execute" } };
+        var property = new Property { Name = new("Value"), Type = typeof(string) };
 
         // Act
         Struct subject = StructTestsData.Create(
@@ -50,8 +50,8 @@ public sealed class WhenConstructorIsCalled
             isPartial: true,
             methods: [method],
             name: new Declaration { Name = StructTestsData.DefaultName },
-            operators: new Operators { Conversions = [new Conversion { Target = Symbol.Undefined }] },
-            parameters: [new Parameter { Name = new Variable("input"), Type = typeof(string) }],
+            operators: new Operators { Conversions = [new() { Target = Symbol.Undefined }] },
+            parameters: [new Parameter { Name = new("input"), Type = typeof(string) }],
             properties: [property],
             scope: Scope.Internal);
 

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenEqualsObjectIsCalled.cs
@@ -34,7 +34,7 @@ public sealed class WhenEqualsObjectIsCalled
     public async Task GivenOtherTypeThenReturnsFalse()
     {
         // Arrange
-        object other = new();
+        var other = new object();
         Struct subject = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenToSnippetIsCalled.cs
@@ -44,7 +44,8 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Struct
         {
             Behavior = Struct.Kind.ReadOnly,
-            Declaration = new() {
+            Declaration = new()
+            {
                 Name = StructName,
                 Generics =
                 [

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenToSnippetIsCalled.cs
@@ -44,8 +44,7 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Struct
         {
             Behavior = Struct.Kind.ReadOnly,
-            Declaration = new Declaration
-            {
+            Declaration = new() {
                 Name = StructName,
                 Generics =
                 [
@@ -54,7 +53,7 @@ public sealed class WhenToSnippetIsCalled
             },
             Parameters =
             [
-                new Parameter { Name = new Identifier(ParameterName), Type = typeof(int) },
+                new Parameter { Name = new(ParameterName), Type = typeof(int) },
             ],
         };
 

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenToStringIsCalled.cs
@@ -26,7 +26,7 @@ public sealed class WhenToStringIsCalled
             constructors: [constructor],
             isPartial: true,
             name: new Declaration { Name = StructTestsData.DefaultName },
-            parameters: [new Parameter { Name = new Variable("input"), Type = typeof(int) }],
+            parameters: [new Parameter { Name = new("input"), Type = typeof(int) }],
             scope: Scope.Internal);
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithEventsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithEventsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithEventsIsCalled
     public async Task GivenEventsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var @event = new Event { Name = new Name("Changed") };
+        var @event = new Event { Name = new("Changed") };
         Struct original = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithFieldsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithFieldsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithFieldsIsCalled
     public async Task GivenFieldsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var field = new Field { Name = new Variable("_value"), Type = typeof(int) };
+        var field = new Field { Name = new("_value"), Type = typeof(int) };
         Struct original = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithIndexersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithIndexersIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithIndexersIsCalled
     public async Task GivenIndexersThenReturnsUpdatedInstance()
     {
         // Arrange
-        var indexer = new Indexer { Parameter = new Parameter { Name = "Item" } };
+        var indexer = new Indexer { Parameter = new() { Name = "Item" } };
         Struct original = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithMethodsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithMethodsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithMethodsIsCalled
     public async Task GivenMethodsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var method = new Method { Name = new Declaration { Name = "Execute" } };
+        var method = new Method { Name = new() { Name = "Execute" } };
         Struct original = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithOperatorsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithOperatorsIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithOperatorsIsCalled
     public async Task GivenOperatorsThenReturnsUpdatedInstance()
     {
         // Arrange
-        var operators = new Operators { Conversions = [new Conversion { Target = Symbol.Undefined }] };
+        var operators = new Operators { Conversions = [new() { Target = Symbol.Undefined }] };
         Struct original = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithParametersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithParametersIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithParametersIsCalled
     public async Task GivenParametersThenReturnsUpdatedInstance()
     {
         // Arrange
-        var parameter = new Parameter { Name = new Variable("input"), Type = typeof(int) };
+        var parameter = new Parameter { Name = new("input"), Type = typeof(int) };
         Struct original = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithPropertiesIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/StructTests/WhenWithPropertiesIsCalled.cs
@@ -6,7 +6,7 @@ public sealed class WhenWithPropertiesIsCalled
     public async Task GivenPropertiesThenReturnsUpdatedInstance()
     {
         // Arrange
-        var property = new Property { Name = new Name("Value"), Type = typeof(string) };
+        var property = new Property { Name = new("Value"), Type = typeof(string) };
         Struct original = StructTestsData.Create();
 
         // Act

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/SymbolTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/SymbolTestsData.cs
@@ -30,7 +30,7 @@ internal static class SymbolTestsData
 
     public static Symbol CreateWithArgumentNames(string? name = DefaultName, params string[] argumentNames)
     {
-        Symbol[] arguments = [.. argumentNames.Select(argument => new() { Name = argument })];
+        Symbol[] arguments = [.. argumentNames.Select(argument => new Symbol() { Name = argument })];
 
         return Create(name, arguments: arguments);
     }

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/SymbolTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/SymbolTestsData.cs
@@ -30,7 +30,7 @@ internal static class SymbolTestsData
 
     public static Symbol CreateWithArgumentNames(string? name = DefaultName, params string[] argumentNames)
     {
-        Symbol[] arguments = [.. argumentNames.Select(argument => new Symbol { Name = argument })];
+        Symbol[] arguments = [.. argumentNames.Select(argument => new() { Name = argument })];
 
         return Create(name, arguments: arguments);
     }

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/WhenValidateIsCalled.cs
@@ -14,7 +14,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var symbol = new Symbol
         {
-            Arguments = [new Symbol { Name = "Invalid Name" }],
+            Arguments = [new() { Name = "Invalid Name" }],
             Name = Name,
         };
 
@@ -60,7 +60,7 @@ public sealed class WhenValidateIsCalled
         // Arrange
         var symbol = new Symbol
         {
-            Arguments = [new Symbol { Name = "Test" }],
+            Arguments = [new() { Name = "Test" }],
         };
 
         var context = new ValidationContext(symbol);
@@ -122,7 +122,7 @@ public sealed class WhenValidateIsCalled
         var symbol = new Symbol
         {
             Name = Name,
-            Arguments = [new Symbol { Name = ArgumentName }],
+            Arguments = [new() { Name = ArgumentName }],
         };
 
         var context = new ValidationContext(symbol);

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/WhenWithArgumentsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/WhenWithArgumentsIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenWithArgumentsIsCalled
     {
         // Arrange
         Symbol original = SymbolTestsData.Create(name: "Container", arguments: new Symbol { Name = "First" });
-        Symbol[] additional = [new Symbol { Name = "Second" }];
+        Symbol[] additional = [new() { Name = "Second" }];
 
         // Act
         Symbol result = original.WithArguments(additional);

--- a/src/MooVC.Syntax.CSharp.Tests/VariableTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/VariableTests/WhenToSnippetIsCalled.cs
@@ -29,7 +29,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Camel);
 
         // Act
@@ -45,7 +45,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Kebab);
 
         // Act
@@ -67,7 +67,7 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Variable(keyword);
         string expected = keyword.ToCamelCase();
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(casing)
             .UseUnderscore(false);
 
@@ -84,7 +84,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(Mixed);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Pascal);
 
         // Act
@@ -100,7 +100,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Snake);
 
         // Act
@@ -116,7 +116,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Camel)
             .UseUnderscore(true);
 

--- a/src/MooVC.Syntax.CSharp.Tests/VariableTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/VariableTests/WhenToSnippetIsCalled.cs
@@ -29,7 +29,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Camel);
 
         // Act
@@ -45,7 +45,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Kebab);
 
         // Act
@@ -67,7 +67,7 @@ public sealed class WhenToSnippetIsCalled
         var subject = new Variable(keyword);
         string expected = keyword.ToCamelCase();
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(casing)
             .UseUnderscore(false);
 
@@ -84,7 +84,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(Mixed);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Pascal);
 
         // Act
@@ -100,7 +100,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Snake);
 
         // Act
@@ -116,7 +116,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Variable(MultiWord);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Camel)
             .UseUnderscore(true);
 

--- a/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToCamelCaseIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToCamelCaseIsCalled.cs
@@ -44,7 +44,7 @@ public sealed class WhenToCamelCaseIsCalled
 
         try
         {
-            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            CultureInfo.CurrentCulture = new("tr-TR");
             result = value.ToCamelCase();
         }
         finally

--- a/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToKebabCaseIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToKebabCaseIsCalled.cs
@@ -44,7 +44,7 @@ public sealed class WhenToKebabCaseIsCalled
 
         try
         {
-            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            CultureInfo.CurrentCulture = new("tr-TR");
             result = value.ToKebabCase();
         }
         finally

--- a/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToPascalCaseIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToPascalCaseIsCalled.cs
@@ -44,7 +44,7 @@ public sealed class WhenToPascalCaseIsCalled
 
         try
         {
-            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            CultureInfo.CurrentCulture = new("tr-TR");
             result = value.ToPascalCase();
         }
         finally

--- a/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToSnakeCaseIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Formatting/StringExtensionsTests/WhenToSnakeCaseIsCalled.cs
@@ -96,7 +96,7 @@ public sealed class WhenToSnakeCaseIsCalled
 
         try
         {
-            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            CultureInfo.CurrentCulture = new("tr-TR");
             result = value.ToSnakeCase();
         }
         finally

--- a/src/MooVC.Syntax.Tests/IdentifierTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/WhenToSnippetIsCalled.cs
@@ -27,7 +27,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(MultiWord);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Camel);
 
         // Act
@@ -43,7 +43,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(MultiWord);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Kebab);
 
         // Act
@@ -59,7 +59,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(Mixed);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Pascal);
 
         // Act
@@ -75,7 +75,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(MultiWord);
 
-        Options options = new()
+        var options = new Options()
             .WithCasing(Casing.Snake);
 
         // Act

--- a/src/MooVC.Syntax.Tests/IdentifierTests/WhenToSnippetIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/WhenToSnippetIsCalled.cs
@@ -27,7 +27,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(MultiWord);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Camel);
 
         // Act
@@ -43,7 +43,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(MultiWord);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Kebab);
 
         // Act
@@ -59,7 +59,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(Mixed);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Pascal);
 
         // Act
@@ -75,7 +75,7 @@ public sealed class WhenToSnippetIsCalled
         // Arrange
         var subject = new Identifier(MultiWord);
 
-        Options options = new Options()
+        Options options = new()
             .WithCasing(Casing.Snake);
 
         // Act

--- a/src/MooVC.Syntax.Tests/PathTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/PathTests/WhenEqualsObjectIsCalled.cs
@@ -48,7 +48,7 @@ public sealed class WhenEqualsObjectIsCalled
     {
         // Arrange
         var subject = new Path(PathTestsData.DefaultPath);
-        object other = new();
+        var other = new object();
 
         // Act
         bool result = subject.Equals(other);

--- a/src/MooVC.Syntax.Tests/Project/ItemTests/WhenWithMetadataIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Project/ItemTests/WhenWithMetadataIsCalled.cs
@@ -10,7 +10,7 @@ public sealed class WhenWithMetadataIsCalled
 
         var additional = new Metadata
         {
-            Name = new Name("Other"),
+            Name = new("Other"),
             Value = Snippet.From("Value"),
         };
 

--- a/src/MooVC.Syntax.Tests/Project/ProjectTests/ProjectTestsData.cs
+++ b/src/MooVC.Syntax.Tests/Project/ProjectTests/ProjectTestsData.cs
@@ -82,7 +82,7 @@ internal static class ProjectTestsData
     {
         return new ItemGroup
         {
-            Items = [new Item { Include = Snippet.From(DefaultItemInclude) }],
+            Items = [new() { Include = Snippet.From(DefaultItemInclude) }],
         };
     }
 
@@ -90,7 +90,7 @@ internal static class ProjectTestsData
     {
         return new PropertyGroup
         {
-            Properties = [new Property { Name = DefaultPropertyName, Value = Snippet.From(DefaultPropertyValue) }],
+            Properties = [new() { Name = DefaultPropertyName, Value = Snippet.From(DefaultPropertyValue) }],
         };
     }
 

--- a/src/MooVC.Syntax.Tests/Project/ProjectTests/ProjectTestsData.cs
+++ b/src/MooVC.Syntax.Tests/Project/ProjectTests/ProjectTestsData.cs
@@ -1,7 +1,6 @@
 namespace MooVC.Syntax.Project.ProjectTests;
 
 using MooVC.Syntax.Resource;
-using Item = MooVC.Syntax.Project.Item;
 using Resource = MooVC.Syntax.Resource.Item;
 
 internal static class ProjectTestsData

--- a/src/MooVC.Syntax.Tests/Project/PropertyGroupTests/WhenWithPropertiesIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Project/PropertyGroupTests/WhenWithPropertiesIsCalled.cs
@@ -11,7 +11,7 @@ public sealed class WhenWithPropertiesIsCalled
         var additional = new Property
         {
             Condition = Snippet.From("Extra"),
-            Name = new Name("Other"),
+            Name = new("Other"),
             Value = Snippet.From("Value"),
         };
 

--- a/src/MooVC.Syntax.Tests/Project/TargetTaskTests/WhenWithOutputsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Project/TargetTaskTests/WhenWithOutputsIsCalled.cs
@@ -10,9 +10,9 @@ public sealed class WhenWithOutputsIsCalled
 
         var additional = new Output
         {
-            ItemName = new Name("Other"),
-            PropertyName = new Name("Property"),
-            TaskParameter = new Name("Parameter"),
+            ItemName = new("Other"),
+            PropertyName = new("Property"),
+            TaskParameter = new("Parameter"),
         };
 
         TargetTask original = TargetTaskTestsData.Create(output: existing);

--- a/src/MooVC.Syntax.Tests/Project/TargetTaskTests/WhenWithParametersIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Project/TargetTaskTests/WhenWithParametersIsCalled.cs
@@ -10,7 +10,7 @@ public sealed class WhenWithParametersIsCalled
 
         var additional = new Parameter
         {
-            Name = new Name("Other"),
+            Name = new("Other"),
             Value = Snippet.From("Value"),
         };
 

--- a/src/MooVC.Syntax.Tests/Project/TargetTests/WhenWithTasksIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Project/TargetTests/WhenWithTasksIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenWithTasksIsCalled
     {
         // Arrange
         TargetTask existing = TargetTestsData.CreateTask();
-        var additional = new TargetTask { Name = new Name("Other") };
+        var additional = new TargetTask { Name = new("Other") };
         Target original = TargetTestsData.Create(task: existing);
 
         // Act

--- a/src/MooVC.Syntax.Tests/Resource/ItemTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Resource/ItemTests/WhenEqualsObjectIsCalled.cs
@@ -48,7 +48,7 @@ public sealed class WhenEqualsObjectIsCalled
     {
         // Arrange
         Item subject = ItemTestsData.Create();
-        object other = new();
+        var other = new object();
 
         // Act
         bool result = subject.Equals(other);

--- a/src/MooVC.Syntax.Tests/Resource/ItemTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Resource/ItemTests/WhenValidateIsCalled.cs
@@ -32,7 +32,7 @@ public sealed class WhenValidateIsCalled
         var subject = new Item
         {
             CustomToolNamespace = Snippet.From($"Line1{Environment.NewLine}Line2"),
-            Location = new Path(ItemTestsData.DefaultLocationPath),
+            Location = new(ItemTestsData.DefaultLocationPath),
         };
 
         var context = new ValidationContext(subject);

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualityOperatorBoundariesBoundariesIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualityOperatorBoundariesBoundariesIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorBoundariesBoundariesIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries right = new()
+        var right = new Snippet.Options.Blocks.Boundaries()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualityOperatorBoundariesBoundariesIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualityOperatorBoundariesBoundariesIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorBoundariesBoundariesIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries right = new Snippet.Options.Blocks.Boundaries()
+        Snippet.Options.Blocks.Boundaries right = new()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualsBoundariesIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualsBoundariesIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsBoundariesIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries right = new()
+        var right = new Snippet.Options.Blocks.Boundaries()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualsBoundariesIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenEqualsBoundariesIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsBoundariesIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries right = new Snippet.Options.Blocks.Boundaries()
+        Snippet.Options.Blocks.Boundaries right = new()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries second = new()
+        var second = new Snippet.Options.Blocks.Boundaries()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries second = new Snippet.Options.Blocks.Boundaries()
+        Snippet.Options.Blocks.Boundaries second = new()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenInequalityOperatorBoundariesBoundariesIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenInequalityOperatorBoundariesBoundariesIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorBoundariesBoundariesIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries right = new Snippet.Options.Blocks.Boundaries()
+        Snippet.Options.Blocks.Boundaries right = new()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenInequalityOperatorBoundariesBoundariesIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/BoundariesTests/WhenInequalityOperatorBoundariesBoundariesIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorBoundariesBoundariesIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks.Boundaries();
 
-        Snippet.Options.Blocks.Boundaries right = new()
+        var right = new Snippet.Options.Blocks.Boundaries()
             .WithClosing("]");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualityOperatorBlocksBlocksIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualityOperatorBlocksBlocksIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorBlocksBlocksIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks right = new()
+        var right = new Snippet.Options.Blocks()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualityOperatorBlocksBlocksIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualityOperatorBlocksBlocksIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorBlocksBlocksIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks right = new Snippet.Options.Blocks()
+        Snippet.Options.Blocks right = new()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualsBlocksIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualsBlocksIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsBlocksIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks right = new Snippet.Options.Blocks()
+        Snippet.Options.Blocks right = new()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualsBlocksIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenEqualsBlocksIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsBlocksIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks right = new()
+        var right = new Snippet.Options.Blocks()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks second = new()
+        var second = new Snippet.Options.Blocks()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks second = new Snippet.Options.Blocks()
+        Snippet.Options.Blocks second = new()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenInequalityOperatorBlocksBlocksIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenInequalityOperatorBlocksBlocksIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorBlocksBlocksIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks right = new Snippet.Options.Blocks()
+        Snippet.Options.Blocks right = new()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenInequalityOperatorBlocksBlocksIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/BlocksTests/WhenInequalityOperatorBlocksBlocksIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorBlocksBlocksIsCalled
         // Arrange
         var left = new Snippet.Options.Blocks();
 
-        Snippet.Options.Blocks right = new()
+        var right = new Snippet.Options.Blocks()
             .WithLayout(Snippet.Options.Blocks.Layouts.KAndR);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Snippet.Options();
 
-        Snippet.Options right = new()
+        var right = new Snippet.Options()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Snippet.Options();
 
-        Snippet.Options right = new Snippet.Options()
+        Snippet.Options right = new()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsOptionsIsCalled
         // Arrange
         var left = new Snippet.Options();
 
-        Snippet.Options right = new()
+        var right = new Snippet.Options()
             .WithMaxLineLength((byte)(Snippet.Options.Default.MaxLineLength - 1));
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenEqualsOptionsIsCalled
         // Arrange
         var left = new Snippet.Options();
 
-        Snippet.Options right = new Snippet.Options()
+        Snippet.Options right = new()
             .WithMaxLineLength((byte)(Snippet.Options.Default.MaxLineLength - 1));
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Snippet.Options();
 
-        Snippet.Options second = new()
+        var second = new Snippet.Options()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -8,7 +8,7 @@ public sealed class WhenGetHashCodeIsCalled
         // Arrange
         var first = new Snippet.Options();
 
-        Snippet.Options second = new Snippet.Options()
+        Snippet.Options second = new()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Snippet.Options();
 
-        Snippet.Options right = new()
+        var right = new Snippet.Options()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -22,7 +22,7 @@ public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
         // Arrange
         var left = new Snippet.Options();
 
-        Snippet.Options right = new Snippet.Options()
+        Snippet.Options right = new()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenIsDefaultIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenIsDefaultIsCalled.cs
@@ -19,7 +19,7 @@ public sealed class WhenIsDefaultIsCalled
     public async Task GivenNonDefaultValuesThenReturnsFalse()
     {
         // Arrange
-        Snippet.Options options = new()
+        var options = new Snippet.Options()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenIsDefaultIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/OptionsTests/WhenIsDefaultIsCalled.cs
@@ -19,7 +19,7 @@ public sealed class WhenIsDefaultIsCalled
     public async Task GivenNonDefaultValuesThenReturnsFalse()
     {
         // Arrange
-        Snippet.Options options = new Snippet.Options()
+        Snippet.Options options = new()
             .WithWhitespace("\t");
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/WhenShiftIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/WhenShiftIsCalled.cs
@@ -33,7 +33,7 @@ public sealed class WhenShiftIsCalled
         const string whitespace = "\t";
         var subject = new Snippet(_lines);
 
-        Snippet.Options options = new Snippet.Options()
+        Snippet.Options options = new()
             .WithWhitespace(whitespace);
 
         // Act

--- a/src/MooVC.Syntax.Tests/SnippetTests/WhenShiftIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/SnippetTests/WhenShiftIsCalled.cs
@@ -33,7 +33,7 @@ public sealed class WhenShiftIsCalled
         const string whitespace = "\t";
         var subject = new Snippet(_lines);
 
-        Snippet.Options options = new()
+        var options = new Snippet.Options()
             .WithWhitespace(whitespace);
 
         // Act

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/FolderTestsData.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/FolderTestsData.cs
@@ -31,8 +31,8 @@ internal static class FolderTestsData
         return new Project
         {
             Id = Guid.Parse("F720AF0F-8F5D-4C77-A4D0-804B9E8BAE89"),
-            DisplayName = new Project.Name("ProjectName"),
-            Path = new Project.RelativePath("src/Project.csproj"),
+            DisplayName = new("ProjectName"),
+            Path = new("src/Project.csproj"),
             Type = Snippet.From("CSharp"),
         };
     }

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/WhenConstructorIsCalled.cs
@@ -29,7 +29,7 @@ public sealed class WhenConstructorIsCalled
         {
             Files = [file],
             Items = [item],
-            Name = new Folder.Path(FolderTestsData.DefaultName),
+            Name = new(FolderTestsData.DefaultName),
             Projects = [project],
         };
 

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/WhenConstructorIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/WhenConstructorIsCalled.cs
@@ -30,8 +30,8 @@ public sealed class WhenConstructorIsCalled
         var subject = new Project
         {
             Id = ProjectTestsData.DefaultId,
-            DisplayName = new Project.Name(ProjectTestsData.DefaultName),
-            Path = new Project.RelativePath(ProjectTestsData.DefaultPath),
+            DisplayName = new(ProjectTestsData.DefaultName),
+            Path = new(ProjectTestsData.DefaultPath),
             Type = Snippet.From(ProjectTestsData.DefaultType),
             Builds = [build],
             Platforms = [platform],

--- a/src/MooVC.Syntax.Tests/Solution/SolutionTests/SolutionTestsData.cs
+++ b/src/MooVC.Syntax.Tests/Solution/SolutionTests/SolutionTestsData.cs
@@ -45,7 +45,7 @@ internal static class SolutionTestsData
     {
         return new Folder
         {
-            Name = new Folder.Path(DefaultFolderName),
+            Name = new(DefaultFolderName),
         };
     }
 
@@ -65,8 +65,8 @@ internal static class SolutionTestsData
         return new Project
         {
             Id = DefaultProjectId,
-            DisplayName = new Project.Name(DefaultProjectName),
-            Path = new Project.RelativePath(DefaultProjectPath),
+            DisplayName = new(DefaultProjectName),
+            Path = new(DefaultProjectPath),
             Type = Snippet.From(DefaultProjectType),
         };
     }

--- a/src/MooVC.Syntax.Tests/Solution/SolutionTests/WhenWithFoldersIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/SolutionTests/WhenWithFoldersIsCalled.cs
@@ -10,7 +10,7 @@ public sealed class WhenWithFoldersIsCalled
 
         var additional = new Folder
         {
-            Name = new Folder.Path("/other/"),
+            Name = new("/other/"),
         };
 
         Solution original = SolutionTestsData.Create(folder: existing);

--- a/src/MooVC.Syntax.Tests/Solution/SolutionTests/WhenWithProjectsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/SolutionTests/WhenWithProjectsIsCalled.cs
@@ -13,8 +13,8 @@ public sealed class WhenWithProjectsIsCalled
         var additional = new Project
         {
             Id = Guid.Parse("9D9B238E-46E7-4B65-944F-3FC5A25E85B1"),
-            DisplayName = new Project.Name("OtherName"),
-            Path = new Project.RelativePath("src/Other.csproj"),
+            DisplayName = new("OtherName"),
+            Path = new("src/Other.csproj"),
             Type = Snippet.From("OtherType"),
         };
 

--- a/src/MooVC.Syntax.Tests/Validation/ValidationContextExtensionsTests/WhenIncludeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Validation/ValidationContextExtensionsTests/WhenIncludeIsCalled.cs
@@ -158,7 +158,7 @@ public sealed class WhenIncludeIsCalled
     {
         public StubValidatable(params ValidationResult[] results)
         {
-            Results = [.. results.DefaultIfEmpty(new ValidationResult(FirstMessage))];
+            Results = [.. results.DefaultIfEmpty(new(FirstMessage))];
         }
 
         public IReadOnlyCollection<ValidationResult> Results { get; }


### PR DESCRIPTION
### Motivation

- Modernize and simplify test code by using C# target-typed `new` expressions and shorter constructor calls to improve readability and reduce verbosity.

### Description

- Replaced many explicit constructor expressions like `new Type { ... }` and `new Type(...)` with target-typed forms such as `new() { ... }` and `new(...)` in test sources across the solution.
- Applied the same concise instantiation style to collection and helper data initializers in numerous test helper classes and test cases.
- These edits are limited to test code and formatting; there are no behavioral or production API changes.

### Testing

- No automated tests were executed as part of this change; running the full unit-test suite (`dotnet test`) is recommended to verify there are no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c5dee8bc832f95aae59f4d5598ec)