### PR TITLE
Add unit tests for equality, hashing, conversions and ToString for domain types

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualityOperatorStylesStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualityOperatorStylesStringIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenEqualityOperatorStylesStringIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Attribute.Options.Styles left = Attribute.Options.Styles.Inline;
+        string right = "Inline";
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualityOperatorStylesStylesIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualityOperatorStylesStylesIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenEqualityOperatorStylesStylesIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Attribute.Options.Styles left = Attribute.Options.Styles.Inline;
+        Attribute.Options.Styles right = Attribute.Options.Styles.Inline;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Attribute.Options.Styles subject = Attribute.Options.Styles.Separate;
+        object other = Attribute.Options.Styles.Separate;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualsStylesIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenEqualsStylesIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenEqualsStylesIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Attribute.Options.Styles subject = Attribute.Options.Styles.Inline;
+        Attribute.Options.Styles other = Attribute.Options.Styles.Separate;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Attribute.Options.Styles left = Attribute.Options.Styles.Inline;
+        Attribute.Options.Styles right = Attribute.Options.Styles.Inline;
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenImplicitOperatorFromStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenImplicitOperatorFromStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenImplicitOperatorFromStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsEquivalentInstance()
+    {
+        // Arrange
+        const string value = "Inline";
+
+        // Act
+        Attribute.Options.Styles result = value;
+
+        // Assert
+        _ = await Assert.That(result == value).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUnderlyingString()
+    {
+        // Arrange
+        Attribute.Options.Styles subject = Attribute.Options.Styles.Inline;
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Inline");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenInequalityOperatorStylesStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenInequalityOperatorStylesStringIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenInequalityOperatorStylesStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Attribute.Options.Styles left = Attribute.Options.Styles.Inline;
+        string right = "Separate";
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenInequalityOperatorStylesStylesIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenInequalityOperatorStylesStylesIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenInequalityOperatorStylesStylesIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Attribute.Options.Styles left = Attribute.Options.Styles.Inline;
+        Attribute.Options.Styles right = Attribute.Options.Styles.Separate;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/AttributeTests/OptionsTests/StylesTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.AttributeTests.OptionsTests.StylesTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsValue()
+    {
+        // Arrange
+        Attribute.Options.Styles subject = Attribute.Options.Styles.Separate;
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Separate");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/BaseTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/BaseTestsData.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public static class BaseTestsData
+{
+    public static Base Create(
+        Qualification? name = default,
+        Token? argument = default)
+    {
+        Base result = new Base
+        {
+            Name = name ?? (Qualification)"Comparable",
+        };
+
+        if (argument is not null)
+        {
+            result = result.WithArguments(argument);
+        }
+
+        return result;
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualityOperatorBaseBaseIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualityOperatorBaseBaseIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenEqualityOperatorBaseBaseIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Base left = BaseTestsData.Create();
+        Base right = BaseTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsBaseIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsBaseIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenEqualsBaseIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Base subject = BaseTestsData.Create(name: (Qualification)"Comparable");
+        Base other = BaseTestsData.Create(name: (Qualification)"IComparable");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Base subject = BaseTestsData.Create();
+        object other = BaseTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Base left = BaseTestsData.Create();
+        Base right = BaseTestsData.Create();
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenInequalityOperatorBaseBaseIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenInequalityOperatorBaseBaseIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenInequalityOperatorBaseBaseIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Base left = BaseTestsData.Create(name: (Qualification)"Comparable");
+        Base right = BaseTestsData.Create(name: (Qualification)"IComparable");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenNamedIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenNamedIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenNamedIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Base original = BaseTestsData.Create(name: (Qualification)"Comparable");
+        var updated = (Qualification)"IComparable";
+
+        // Act
+        Base result = original.Named(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Name).IsEqualTo(updated);
+        _ = await Assert.That(result.Arguments).IsEqualTo(original.Arguments);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringContainsName()
+    {
+        // Arrange
+        Base subject = BaseTestsData.Create(name: (Qualification)"Comparable");
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).Contains("Comparable");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenWithArgumentsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/BaseTests/WhenWithArgumentsIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.BaseTests;
+
+public sealed class WhenWithArgumentsIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Base original = BaseTestsData.Create();
+        Token argument = (Name)"T";
+
+        // Act
+        Base result = original.WithArguments(argument);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Arguments).Contains(argument);
+        _ = await Assert.That(result.Name).IsEqualTo(original.Name);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/ImplementationTestsData.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/ImplementationTestsData.cs
@@ -1,0 +1,21 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public static class ImplementationTestsData
+{
+    public static Implementation Create(
+        Qualification? name = default,
+        Token? argument = default)
+    {
+        Implementation result = new Implementation
+        {
+            Name = name ?? (Qualification)"IComparable",
+        };
+
+        if (argument is not null)
+        {
+            result = result.WithArguments(argument);
+        }
+
+        return result;
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualityOperatorImplementationImplementationIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualityOperatorImplementationImplementationIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenEqualityOperatorImplementationImplementationIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Implementation left = ImplementationTestsData.Create();
+        Implementation right = ImplementationTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsImplementationIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsImplementationIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenEqualsImplementationIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Implementation subject = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+        Implementation other = ImplementationTestsData.Create(name: (Qualification)"IDisposable");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Implementation subject = ImplementationTestsData.Create();
+        object other = ImplementationTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Implementation left = ImplementationTestsData.Create();
+        Implementation right = ImplementationTestsData.Create();
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenInequalityOperatorImplementationImplementationIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenInequalityOperatorImplementationImplementationIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenInequalityOperatorImplementationImplementationIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Implementation left = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+        Implementation right = ImplementationTestsData.Create(name: (Qualification)"IDisposable");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenNamedIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenNamedIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenNamedIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Implementation original = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+        var updated = (Qualification)"IDisposable";
+
+        // Act
+        Implementation result = original.Named(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Name).IsEqualTo(updated);
+        _ = await Assert.That(result.Arguments).IsEqualTo(original.Arguments);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringContainsName()
+    {
+        // Arrange
+        Implementation subject = ImplementationTestsData.Create(name: (Qualification)"IComparable");
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).Contains("IComparable");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenWithArgumentsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ImplementationTests/WhenWithArgumentsIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.ImplementationTests;
+
+public sealed class WhenWithArgumentsIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUpdatedInstance()
+    {
+        // Arrange
+        Implementation original = ImplementationTestsData.Create();
+        Token argument = (Name)"T";
+
+        // Act
+        Implementation result = original.WithArguments(argument);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Arguments).Contains(argument);
+        _ = await Assert.That(result.Name).IsEqualTo(original.Name);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerMonikerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerMonikerIsCalled.cs
@@ -1,0 +1,49 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualityOperatorMonikerMonikerIsCalled
+{
+    private const string Same = "Value";
+    private const string Different = "Other";
+
+    [Test]
+    public async Task GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Moniker? left = default;
+        Moniker? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = Same;
+        Moniker right = Different;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = Same;
+        Moniker right = Same;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualityOperatorMonikerStringIsCalled.cs
@@ -1,0 +1,39 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualityOperatorMonikerStringIsCalled
+{
+    private const string Same = "Value";
+    private const string Different = "Other";
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = Same;
+        string right = Different;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = Same;
+        string right = Same;
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsMonikerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsMonikerIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualsMonikerIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        Moniker other = "Value";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        Moniker? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        object other = (Moniker)"Value";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenOtherTypeThenReturnsFalse()
+    {
+        // Arrange
+        Moniker subject = "Value";
+        object other = "Value";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Moniker left = "Value";
+        Moniker right = "Value";
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorFromStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorFromStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenImplicitOperatorFromStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenMonikerEqualsString()
+    {
+        // Arrange
+        const string value = "Value";
+
+        // Act
+        Moniker result = value;
+
+        // Assert
+        _ = await Assert.That(result == value).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringIsReturned()
+    {
+        // Arrange
+        Moniker subject = "Value";
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Value");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerMonikerIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerMonikerIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenInequalityOperatorMonikerMonikerIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = "Value";
+        Moniker right = "Other";
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = "Value";
+        Moniker right = "Value";
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenInequalityOperatorMonikerStringIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenInequalityOperatorMonikerStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Moniker left = "Value";
+        string right = "Other";
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Moniker left = "Value";
+        string right = "Value";
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/MonikerTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.MonikerTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenValueIsReturned()
+    {
+        // Arrange
+        Moniker subject = "Value";
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Value");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualityOperatorFormatsFormatsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualityOperatorFormatsFormatsIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenEqualityOperatorFormatsFormatsIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Qualification.Options.Formats left = Qualification.Options.Formats.Full;
+        Qualification.Options.Formats right = Qualification.Options.Formats.Full;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualityOperatorFormatsStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualityOperatorFormatsStringIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenEqualityOperatorFormatsStringIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Qualification.Options.Formats left = Qualification.Options.Formats.Full;
+        string right = "Full";
+
+        // Act
+        bool resultLeftRight = left == right;
+        bool resultRightLeft = right == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualsFormatsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualsFormatsIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenEqualsFormatsIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Qualification.Options.Formats subject = Qualification.Options.Formats.Full;
+        Qualification.Options.Formats other = Qualification.Options.Formats.Global;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Qualification.Options.Formats subject = Qualification.Options.Formats.Full;
+        object other = Qualification.Options.Formats.Full;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Qualification.Options.Formats left = Qualification.Options.Formats.Global;
+        Qualification.Options.Formats right = Qualification.Options.Formats.Global;
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenImplicitOperatorFromStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenImplicitOperatorFromStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenImplicitOperatorFromStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsEquivalentInstance()
+    {
+        // Arrange
+        const string value = "Global";
+
+        // Act
+        Qualification.Options.Formats result = value;
+
+        // Assert
+        _ = await Assert.That(result == value).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsUnderlyingString()
+    {
+        // Arrange
+        Qualification.Options.Formats subject = Qualification.Options.Formats.Full;
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Full");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenInequalityOperatorFormatsFormatsIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenInequalityOperatorFormatsFormatsIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenInequalityOperatorFormatsFormatsIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Qualification.Options.Formats left = Qualification.Options.Formats.Full;
+        Qualification.Options.Formats right = Qualification.Options.Formats.Global;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenInequalityOperatorFormatsStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenInequalityOperatorFormatsStringIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenInequalityOperatorFormatsStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Qualification.Options.Formats left = Qualification.Options.Formats.Full;
+        string right = "Minimum";
+
+        // Act
+        bool resultLeftRight = left != right;
+        bool resultRightLeft = right != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/SymbolTests/QualificationTests/FormatsTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.SymbolTests.QualificationTests.FormatsTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsValue()
+    {
+        // Arrange
+        Qualification.Options.Formats subject = Qualification.Options.Formats.Minimum;
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Minimum");
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/BuildTestsData.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/BuildTestsData.cs
@@ -1,0 +1,15 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public static class BuildTestsData
+{
+    public static Build Create(
+        Snippet? project = default,
+        Snippet? solution = default)
+    {
+        return new Build
+        {
+            Project = project ?? Snippet.From("Debug|AnyCPU"),
+            Solution = solution ?? Snippet.From("Debug|Any CPU"),
+        };
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualityOperatorBuildBuildIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualityOperatorBuildBuildIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenEqualityOperatorBuildBuildIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Build left = BuildTestsData.Create();
+        Build right = BuildTestsData.Create();
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsBuildIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsBuildIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenEqualsBuildIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Build subject = BuildTestsData.Create(project: Snippet.From("Debug|AnyCPU"));
+        Build other = BuildTestsData.Create(project: Snippet.From("Release|AnyCPU"));
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValueThenReturnsTrue()
+    {
+        // Arrange
+        Build subject = BuildTestsData.Create();
+        object other = BuildTestsData.Create();
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForProjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForProjectIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenForProjectIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsNewInstanceWithUpdatedProject()
+    {
+        // Arrange
+        Build original = BuildTestsData.Create();
+        var updated = Snippet.From("Release|AnyCPU");
+
+        // Act
+        Build result = original.ForProject(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Project).IsEqualTo(updated);
+        _ = await Assert.That(result.Solution).IsEqualTo(original.Solution);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForSolutionIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenForSolutionIsCalled.cs
@@ -1,0 +1,20 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenForSolutionIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsNewInstanceWithUpdatedSolution()
+    {
+        // Arrange
+        Build original = BuildTestsData.Create();
+        var updated = Snippet.From("Release|Any CPU");
+
+        // Act
+        Build result = original.ForSolution(updated);
+
+        // Assert
+        _ = await Assert.That(result).IsNotSameReferenceAs(original);
+        _ = await Assert.That(result.Project).IsEqualTo(original.Project);
+        _ = await Assert.That(result.Solution).IsEqualTo(updated);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentValuesThenHashCodesMatch()
+    {
+        // Arrange
+        Build left = BuildTestsData.Create();
+        Build right = BuildTestsData.Create();
+
+        // Act
+        int leftHash = left.GetHashCode();
+        int rightHash = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHash).IsEqualTo(rightHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenInequalityOperatorBuildBuildIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenInequalityOperatorBuildBuildIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenInequalityOperatorBuildBuildIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Build left = BuildTestsData.Create(project: Snippet.From("Debug|AnyCPU"));
+        Build right = BuildTestsData.Create(project: Snippet.From("Release|AnyCPU"));
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenToStringIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenStringContainsProjectAndSolutionAttributes()
+    {
+        // Arrange
+        Build subject = BuildTestsData.Create();
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).Contains(nameof(Build.Project));
+        _ = await Assert.That(result).Contains(nameof(Build.Solution));
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure correct equality, inequality, `Equals`, `GetHashCode`, implicit conversion and `ToString` behavior across several domain types.
- Provide test coverage for mutating helper methods such as `Named`, `WithArguments`, `ForProject`, and `ForSolution` to validate immutability and value updates.
- Centralize test object creation with helper factories to simplify and standardize test data setup.

### Description

- Added a large set of unit tests covering `Attribute.Options.Styles`, `Base`, `Implementation`, `Moniker`, `Qualification.Options.Formats`, and `Build` types to validate equality operators, inequality operators, `Equals(object)`, `GetHashCode()`, implicit conversions, and `ToString()` behavior.
- Introduced test helper classes `BaseTestsData`, `ImplementationTestsData`, `BuildTestsData` to construct common test instances with optional parameters.
- Added tests for instance update methods `Named`, `WithArguments`, `ForProject`, and `ForSolution` to assert returned instances are new and correctly updated.
- Organized tests into appropriate namespaces and folders reflecting the domain areas (`AttributeTests`, `BaseTests`, `ImplementationTests`, `MonikerTests`, `SymbolTests`, `Solution.BuildTests`).

### Testing

- Ran the unit test suite with `dotnet test` including all newly added tests. 
- All newly added tests executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8459e504832fb3956dada019bddb)