### PR TITLE
Add unit coverage for Moniker and Build generated members

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/BaseTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/BaseTestsData.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public static class BaseTestsData
+{
+    public static Base Create(
+        Qualification? name = default,
+        Token? argument = default)
+    {
+        Base result = new Base
+        {
+            Name = name ?? (Qualification)"Comparable",
+        };
+
+        if (argument is not null)
+        {
+            result = result.WithArguments(argument);
+        }
+
+        return result;
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualityOperatorBaseBaseIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualityOperatorBaseBaseIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenEqualityOperatorBaseBaseIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Base left = BaseTestsData.Create();
+        Base right = BaseTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsBaseIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsBaseIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenEqualsBaseIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Base subject = BaseTestsData.Create(name: (Qualification)"Comparable");
+        Base other = BaseTestsData.Create(name: (Qualification)"IComparable");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Base subject = BaseTestsData.Create();
+        object other = BaseTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Base left = BaseTestsData.Create();
+        Base right = BaseTestsData.Create();
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenInequalityOperatorBaseBaseIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenInequalityOperatorBaseBaseIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenInequalityOperatorBaseBaseIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Base left = BaseTestsData.Create(name: (Qualification)"Comparable");
+        Base right = BaseTestsData.Create(name: (Qualification)"IComparable");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenNamedIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenNamedIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenNamedIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Base original = BaseTestsData.Create(name: (Qualification)"Comparable");
+        var updated = (Qualification)"IComparable";
+
+        // Act
+        Base result = original.Named(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Name).IsEqualTo(updated);
+        _ = await Assert.That(result.Arguments).IsEqualTo(original.Arguments);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringContainsName()
+    {
+        // Arrange
+        Base subject = BaseTestsData.Create(name: (Qualification)"Comparable");
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).Contains("Comparable");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenWithArgumentsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenWithArgumentsIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenWithArgumentsIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Base original = BaseTestsData.Create();
+        Token argument = (Name)"T";
+
+        // Act
+        Base result = original.WithArguments(argument);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Arguments).Contains(argument);
+        _ = await Assert.That(result.Name).IsEqualTo(original.Name);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/ImplementationTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/ImplementationTestsData.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public static class ImplementationTestsData
+{
+    public static Implementation Create(
+        Qualification? name = default,
+        Token? argument = default)
+    {
+        Implementation result = new Implementation
+        {
+            Name = name ?? (Qualification)"IComparable",
+        };
+
+        if (argument is not null)
+        {
+            result = result.WithArguments(argument);
+        }
+
+        return result;
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualityOperatorImplementationImplementationIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualityOperatorImplementationImplementationIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenEqualityOperatorImplementationImplementationIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Implementation left = ImplementationTestsData.Create();
+        Implementation right = ImplementationTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsImplementationIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsImplementationIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenEqualsImplementationIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Implementation subject = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+        Implementation other = ImplementationTestsData.Create(name: (Qualification)"IDisposable");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Implementation subject = ImplementationTestsData.Create();
+        object other = ImplementationTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Implementation left = ImplementationTestsData.Create();
+        Implementation right = ImplementationTestsData.Create();
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenInequalityOperatorImplementationImplementationIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenInequalityOperatorImplementationImplementationIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenInequalityOperatorImplementationImplementationIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Implementation left = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+        Implementation right = ImplementationTestsData.Create(name: (Qualification)"IDisposable");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenNamedIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenNamedIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenNamedIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Implementation original = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+        var updated = (Qualification)"IDisposable";
+
+        // Act
+        Implementation result = original.Named(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Name).IsEqualTo(updated);
+        _ = await Assert.That(result.Arguments).IsEqualTo(original.Arguments);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringContainsName()
+    {
+        // Arrange
+        Implementation subject = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).Contains("IComparable");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenWithArgumentsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenWithArgumentsIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenWithArgumentsIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Implementation original = ImplementationTestsData.Create();
+        Token argument = (Name)"T";
+
+        // Act
+        Implementation result = original.WithArguments(argument);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Arguments).Contains(argument);
+        _ = await Assert.That(result.Name).IsEqualTo(original.Name);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerMonikerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerMonikerIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualityOperatorMonikerMonikerIsCalled
+{
+    private const string Same = "Value";
+    private const string Different = "Other";
+
+    [Test]
+    public async Task GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Moniker? left = default;
+        Moniker? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = Same;
+        Moniker right = Different;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = Same;
+        Moniker right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerStringIsCalled.cs
@@ -1,0 +1,39 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualityOperatorMonikerStringIsCalled
+{
+    private const string Same = "Value";
+    private const string Different = "Other";
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = Same;
+        string right = Different;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = Same;
+        string right = Same;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsMonikerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsMonikerIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualsMonikerIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        Moniker other = "Value";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        Moniker? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        object other = (Moniker)"Value";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenOtherTypeThenReturnsFalse()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        object other = "Value";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Moniker left = "Value";
+        Moniker right = "Value";
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorFromStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorFromStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenImplicitOperatorFromStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenMonikerEqualsString()
+    {
+        // Arrange
+        const string value = "Value";
+
+        // Act
+        Moniker result = value;
+
+        // Assert
+        _ = await Assert.That(result == value).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringIsReturned()
+    {
+        // Arrange
+        Moniker subject = "Value";
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Value");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerMonikerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerMonikerIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenInequalityOperatorMonikerMonikerIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = "Value";
+        Moniker right = "Other";
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = "Value";
+        Moniker right = "Value";
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerStringIsCalled.cs
@@ -7,7 +7,7 @@ public sealed class WhenInequalityOperatorMonikerStringIsCalled
     {
         // Arrange
         Moniker left = "Value";
-        const string right = "Other";
+        string right = "Other";
 
         // Act
         bool resultLeftRight = left != right;
@@ -23,7 +23,7 @@ public sealed class WhenInequalityOperatorMonikerStringIsCalled
     {
         // Arrange
         Moniker left = "Value";
-        const string right = "Value";
+        string right = "Value";
 
         // Act
         bool resultLeftRight = left != right;

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerStringIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenInequalityOperatorMonikerStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = "Value";
+        const string right = "Other";
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = "Value";
+        const string right = "Value";
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenValueIsReturned()
+    {
+        // Arrange
+        Moniker subject = "Value";
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Value");
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/BuildTestsData.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/BuildTestsData.cs
@@ -1,0 +1,15 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public static class BuildTestsData
+{
+    public static Build Create(
+        Snippet? project = default,
+        Snippet? solution = default)
+    {
+        return new Build
+        {
+            Project = project ?? Snippet.From("Debug|AnyCPU"),
+            Solution = solution ?? Snippet.From("Debug|Any CPU"),
+        };
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualityOperatorBuildBuildIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualityOperatorBuildBuildIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenEqualityOperatorBuildBuildIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Build left = BuildTestsData.Create();
+        Build right = BuildTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsBuildIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsBuildIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenEqualsBuildIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Build subject = BuildTestsData.Create(project: Snippet.From("Debug|AnyCPU"));
+        Build other = BuildTestsData.Create(project: Snippet.From("Release|AnyCPU"));
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Build subject = BuildTestsData.Create();
+        object other = BuildTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForProjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForProjectIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenForProjectIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsNewInstanceWithUpdatedProject()
+    {
+        // Arrange
+        Build original = BuildTestsData.Create();
+        var updated = Snippet.From("Release|AnyCPU");
+
+        // Act
+        Build result = original.ForProject(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Project).IsEqualTo(updated);
+        _ = await Assert.That(result.Solution).IsEqualTo(original.Solution);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForSolutionIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForSolutionIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenForSolutionIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsNewInstanceWithUpdatedSolution()
+    {
+        // Arrange
+        Build original = BuildTestsData.Create();
+        var updated = Snippet.From("Release|Any CPU");
+
+        // Act
+        Build result = original.ForSolution(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Project).IsEqualTo(original.Project);
+        _ = await Assert.That(result.Solution).IsEqualTo(updated);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Build left = BuildTestsData.Create();
+        Build right = BuildTestsData.Create();
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenInequalityOperatorBuildBuildIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenInequalityOperatorBuildBuildIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenInequalityOperatorBuildBuildIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Build left = BuildTestsData.Create(project: Snippet.From("Debug|AnyCPU"));
+        Build right = BuildTestsData.Create(project: Snippet.From("Release|AnyCPU"));
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenToStringIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringContainsProjectAndSolutionAttributes()
+    {
+        // Arrange
+        Build subject = BuildTestsData.Create();
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).Contains(nameof(Build.Project));
+        _ = await Assert.That(result).Contains(nameof(Build.Solution));
+    }
+}


### PR DESCRIPTION
### Motivation

- Cover generated behavior for types annotated with `Monify`, `Valuify` and `Fluentify` that lacked dedicated tests in the `Syntax` libraries. 
- Ensure value/monadic semantics (operators, equality, hashing, ToString, conversions) are validated for `Moniker` and mapping/fluent behaviors are validated for `Build`. 
- Move toward full unit-test coverage of generated members required by the repository testing conventions.

### Description

- Added a `MonikerTests` suite under `src/MooVC.Syntax.CSharp.Tests/MonikerTests/` that exercises `Moniker` semantics including `==`/`!=` operators (both `Moniker`/`Moniker` and `Moniker`/`string`), `object.Equals(...)`, typed `Equals(Moniker)`, `GetHashCode()`, `ToString()`, and implicit conversions to/from `string`.
- Added a `BuildTests` suite under `src/MooVC.Syntax.Tests/Solution/BuildTests/` and a helper `BuildTestsData` factory that exercises `Build` behaviors produced by `Valuify` and `Fluentify`, including `==`/`!=`, `object.Equals(...)`, typed `Equals(Build)`, `GetHashCode()`, `ToString()`, and descriptor-based fluent methods `ForProject(...)` and `ForSolution(...)`.
- Created 19 new test files covering the generated-members behaviors for these types and placed them following the project test layout and naming conventions.

### Testing

- Ran repository scans to identify annotated types and missing test suites using `rg -n "\[(Fluentify|Valuify|Monify)" src` and a small Python script to detect types without corresponding test directories, which identified `Moniker` and `Build` as gaps and guided the added tests.
- Verified the new test files were added to the test projects and follow existing conventions by file inspection (no full test run performed in this environment). 
- Attempted to run `.NET` locally via `dotnet --version` / `dotnet test` but execution was blocked because the environment lacks the .NET SDK (`dotnet: command not found`), so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8459e504832fb3956dada019bddb)