### PR TITLE
docs: improve XML documentation across syntax models

### DIFF
--- a/src/MooVC.Syntax.CSharp/Extensions.cs
+++ b/src/MooVC.Syntax.CSharp/Extensions.cs
@@ -3,16 +3,21 @@
     /// <summary>
     /// Provides constants used by C# syntax modelling extensions.
     /// </summary>
+    /// <remarks>
+    /// These values are used when generating file names for C# source and project artifacts.
+    /// </remarks>
     public static class Extensions
     {
         /// <summary>
         /// Gets the default C# source code file extension.
         /// </summary>
+        /// <value>The <c>cs</c> extension without a leading dot.</value>
         public static readonly string Code = "cs";
 
         /// <summary>
         /// Gets the default C# project file extension.
         /// </summary>
+        /// <value>The <c>csproj</c> extension without a leading dot.</value>
         public static readonly string Project = "csproj";
     }
 }

--- a/src/MooVC.Syntax.CSharp/Options.cs
+++ b/src/MooVC.Syntax.CSharp/Options.cs
@@ -10,6 +10,10 @@
     /// <summary>
     /// Represents top-level rendering options for type declarations.
     /// </summary>
+    /// <remarks>
+    /// This type provides implicit conversions to common option subsets so APIs can accept either
+    /// aggregate or specialized options.
+    /// </remarks>
     [AutoInitializeWith(nameof(Default))]
     [Fluentify]
     [Valuify]
@@ -30,13 +34,13 @@
         /// <summary>
         /// Gets the namespace options.
         /// </summary>
-        /// <value>The namespace options.</value>
+        /// <value>The namespace rendering options.</value>
         public Qualifier.Options Namespace { get; internal set; } = Qualifier.Options.File;
 
         /// <summary>
-        /// Gets the Snippets options.
+        /// Gets the snippet options.
         /// </summary>
-        /// <value>The Snippets options.</value>
+        /// <value>The snippet formatting options used during rendering.</value>
         public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Default.WithChaining(new[]
         {
             OneDotPerLine.Instance,
@@ -44,9 +48,9 @@
         });
 
         /// <summary>
-        /// Gets the symbol options.
+        /// Gets the type options.
         /// </summary>
-        /// <value>The symbol options.</value>
+        /// <value>The type rendering options.</value>
         public Type.Options Types { get; internal set; } = Type.Options.Default;
 
         /// <summary>
@@ -54,6 +58,9 @@
         /// </summary>
         /// <param name="options">The source options.</param>
         /// <returns>The namespace options.</returns>
+        /// <remarks>
+        /// Conversion fails when <paramref name="options"/> is null.
+        /// </remarks>
         public static implicit operator Qualifier.Options(Options options)
         {
             Guard.Against.Conversion<Options, Qualifier.Options>(options);
@@ -66,6 +73,9 @@
         /// </summary>
         /// <param name="options">The source options.</param>
         /// <returns>The snippet options.</returns>
+        /// <remarks>
+        /// Conversion fails when <paramref name="options"/> is null.
+        /// </remarks>
         public static implicit operator Snippet.Options(Options options)
         {
             Guard.Against.Conversion<Options, Snippet.Options>(options);
@@ -74,10 +84,14 @@
         }
 
         /// <summary>
-        /// Converts the current options to Type options.
+        /// Converts the current options to type options.
         /// </summary>
         /// <param name="options">The source options.</param>
-        /// <returns>The Type options.</returns>
+        /// <returns>The type options.</returns>
+        /// <remarks>
+        /// Conversion fails when <paramref name="options"/> is null. Missing snippet options in
+        /// <see cref="Types"/> are automatically populated from <see cref="Snippets"/>.
+        /// </remarks>
         public static implicit operator Type.Options(Options options)
         {
             Guard.Against.Conversion<Options, Type.Options>(options);

--- a/src/MooVC.Syntax/Builder.cs
+++ b/src/MooVC.Syntax/Builder.cs
@@ -1,14 +1,18 @@
 ﻿namespace MooVC.Syntax
 {
     /// <summary>
-    /// Represents a syntax helper builder.
+    /// Provides factory helpers for syntax constructs.
     /// </summary>
+    /// <remarks>
+    /// The builder centralizes object creation so fluent configuration can begin from a single entry point.
+    /// </remarks>
     public static class Builder
     {
         /// <summary>
-        /// Performs the new t operation for the syntax helper.
+        /// Creates a new instance of the specified construct type.
         /// </summary>
-        /// <returns>The t.</returns>
+        /// <typeparam name="T">The syntax construct type to create.</typeparam>
+        /// <returns>A new instance of <typeparamref name="T"/>.</returns>
         public static T New<T>()
             where T : Construct, new()
         {

--- a/src/MooVC.Syntax/Construct.cs
+++ b/src/MooVC.Syntax/Construct.cs
@@ -6,8 +6,11 @@
     using Ignore = Valuify.IgnoreAttribute;
 
     /// <summary>
-    /// Represents a syntax construct construct.
+    /// Represents a base type for syntax constructs.
     /// </summary>
+    /// <remarks>
+    /// Derived types expose domain-specific state and validation while sharing a common undefined-state contract.
+    /// </remarks>
     public abstract class Construct
         : IValidatableObject
     {
@@ -19,18 +22,23 @@
         }
 
         /// <summary>
-        /// Gets a value indicating whether the Construct is undefined.
+        /// Gets a value indicating whether the construct represents an undefined value.
         /// </summary>
-        /// <value>A value indicating whether the Construct is undefined.</value>
+        /// <value>
+        /// <see langword="true"/> when the current instance is an undefined sentinel; otherwise, <see langword="false"/>.
+        /// </value>
         [Ignore]
         [SuppressMessage("Usage", "VALFY04:Type does not utilize Valuify", Justification = "The derived class will be annotated with it.")]
         public abstract bool IsUndefined { get; }
 
         /// <summary>
-        /// Validates the Construct.
+        /// Validates the construct.
         /// </summary>
         /// <param name="validationContext">The validation context.</param>
-        /// <returns>The validation results.</returns>
+        /// <returns>A sequence containing all validation failures for the current instance.</returns>
+        /// <remarks>
+        /// Implementations should return an empty sequence when no validation failures are present.
+        /// </remarks>
         public abstract IEnumerable<ValidationResult> Validate(ValidationContext validationContext);
     }
 }

--- a/src/MooVC.Syntax/IProduceXml.cs
+++ b/src/MooVC.Syntax/IProduceXml.cs
@@ -6,14 +6,20 @@
     /// <summary>
     /// Defines a contract for producing XML fragments as a collection of <see cref="XElement"/> objects.
     /// </summary>
+    /// <remarks>
+    /// Implementations should produce deterministic output so repeated invocations can be safely compared in tests.
+    /// </remarks>
     public interface IProduceXml
     {
         /// <summary>
         /// Returns the XML fragments that represent the current object's content.
         /// </summary>
         /// <returns>
-        /// An immutable array of <see cref="XElement"/> objects containing the XML fragments. The array will be empty if there is no content.
+        /// An immutable array of <see cref="XElement"/> objects containing the XML fragments.
         /// </returns>
+        /// <remarks>
+        /// The returned array should be empty when no XML output is applicable for the current instance.
+        /// </remarks>
         ImmutableArray<XElement> ToFragments();
     }
 }

--- a/src/MooVC.Syntax/Resource/Metadata.cs
+++ b/src/MooVC.Syntax/Resource/Metadata.cs
@@ -12,8 +12,12 @@ namespace MooVC.Syntax.Resource
     using Ignore = Valuify.IgnoreAttribute;
 
     /// <summary>
-    /// Represents a resource file attribute metadata.
+    /// Represents metadata associated with a resource entry in a .resx document.
     /// </summary>
+    /// <remarks>
+    /// Metadata is serialized as a <c>metadata</c> element with optional attributes and an optional
+    /// nested <c>value</c> element.
+    /// </remarks>
     [Fluentify]
     [Valuify]
     public sealed partial class Metadata
@@ -40,35 +44,35 @@ namespace MooVC.Syntax.Resource
         public bool IsUndefined => this == Undefined;
 
         /// <summary>
-        /// Gets the mime type on the Metadata.
+        /// Gets the MIME type metadata value.
         /// </summary>
-        /// <value>The mime type.</value>
+        /// <value>The MIME type metadata value.</value>
         public Snippet MimeType { get; internal set; } = Snippet.Empty;
 
         /// <summary>
-        /// Gets the name on the Metadata.
+        /// Gets the metadata name.
         /// </summary>
-        /// <value>The name.</value>
+        /// <value>The metadata name.</value>
         [Descriptor("Named")]
         public Snippet Name { get; internal set; } = Snippet.Empty;
 
         /// <summary>
-        /// Gets the type on the Metadata.
+        /// Gets the CLR type metadata value.
         /// </summary>
-        /// <value>The type.</value>
+        /// <value>The CLR type metadata value.</value>
         [Descriptor("OfType")]
         public Snippet Type { get; internal set; } = Snippet.Empty;
 
         /// <summary>
-        /// Gets the value on the Metadata.
+        /// Gets the metadata payload.
         /// </summary>
-        /// <value>The value.</value>
+        /// <value>The metadata payload.</value>
         public Snippet Value { get; internal set; } = Snippet.Empty;
 
         /// <summary>
-        /// Performs the to fragments operation for the resource file attribute.
+        /// Creates the XML fragments for the metadata element.
         /// </summary>
-        /// <returns>The immutable array x element.</returns>
+        /// <returns>An immutable array containing a single <see cref="XElement"/> when defined; otherwise an empty array.</returns>
         public ImmutableArray<XElement> ToFragments()
         {
             if (IsUndefined)
@@ -85,9 +89,9 @@ namespace MooVC.Syntax.Resource
         }
 
         /// <summary>
-        /// Returns the string representation of the Metadata.
+        /// Returns the string representation of the metadata element.
         /// </summary>
-        /// <returns>The string representation.</returns>
+        /// <returns>The XML representation, or <see cref="string.Empty"/> when undefined.</returns>
         public override string ToString()
         {
             if (IsUndefined)
@@ -99,9 +103,11 @@ namespace MooVC.Syntax.Resource
         }
 
         /// <summary>
-        /// Validates the Metadata.
+        /// Validates the metadata.
         /// </summary>
-        /// <remarks>Required members include: MimeType, Name, Type.</remarks>
+        /// <remarks>
+        /// Required members include <see cref="MimeType"/>, <see cref="Name"/>, and <see cref="Type"/>.
+        /// </remarks>
         /// <param name="validationContext">The validation context.</param>
         /// <returns>The validation results.</returns>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)


### PR DESCRIPTION
### Motivation
- Improve the XML documentation for core syntax model types to clarify usage, serialization, validation and implicit conversion semantics for maintainers and consumers. 
- Add richer documentation tags and remarks so generated docs and unit tests can rely on clearer contracts for behavior and invariants.

### Description
- Updated `src/MooVC.Syntax/Builder.cs` to provide a clearer summary, add a `<typeparam>` tag and a `<remarks>` paragraph describing the factory intent. 
- Refined `src/MooVC.Syntax/Construct.cs` documentation to clarify the undefined-state contract, the `IsUndefined` semantics and validation return expectations. 
- Enhanced `src/MooVC.Syntax/IProduceXml.cs` with a `<remarks>` note about deterministic output and clarified the `ToFragments` contract. 
- Expanded `src/MooVC.Syntax/Resource/Metadata.cs` comments to describe `.resx` serialization, improve property descriptions (`MimeType`, `Name`, `Type`, `Value`) and clarify validation requirements and `ToFragments`/`ToString` behavior. 
- Improved `src/MooVC.Syntax.CSharp/Extensions.cs` and `src/MooVC.Syntax.CSharp/Options.cs` documentation to explain extension constants and implicit conversion behavior (including null-conversion and snippet propagation semantics). 

### Testing
- Attempted to run the repository checks with `dotnet --version && dotnet restore && dotnet test -v minimal`, but the `dotnet` command is not available in the current environment so tests could not be executed. 
- Changes are documentation-only and do not modify runtime logic or public APIs, so no functional test changes were required or performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db77fd73f8832f8989c2b4b30b150e)