### PR TITLE
docs: use cref metadata tags in implicit conversion comments

### DIFF
--- a/src/MooVC.Syntax.CSharp/Argument.Modes.cs
+++ b/src/MooVC.Syntax.CSharp/Argument.Modes.cs
@@ -72,10 +72,10 @@ namespace MooVC.Syntax.CSharp
             public bool IsRef => this == Ref;
 
             /// <summary>
-            /// Defines the string operator for the Mode.
+            /// Defines an implicit conversion from <see cref="Modes" /> to <see cref="string" />.
             /// </summary>
-            /// <param name="mode">The mode.</param>
-            /// <returns>The string.</returns>
+            /// <param name="mode">The <see cref="Modes" /> value to convert.</param>
+            /// <returns>The converted <see cref="string" /> value.</returns>
             public static implicit operator string(Modes mode)
             {
                 Guard.Against.Conversion<Modes, string>(mode);
@@ -84,10 +84,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines the Snippet operator for the Mode.
+            /// Defines an implicit conversion from <see cref="Modes" /> to <see cref="Snippet" />.
             /// </summary>
-            /// <param name="mode">The mode.</param>
-            /// <returns>The snippet.</returns>
+            /// <param name="mode">The <see cref="Modes" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet" /> value.</returns>
             public static implicit operator Snippet(Modes mode)
             {
                 Guard.Against.Conversion<Modes, Snippet>(mode);

--- a/src/MooVC.Syntax.CSharp/Argument.Options.Formatters.cs
+++ b/src/MooVC.Syntax.CSharp/Argument.Options.Formatters.cs
@@ -50,10 +50,10 @@ namespace MooVC.Syntax.CSharp
                 public bool IsDeclaration => this == Declaration;
 
                 /// <summary>
-                /// Defines the string operator for the Formatter.
+                /// Defines an implicit conversion from <see cref="Formatters" /> to <see cref="string" />.
                 /// </summary>
-                /// <param name="formatter">The formatter.</param>
-                /// <returns>The string.</returns>
+                /// <param name="formatter">The <see cref="Formatters" /> value to convert.</param>
+                /// <returns>The converted <see cref="string" /> value.</returns>
                 public static implicit operator string(Formatters formatter)
                 {
                     Guard.Against.Conversion<Formatters, string>(formatter);
@@ -62,10 +62,10 @@ namespace MooVC.Syntax.CSharp
                 }
 
                 /// <summary>
-                /// Defines the Snippet operator for the Formatter.
+                /// Defines an implicit conversion from <see cref="Formatters" /> to <see cref="Snippet" />.
                 /// </summary>
-                /// <param name="formatter">The formatter.</param>
-                /// <returns>The snippet.</returns>
+                /// <param name="formatter">The <see cref="Formatters" /> value to convert.</param>
+                /// <returns>The converted <see cref="Snippet" /> value.</returns>
                 public static implicit operator Snippet(Formatters formatter)
                 {
                     Guard.Against.Conversion<Formatters, Snippet>(formatter);

--- a/src/MooVC.Syntax.CSharp/Argument.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Argument.Options.cs
@@ -57,10 +57,10 @@ namespace MooVC.Syntax.CSharp
             public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Unspecified;
 
             /// <summary>
-            /// Converts argument options into formatter options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Formatters" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The formatter options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Formatters" /> value.</returns>
             public static implicit operator Formatters(Options options)
             {
                 Guard.Against.Conversion<Options, Formatters>(options);
@@ -69,10 +69,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts argument options into variable naming options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Variable.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The variable options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Variable.Options" /> value.</returns>
             public static implicit operator Variable.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Variable.Options>(options);
@@ -81,10 +81,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts argument options into code options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The code options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Argument.cs
+++ b/src/MooVC.Syntax.CSharp/Argument.cs
@@ -58,10 +58,10 @@ namespace MooVC.Syntax.CSharp
         public Snippet Value { get; internal set; } = Snippet.Empty;
 
         /// <summary>
-        /// Converts the argument expression to its C# source representation.
+        /// Defines an implicit conversion from <see cref="Argument" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="argument">The argument to render.</param>
-        /// <returns>The rendered argument text.</returns>
+        /// <param name="argument">The <see cref="Argument" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Argument argument)
         {
             Guard.Against.Conversion<Argument, string>(argument);
@@ -70,10 +70,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the argument expression to a snippet for composition.
+        /// Defines an implicit conversion from <see cref="Argument" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="argument">The argument to convert.</param>
-        /// <returns>The snippet representing the argument.</returns>
+        /// <param name="argument">The <see cref="Argument" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Argument argument)
         {
             Guard.Against.Conversion<Argument, Snippet>(argument);
@@ -82,10 +82,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing an argument name and value into an argument expression.
+        /// Defines an implicit conversion to <see cref="Argument" />.
         /// </summary>
-        /// <param name="argument">The tuple that provides the argument name and value.</param>
-        /// <returns>The Argument.</returns>
+        /// <param name="argument">The value to convert.</param>
+        /// <returns>The converted <see cref="Argument" /> value.</returns>
         public static implicit operator Argument((Name Name, Snippet Value) argument)
         {
             Guard.Against.Conversion<(Name Name, Snippet Value), Argument>(argument);

--- a/src/MooVC.Syntax.CSharp/Attribute.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Attribute.Options.cs
@@ -108,10 +108,10 @@ namespace MooVC.Syntax.CSharp
             public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Unspecified;
 
             /// <summary>
-            /// Converts parameter options into snippet options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The snippet options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);
@@ -120,10 +120,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts parameter options into symbol options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Qualification.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The symbol options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Qualification.Options" /> value.</returns>
             public static implicit operator Qualification.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Qualification.Options>(options);
@@ -132,13 +132,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines an implicit conversion from an Options instance to a Style instance.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Styles" />.
             /// </summary>
-            /// <param name="options">The Options instance to convert to a Style.</param>
-            /// <remarks>
-            /// This operator enables seamless assignment of an Options object where a Style
-            /// is expected, by extracting the Format property from the Options instance.
-            /// </remarks>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Styles" /> value.</returns>
             public static implicit operator Styles(Options options)
             {
                 Guard.Against.Conversion<Options, Styles>(options);

--- a/src/MooVC.Syntax.CSharp/Attribute.Specifiers.cs
+++ b/src/MooVC.Syntax.CSharp/Attribute.Specifiers.cs
@@ -113,10 +113,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines the string operator for the Specifier.
+            /// Defines an implicit conversion from <see cref="Specifiers" /> to <see cref="string" />.
             /// </summary>
-            /// <param name="specifiers">The specifier.</param>
-            /// <returns>The string.</returns>
+            /// <param name="specifiers">The <see cref="Specifiers" /> value to convert.</param>
+            /// <returns>The converted <see cref="string" /> value.</returns>
             public static implicit operator string(Specifiers specifiers)
             {
                 Guard.Against.Conversion<Specifiers, string>(specifiers);
@@ -125,10 +125,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines the Snippet operator for the Specifier.
+            /// Defines an implicit conversion from <see cref="Specifiers" /> to <see cref="Snippet" />.
             /// </summary>
-            /// <param name="specifiers">The specifier.</param>
-            /// <returns>The snippet.</returns>
+            /// <param name="specifiers">The <see cref="Specifiers" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet" /> value.</returns>
             public static implicit operator Snippet(Specifiers specifiers)
             {
                 Guard.Against.Conversion<Specifiers, Snippet>(specifiers);

--- a/src/MooVC.Syntax.CSharp/Attribute.cs
+++ b/src/MooVC.Syntax.CSharp/Attribute.cs
@@ -66,10 +66,10 @@ namespace MooVC.Syntax.CSharp
         public Specifiers Target { get; internal set; } = Specifiers.None;
 
         /// <summary>
-        /// Defines the string operator for the Attribute.
+        /// Defines an implicit conversion from <see cref="Attribute" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="attribute">The attribute.</param>
-        /// <returns>The string.</returns>
+        /// <param name="attribute">The <see cref="Attribute" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Attribute attribute)
         {
             Guard.Against.Conversion<Attribute, string>(attribute);
@@ -78,10 +78,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Attribute.
+        /// Defines an implicit conversion from <see cref="Attribute" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="attribute">The attribute.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="attribute">The <see cref="Attribute" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Attribute attribute)
         {
             Guard.Against.Conversion<Attribute, Snippet>(attribute);
@@ -90,10 +90,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Type operator for the Attribute.
+        /// Defines an implicit conversion from <see cref="CType" /> to <see cref="Attribute" />.
         /// </summary>
-        /// <param name="type">The Type representing the Name of the Attribute.</param>
-        /// <returns>The Attribute.</returns>
+        /// <param name="type">The <see cref="CType" /> value to convert.</param>
+        /// <returns>The converted <see cref="Attribute" /> value.</returns>
         public static implicit operator Attribute(CType type)
         {
             Guard.Against.Conversion<CType, Attribute>(type);
@@ -103,10 +103,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Symbol operator for the Attribute.
+        /// Defines an implicit conversion from <see cref="Symbol" /> to <see cref="Attribute" />.
         /// </summary>
-        /// <param name="name">The Symbol representing the Name of the Attribute.</param>
-        /// <returns>The Attribute.</returns>
+        /// <param name="name">The <see cref="Symbol" /> value to convert.</param>
+        /// <returns>The converted <see cref="Attribute" /> value.</returns>
         public static implicit operator Attribute(Symbol name)
         {
             Guard.Against.Conversion<Symbol, Attribute>(name);

--- a/src/MooVC.Syntax.CSharp/Base.cs
+++ b/src/MooVC.Syntax.CSharp/Base.cs
@@ -56,10 +56,10 @@ namespace MooVC.Syntax.CSharp
         public bool IsUnspecified => this == Unspecified;
 
         /// <summary>
-        /// Defines the string operator for the Base.
+        /// Defines an implicit conversion from <see cref="Base" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="base">The base.</param>
-        /// <returns>The string.</returns>
+        /// <param name="@base">The <see cref="Base" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Base @base)
         {
             Guard.Against.Conversion<Base, string>(@base);
@@ -68,10 +68,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Base.
+        /// Defines an implicit conversion from <see cref="Base" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="base">The base.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="@base">The <see cref="Base" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Base @base)
         {
             Guard.Against.Conversion<Base, Snippet>(@base);
@@ -80,10 +80,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a moniker and qualifier into a base type reference.
+        /// Defines an implicit conversion from <see cref="Qualification" /> to <see cref="Base" />.
         /// </summary>
-        /// <param name="qualification">The tuple that provides the moniker and qualifier.</param>
-        /// <returns>The Base.</returns>
+        /// <param name="qualification">The <see cref="Qualification" /> value to convert.</param>
+        /// <returns>The converted <see cref="Base" /> value.</returns>
         public static implicit operator Base(Qualification qualification)
         {
             Guard.Against.Conversion<Qualification, Base>(qualification);
@@ -93,10 +93,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Symbol operator for the Base.
+        /// Defines an implicit conversion from <see cref="Symbol" /> to <see cref="Base" />.
         /// </summary>
-        /// <param name="symbol">The Symbol.</param>
-        /// <returns>The Base.</returns>
+        /// <param name="symbol">The <see cref="Symbol" /> value to convert.</param>
+        /// <returns>The converted <see cref="Base" /> value.</returns>
         public static implicit operator Base(Symbol symbol)
         {
             Guard.Against.Conversion<Symbol, Base>(symbol);
@@ -107,10 +107,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Base operator for the Base.
+        /// Defines an implicit conversion from <see cref="CType" /> to <see cref="Base" />.
         /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>The Base.</returns>
+        /// <param name="type">The <see cref="CType" /> value to convert.</param>
+        /// <returns>The converted <see cref="Base" /> value.</returns>
         public static implicit operator Base(CType type)
         {
             Guard.Against.Conversion<CType, Base>(type);
@@ -121,10 +121,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a moniker and qualifier into a base type reference.
+        /// Defines an implicit conversion to <see cref="Base" />.
         /// </summary>
-        /// <param name="name">The tuple that provides the moniker and qualifier.</param>
-        /// <returns>The base type reference.</returns>
+        /// <param name="name">The value to convert.</param>
+        /// <returns>The converted <see cref="Base" /> value.</returns>
         public static implicit operator Base((Moniker Name, Qualifier Qualifier) name)
         {
             Guard.Against.Conversion<(Moniker Name, Qualifier Qualifier), Base>(name);

--- a/src/MooVC.Syntax.CSharp/Constraint.cs
+++ b/src/MooVC.Syntax.CSharp/Constraint.cs
@@ -67,10 +67,10 @@ namespace MooVC.Syntax.CSharp
         public New New { get; internal set; } = New.NotRequired;
 
         /// <summary>
-        /// Defines the string operator for the Constraint.
+        /// Defines an implicit conversion from <see cref="Constraint" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="constraint">The constraint.</param>
-        /// <returns>The string.</returns>
+        /// <param name="constraint">The <see cref="Constraint" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Constraint constraint)
         {
             Guard.Against.Conversion<Constraint, string>(constraint);
@@ -79,10 +79,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Constraint.
+        /// Defines an implicit conversion from <see cref="Constraint" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="constraint">The constraint.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="constraint">The <see cref="Constraint" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Constraint constraint)
         {
             Guard.Against.Conversion<Constraint, Snippet>(constraint);

--- a/src/MooVC.Syntax.CSharp/Constructor.cs
+++ b/src/MooVC.Syntax.CSharp/Constructor.cs
@@ -77,10 +77,10 @@ namespace MooVC.Syntax.CSharp
         public Scopes Scope { get; internal set; } = Scopes.Public;
 
         /// <summary>
-        /// Defines the string operator for the Constructor.
+        /// Defines an implicit conversion from <see cref="Constructor" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="constructor">The constructor.</param>
-        /// <returns>The string.</returns>
+        /// <param name="constructor">The <see cref="Constructor" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Constructor constructor)
         {
             Guard.Against.Conversion<Constructor, string>(constructor);
@@ -89,10 +89,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Constructor.
+        /// Defines an implicit conversion from <see cref="Constructor" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="constructor">The constructor.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="constructor">The <see cref="Constructor" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Constructor constructor)
         {
             Guard.Against.Conversion<Constructor, Snippet>(constructor);

--- a/src/MooVC.Syntax.CSharp/Declaration.cs
+++ b/src/MooVC.Syntax.CSharp/Declaration.cs
@@ -57,10 +57,10 @@ namespace MooVC.Syntax.CSharp
         public Name Name { get; internal set; } = Name.Unnamed;
 
         /// <summary>
-        /// Defines the string operator for the Declaration.
+        /// Defines an implicit conversion from <see cref="Declaration" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="declaration">The declaration.</param>
-        /// <returns>The string.</returns>
+        /// <param name="declaration">The <see cref="Declaration" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Declaration declaration)
         {
             Guard.Against.Conversion<Declaration, string>(declaration);
@@ -69,10 +69,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Declaration.
+        /// Defines an implicit conversion from <see cref="Declaration" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="declaration">The declaration.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="declaration">The <see cref="Declaration" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Declaration declaration)
         {
             Guard.Against.Conversion<Declaration, Snippet>(declaration);
@@ -81,10 +81,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the string operator for the Declaration.
+        /// Defines an implicit conversion from <see cref="string" /> to <see cref="Declaration" />.
         /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>The declaration.</returns>
+        /// <param name="name">The <see cref="string" /> value to convert.</param>
+        /// <returns>The converted <see cref="Declaration" /> value.</returns>
         public static implicit operator Declaration(string name)
         {
             Guard.Against.Conversion<string, Declaration>(name);
@@ -94,10 +94,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Name operator for the Declaration.
+        /// Defines an implicit conversion from <see cref="Name" /> to <see cref="Declaration" />.
         /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>The declaration.</returns>
+        /// <param name="name">The <see cref="Name" /> value to convert.</param>
+        /// <returns>The converted <see cref="Declaration" /> value.</returns>
         public static implicit operator Declaration(Name name)
         {
             Guard.Against.Conversion<Name, Declaration>(name);

--- a/src/MooVC.Syntax.CSharp/Directive.cs
+++ b/src/MooVC.Syntax.CSharp/Directive.cs
@@ -68,10 +68,10 @@ namespace MooVC.Syntax.CSharp
         public Qualifier Qualifier { get; internal set; }
 
         /// <summary>
-        /// Defines the string operator for the Directive.
+        /// Defines an implicit conversion from <see cref="Directive" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="directive">The directive.</param>
-        /// <returns>The string.</returns>
+        /// <param name="directive">The <see cref="Directive" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Directive directive)
         {
             Guard.Against.Conversion<Directive, string>(directive);
@@ -80,10 +80,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Directive.
+        /// Defines an implicit conversion from <see cref="Directive" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="directive">The directive.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="directive">The <see cref="Directive" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Directive directive)
         {
             Guard.Against.Conversion<Directive, Snippet>(directive);
@@ -92,10 +92,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Qualifier operator for the Directive.
+        /// Defines an implicit conversion from <see cref="Qualifier" /> to <see cref="Directive" />.
         /// </summary>
-        /// <param name="qualifier">The qualifer.</param>
-        /// <returns>The directive.</returns>
+        /// <param name="qualifier">The <see cref="Qualifier" /> value to convert.</param>
+        /// <returns>The converted <see cref="Directive" /> value.</returns>
         public static implicit operator Directive(Qualifier qualifier)
         {
             Guard.Against.Conversion<Qualifier, Directive>(qualifier);

--- a/src/MooVC.Syntax.CSharp/Event.Methods.cs
+++ b/src/MooVC.Syntax.CSharp/Event.Methods.cs
@@ -52,10 +52,10 @@ namespace MooVC.Syntax.CSharp
             public Snippet Remove { get; internal set; } = Snippet.Empty;
 
             /// <summary>
-            /// Defines the string operator for the Methods.
+            /// Defines an implicit conversion from <see cref="Methods" /> to <see cref="string" />.
             /// </summary>
-            /// <param name="methods">The methods.</param>
-            /// <returns>The string.</returns>
+            /// <param name="methods">The <see cref="Methods" /> value to convert.</param>
+            /// <returns>The converted <see cref="string" /> value.</returns>
             public static implicit operator string(Methods methods)
             {
                 Guard.Against.Conversion<Methods, string>(methods);
@@ -64,10 +64,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines the Snippet operator for the Methods.
+            /// Defines an implicit conversion from <see cref="Methods" /> to <see cref="Snippet" />.
             /// </summary>
-            /// <param name="methods">The methods.</param>
-            /// <returns>The snippet.</returns>
+            /// <param name="methods">The <see cref="Methods" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet" /> value.</returns>
             public static implicit operator Snippet(Methods methods)
             {
                 Guard.Against.Conversion<Methods, Snippet>(methods);

--- a/src/MooVC.Syntax.CSharp/Event.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Event.Options.cs
@@ -80,10 +80,10 @@ namespace MooVC.Syntax.CSharp
                     .WithInline(Snippet.Options.Blocks.Styles.Lambda));
 
             /// <summary>
-            /// Converts event options into a scope value.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Scopes" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The implied scope.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Scopes" /> value.</returns>
             public static implicit operator Scopes(Options options)
             {
                 Guard.Against.Conversion<Options, Scopes>(options);
@@ -92,10 +92,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts event options into snippet options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The snippet options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Event.cs
+++ b/src/MooVC.Syntax.CSharp/Event.cs
@@ -75,10 +75,10 @@ namespace MooVC.Syntax.CSharp
         public Scopes Scope { get; internal set; } = Scopes.Public;
 
         /// <summary>
-        /// Defines the string operator for the Event.
+        /// Defines an implicit conversion from <see cref="Event" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="event">The event.</param>
-        /// <returns>The string.</returns>
+        /// <param name="@event">The <see cref="Event" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Event @event)
         {
             Guard.Against.Conversion<Event, string>(@event);
@@ -87,10 +87,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Event.
+        /// Defines an implicit conversion from <see cref="Event" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="event">The event.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="@event">The <see cref="Event" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Event @event)
         {
             Guard.Against.Conversion<Event, Snippet>(@event);

--- a/src/MooVC.Syntax.CSharp/Field.cs
+++ b/src/MooVC.Syntax.CSharp/Field.cs
@@ -91,10 +91,10 @@ namespace MooVC.Syntax.CSharp
         public Symbol Type { get; internal set; } = Symbol.Undefined;
 
         /// <summary>
-        /// Defines the string operator for the Field.
+        /// Defines an implicit conversion from <see cref="Field" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="field">The field.</param>
-        /// <returns>The string.</returns>
+        /// <param name="field">The <see cref="Field" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Field field)
         {
             Guard.Against.Conversion<Field, string>(field);
@@ -103,10 +103,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Field.
+        /// Defines an implicit conversion from <see cref="Field" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="field">The field.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="field">The <see cref="Field" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Field field)
         {
             Guard.Against.Conversion<Field, Snippet>(field);
@@ -115,10 +115,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a field name and type into a field declaration.
+        /// Defines an implicit conversion to <see cref="Field" />.
         /// </summary>
-        /// <param name="field">The tuple that provides the field name and type.</param>
-        /// <returns>The Field.</returns>
+        /// <param name="field">The value to convert.</param>
+        /// <returns>The converted <see cref="Field" /> value.</returns>
         public static implicit operator Field((Variable Name, Symbol Type) field)
         {
             Guard.Against.Conversion<(Variable Name, Symbol Type), Field>(field);

--- a/src/MooVC.Syntax.CSharp/Generic.cs
+++ b/src/MooVC.Syntax.CSharp/Generic.cs
@@ -61,10 +61,10 @@ namespace MooVC.Syntax.CSharp
         public bool IsUndefined => this == Undefined;
 
         /// <summary>
-        /// Defines the string operator for the Generic.
+        /// Defines an implicit conversion from <see cref="Generic" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="generic">The generic.</param>
-        /// <returns>The string.</returns>
+        /// <param name="generic">The <see cref="Generic" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Generic generic)
         {
             Guard.Against.Conversion<Generic, string>(generic);
@@ -73,10 +73,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Generic.
+        /// Defines an implicit conversion from <see cref="Generic" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="generic">The generic.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="generic">The <see cref="Generic" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Generic generic)
         {
             Guard.Against.Conversion<Generic, Snippet>(generic);

--- a/src/MooVC.Syntax.CSharp/Implementation.cs
+++ b/src/MooVC.Syntax.CSharp/Implementation.cs
@@ -57,10 +57,10 @@ namespace MooVC.Syntax.CSharp
         public bool IsUnspecified => this == Unspecified;
 
         /// <summary>
-        /// Defines the string operator for the Implementation.
+        /// Defines an implicit conversion from <see cref="Implementation" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="implementation">The base.</param>
-        /// <returns>The string.</returns>
+        /// <param name="implementation">The <see cref="Implementation" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Implementation implementation)
         {
             Guard.Against.Conversion<Implementation, string>(implementation);
@@ -69,10 +69,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Implementation.
+        /// Defines an implicit conversion from <see cref="Implementation" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="implementation">The base.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="implementation">The <see cref="Implementation" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Implementation implementation)
         {
             Guard.Against.Conversion<Implementation, Snippet>(implementation);
@@ -81,10 +81,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a moniker and qualifier into an implemented interface reference.
+        /// Defines an implicit conversion from <see cref="Qualification" /> to <see cref="Implementation" />.
         /// </summary>
-        /// <param name="qualification">The tuple that provides the moniker and qualifier.</param>
-        /// <returns>The Implementation.</returns>
+        /// <param name="qualification">The <see cref="Qualification" /> value to convert.</param>
+        /// <returns>The converted <see cref="Implementation" /> value.</returns>
         public static implicit operator Implementation(Qualification qualification)
         {
             Guard.Against.Conversion<Qualification, Implementation>(qualification);
@@ -94,10 +94,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Symbol operator for the Implementation.
+        /// Defines an implicit conversion from <see cref="Symbol" /> to <see cref="Implementation" />.
         /// </summary>
-        /// <param name="symbol">The Symbol.</param>
-        /// <returns>The Implementation.</returns>
+        /// <param name="symbol">The <see cref="Symbol" /> value to convert.</param>
+        /// <returns>The converted <see cref="Implementation" /> value.</returns>
         public static implicit operator Implementation(Symbol symbol)
         {
             Guard.Against.Conversion<Symbol, Implementation>(symbol);
@@ -108,10 +108,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Implementation operator for the Implementation.
+        /// Defines an implicit conversion from <see cref="Kind" /> to <see cref="Implementation" />.
         /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>The Implementation.</returns>
+        /// <param name="type">The <see cref="Kind" /> value to convert.</param>
+        /// <returns>The converted <see cref="Implementation" /> value.</returns>
         public static implicit operator Implementation(Kind type)
         {
             Guard.Against.Conversion<Kind, Implementation>(type);
@@ -122,10 +122,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a moniker and qualifier into an implemented interface reference.
+        /// Defines an implicit conversion to <see cref="Implementation" />.
         /// </summary>
-        /// <param name="name">The tuple that provides the moniker and qualifier.</param>
-        /// <returns>The implementation reference.</returns>
+        /// <param name="name">The value to convert.</param>
+        /// <returns>The converted <see cref="Implementation" /> value.</returns>
         public static implicit operator Implementation((Moniker Name, Qualifier Qualifier) name)
         {
             Guard.Against.Conversion<(Moniker Name, Qualifier Qualifier), Implementation>(name);

--- a/src/MooVC.Syntax.CSharp/Indexer.Methods.cs
+++ b/src/MooVC.Syntax.CSharp/Indexer.Methods.cs
@@ -52,10 +52,10 @@ namespace MooVC.Syntax.CSharp
             public Snippet Set { get; internal set; } = Snippet.Empty;
 
             /// <summary>
-            /// Defines the string operator for the Methods.
+            /// Defines an implicit conversion from <see cref="Methods" /> to <see cref="string" />.
             /// </summary>
-            /// <param name="methods">The methods.</param>
-            /// <returns>The string.</returns>
+            /// <param name="methods">The <see cref="Methods" /> value to convert.</param>
+            /// <returns>The converted <see cref="string" /> value.</returns>
             public static implicit operator string(Methods methods)
             {
                 Guard.Against.Conversion<Methods, string>(methods);
@@ -64,10 +64,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines the Snippet operator for the Methods.
+            /// Defines an implicit conversion from <see cref="Methods" /> to <see cref="Snippet" />.
             /// </summary>
-            /// <param name="methods">The methods.</param>
-            /// <returns>The snippet.</returns>
+            /// <param name="methods">The <see cref="Methods" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet" /> value.</returns>
             public static implicit operator Snippet(Methods methods)
             {
                 Guard.Against.Conversion<Methods, Snippet>(methods);

--- a/src/MooVC.Syntax.CSharp/Indexer.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Indexer.Options.cs
@@ -80,10 +80,10 @@ namespace MooVC.Syntax.CSharp
                     .WithInline(Snippet.Options.Blocks.Styles.Lambda));
 
             /// <summary>
-            /// Converts indexer options into scope options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Scopes" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The implied scope.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Scopes" /> value.</returns>
             public static implicit operator Scopes(Options options)
             {
                 Guard.Against.Conversion<Options, Scopes>(options);
@@ -92,10 +92,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts indexer options into snippet options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The snippet options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Indexer.cs
+++ b/src/MooVC.Syntax.CSharp/Indexer.cs
@@ -76,10 +76,10 @@ namespace MooVC.Syntax.CSharp
         public Scopes Scope { get; internal set; } = Scopes.Public;
 
         /// <summary>
-        /// Defines the string operator for the Indexer.
+        /// Defines an implicit conversion from <see cref="Indexer" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="indexer">The indexer.</param>
-        /// <returns>The string.</returns>
+        /// <param name="indexer">The <see cref="Indexer" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Indexer indexer)
         {
             Guard.Against.Conversion<Indexer, string>(indexer);
@@ -88,10 +88,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Indexer.
+        /// Defines an implicit conversion from <see cref="Indexer" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="indexer">The indexer.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="indexer">The <see cref="Indexer" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Indexer indexer)
         {
             Guard.Against.Conversion<Indexer, Snippet>(indexer);

--- a/src/MooVC.Syntax.CSharp/Method.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Method.Options.cs
@@ -93,10 +93,10 @@ namespace MooVC.Syntax.CSharp
             public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Unspecified;
 
             /// <summary>
-            /// Converts Method options into Attribute options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Attribute.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Attribute options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Attribute.Options" /> value.</returns>
             public static implicit operator Attribute.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Attribute.Options>(options);
@@ -122,10 +122,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts method options into scope options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Scopes" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The implied scope.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Scopes" /> value.</returns>
             public static implicit operator Scopes(Options options)
             {
                 Guard.Against.Conversion<Options, Scopes>(options);
@@ -134,10 +134,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts method options into snippet options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The snippet options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);
@@ -146,10 +146,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts method options into type options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Qualification.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The type options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Qualification.Options" /> value.</returns>
             public static implicit operator Qualification.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Qualification.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Method.cs
+++ b/src/MooVC.Syntax.CSharp/Method.cs
@@ -92,10 +92,10 @@ namespace MooVC.Syntax.CSharp
         public Scopes Scope { get; internal set; } = Scopes.Public;
 
         /// <summary>
-        /// Converts the method declaration to its C# source representation.
+        /// Defines an implicit conversion from <see cref="Method" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="method">The method declaration to render.</param>
-        /// <returns>The rendered C# source text.</returns>
+        /// <param name="method">The <see cref="Method" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Method method)
         {
             Guard.Against.Conversion<Method, string>(method);
@@ -104,10 +104,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the method declaration to a snippet for composition.
+        /// Defines an implicit conversion from <see cref="Method" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="method">The method declaration to convert.</param>
-        /// <returns>The snippet representing the method declaration.</returns>
+        /// <param name="method">The <see cref="Method" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Method method)
         {
             Guard.Against.Conversion<Method, Snippet>(method);

--- a/src/MooVC.Syntax.CSharp/Modifiers.cs
+++ b/src/MooVC.Syntax.CSharp/Modifiers.cs
@@ -51,10 +51,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the extensibility modifier to its C# source representation.
+        /// Defines an implicit conversion from <see cref="Modifiers" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="modifiers">The extensibility modifier to render.</param>
-        /// <returns>The modifier text.</returns>
+        /// <param name="modifiers">The <see cref="Modifiers" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Modifiers modifiers)
         {
             Guard.Against.Conversion<Modifiers, string>(modifiers);
@@ -63,10 +63,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the extensibility modifier to a snippet.
+        /// Defines an implicit conversion from <see cref="Modifiers" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="modifiers">The extensibility modifier to convert.</param>
-        /// <returns>The snippet containing the modifier.</returns>
+        /// <param name="modifiers">The <see cref="Modifiers" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Modifiers modifiers)
         {
             Guard.Against.Conversion<Modifiers, Snippet>(modifiers);

--- a/src/MooVC.Syntax.CSharp/Moniker.cs
+++ b/src/MooVC.Syntax.CSharp/Moniker.cs
@@ -38,10 +38,10 @@ namespace MooVC.Syntax.CSharp
         public bool IsUnnamed => this == Unnamed;
 
         /// <summary>
-        /// Defines the string operator for the Moniker.
+        /// Defines an implicit conversion from <see cref="Moniker" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="moniker">The moniker.</param>
-        /// <returns>The string.</returns>
+        /// <param name="moniker">The <see cref="Moniker" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Moniker moniker)
         {
             Guard.Against.Conversion<Moniker, string>(moniker);
@@ -50,10 +50,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Moniker.
+        /// Defines an implicit conversion from <see cref="Moniker" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="moniker">The moniker.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="moniker">The <see cref="Moniker" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Moniker moniker)
         {
             Guard.Against.Conversion<Moniker, Snippet>(moniker);
@@ -62,10 +62,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Name operator for the Moniker.
+        /// Defines an implicit conversion from <see cref="Name" /> to <see cref="Moniker" />.
         /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>The moniker.</returns>
+        /// <param name="name">The <see cref="Name" /> value to convert.</param>
+        /// <returns>The converted <see cref="Moniker" /> value.</returns>
         public static implicit operator Moniker(Name name)
         {
             Guard.Against.Conversion<Name, Moniker>(name);
@@ -74,10 +74,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Type operator for the Moniker.
+        /// Defines an implicit conversion from <see cref="CType" /> to <see cref="Moniker" />.
         /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>The moniker.</returns>
+        /// <param name="type">The <see cref="CType" /> value to convert.</param>
+        /// <returns>The converted <see cref="Moniker" /> value.</returns>
         public static implicit operator Moniker(CType type)
         {
             Guard.Against.Conversion<CType, Moniker>(type);

--- a/src/MooVC.Syntax.CSharp/Nature.cs
+++ b/src/MooVC.Syntax.CSharp/Nature.cs
@@ -49,10 +49,10 @@ namespace MooVC.Syntax.CSharp
         public bool IsUnspecified => this == Unspecified;
 
         /// <summary>
-        /// Defines the string operator for the Nature.
+        /// Defines an implicit conversion from <see cref="Natures" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="nature">The nature.</param>
-        /// <returns>The string.</returns>
+        /// <param name="nature">The <see cref="Natures" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Natures nature)
         {
             Guard.Against.Conversion<Natures, string>(nature);
@@ -61,10 +61,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Nature.
+        /// Defines an implicit conversion from <see cref="Natures" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="nature">The nature.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="nature">The <see cref="Natures" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Natures nature)
         {
             Guard.Against.Conversion<Natures, Snippet>(nature);

--- a/src/MooVC.Syntax.CSharp/New.cs
+++ b/src/MooVC.Syntax.CSharp/New.cs
@@ -40,10 +40,10 @@ namespace MooVC.Syntax.CSharp
         public bool IsNotRequired => this == NotRequired;
 
         /// <summary>
-        /// Defines the string operator for the New.
+        /// Defines an implicit conversion from <see cref="New" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="new">The new instance.</param>
-        /// <returns>The string.</returns>
+        /// <param name="@new">The <see cref="New" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(New @new)
         {
             Guard.Against.Conversion<New, string>(@new);
@@ -52,10 +52,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the New.
+        /// Defines an implicit conversion from <see cref="New" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="new">The new instance.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="@new">The <see cref="New" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(New @new)
         {
             Guard.Against.Conversion<New, Snippet>(@new);

--- a/src/MooVC.Syntax.CSharp/Options.cs
+++ b/src/MooVC.Syntax.CSharp/Options.cs
@@ -54,13 +54,10 @@
         public Type.Options Types { get; internal set; } = Type.Options.Default;
 
         /// <summary>
-        /// Converts the current options to namespace options.
+        /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Qualifier.Options" />.
         /// </summary>
-        /// <param name="options">The source options.</param>
-        /// <returns>The namespace options.</returns>
-        /// <remarks>
-        /// Conversion fails when <paramref name="options"/> is null.
-        /// </remarks>
+        /// <param name="options">The <see cref="Options" /> value to convert.</param>
+        /// <returns>The converted <see cref="Qualifier.Options" /> value.</returns>
         public static implicit operator Qualifier.Options(Options options)
         {
             Guard.Against.Conversion<Options, Qualifier.Options>(options);
@@ -69,13 +66,10 @@
         }
 
         /// <summary>
-        /// Converts type options into snippet options.
+        /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
         /// </summary>
-        /// <param name="options">The source options.</param>
-        /// <returns>The snippet options.</returns>
-        /// <remarks>
-        /// Conversion fails when <paramref name="options"/> is null.
-        /// </remarks>
+        /// <param name="options">The <see cref="Options" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
         public static implicit operator Snippet.Options(Options options)
         {
             Guard.Against.Conversion<Options, Snippet.Options>(options);
@@ -84,14 +78,10 @@
         }
 
         /// <summary>
-        /// Converts the current options to type options.
+        /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Type.Options" />.
         /// </summary>
-        /// <param name="options">The source options.</param>
-        /// <returns>The type options.</returns>
-        /// <remarks>
-        /// Conversion fails when <paramref name="options"/> is null. Missing snippet options in
-        /// <see cref="Types"/> are automatically populated from <see cref="Snippets"/>.
-        /// </remarks>
+        /// <param name="options">The <see cref="Options" /> value to convert.</param>
+        /// <returns>The converted <see cref="Type.Options" /> value.</returns>
         public static implicit operator Type.Options(Options options)
         {
             Guard.Against.Conversion<Options, Type.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Parameter.Modes.cs
+++ b/src/MooVC.Syntax.CSharp/Parameter.Modes.cs
@@ -111,10 +111,10 @@ namespace MooVC.Syntax.CSharp
             public bool IsThis => this == This;
 
             /// <summary>
-            /// Defines the string operator for the Mode.
+            /// Defines an implicit conversion from <see cref="Modes" /> to <see cref="string" />.
             /// </summary>
-            /// <param name="mode">The mode.</param>
-            /// <returns>The string.</returns>
+            /// <param name="mode">The <see cref="Modes" /> value to convert.</param>
+            /// <returns>The converted <see cref="string" /> value.</returns>
             public static implicit operator string(Modes mode)
             {
                 Guard.Against.Conversion<Modes, string>(mode);
@@ -123,10 +123,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines the Snippet operator for the Mode.
+            /// Defines an implicit conversion from <see cref="Modes" /> to <see cref="Snippet" />.
             /// </summary>
-            /// <param name="mode">The mode.</param>
-            /// <returns>The snippet.</returns>
+            /// <param name="mode">The <see cref="Modes" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet" /> value.</returns>
             public static implicit operator Snippet(Modes mode)
             {
                 Guard.Against.Conversion<Modes, Snippet>(mode);

--- a/src/MooVC.Syntax.CSharp/Parameter.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Parameter.Options.cs
@@ -62,10 +62,10 @@ namespace MooVC.Syntax.CSharp
             public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Unspecified;
 
             /// <summary>
-            /// Converts Parameter options into Attribute options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Attribute.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Attribute options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Attribute.Options" /> value.</returns>
             public static implicit operator Attribute.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Attribute.Options>(options);
@@ -82,10 +82,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts parameter options into symbol options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Qualification.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The symbol options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Qualification.Options" /> value.</returns>
             public static implicit operator Qualification.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Qualification.Options>(options);
@@ -94,10 +94,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts parameter options into snippet options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The snippet options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);
@@ -106,10 +106,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts parameter options into variable naming options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Variable.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The variable options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Variable.Options" /> value.</returns>
             public static implicit operator Variable.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Variable.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Parameter.cs
+++ b/src/MooVC.Syntax.CSharp/Parameter.cs
@@ -76,10 +76,10 @@ namespace MooVC.Syntax.CSharp
         public Symbol Type { get; internal set; } = Symbol.Undefined;
 
         /// <summary>
-        /// Converts the parameter declaration to its C# source representation.
+        /// Defines an implicit conversion from <see cref="Parameter" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="parameter">The parameter declaration to render.</param>
-        /// <returns>The rendered parameter text.</returns>
+        /// <param name="parameter">The <see cref="Parameter" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Parameter parameter)
         {
             Guard.Against.Conversion<Parameter, string>(parameter);
@@ -88,10 +88,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the parameter declaration to a snippet for composition.
+        /// Defines an implicit conversion from <see cref="Parameter" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="parameter">The parameter declaration to convert.</param>
-        /// <returns>The snippet representing the parameter declaration.</returns>
+        /// <param name="parameter">The <see cref="Parameter" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Parameter parameter)
         {
             Guard.Against.Conversion<Parameter, Snippet>(parameter);
@@ -100,10 +100,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a parameter name and type into a parameter declaration.
+        /// Defines an implicit conversion to <see cref="Parameter" />.
         /// </summary>
-        /// <param name="parameter">The tuple that provides the parameter name and type.</param>
-        /// <returns>The Parameter.</returns>
+        /// <param name="parameter">The value to convert.</param>
+        /// <returns>The converted <see cref="Parameter" /> value.</returns>
         public static implicit operator Parameter((Variable Name, Symbol Type) parameter)
         {
             Guard.Against.Conversion<(Variable Name, Symbol Type), Parameter>(parameter);

--- a/src/MooVC.Syntax.CSharp/Property.Methods.cs
+++ b/src/MooVC.Syntax.CSharp/Property.Methods.cs
@@ -52,10 +52,10 @@ namespace MooVC.Syntax.CSharp
             public Setter Set { get; internal set; } = Setter.Default;
 
             /// <summary>
-            /// Defines the string operator for the Methods.
+            /// Defines an implicit conversion from <see cref="Methods" /> to <see cref="string" />.
             /// </summary>
-            /// <param name="methods">The methods.</param>
-            /// <returns>The string.</returns>
+            /// <param name="methods">The <see cref="Methods" /> value to convert.</param>
+            /// <returns>The converted <see cref="string" /> value.</returns>
             public static implicit operator string(Methods methods)
             {
                 Guard.Against.Conversion<Methods, string>(methods);
@@ -64,10 +64,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Defines the Snippet operator for the Methods.
+            /// Defines an implicit conversion from <see cref="Methods" /> to <see cref="Snippet" />.
             /// </summary>
-            /// <param name="methods">The methods.</param>
-            /// <returns>The snippet.</returns>
+            /// <param name="methods">The <see cref="Methods" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet" /> value.</returns>
             public static implicit operator Snippet(Methods methods)
             {
                 Guard.Against.Conversion<Methods, Snippet>(methods);

--- a/src/MooVC.Syntax.CSharp/Property.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Property.Options.cs
@@ -95,10 +95,10 @@ namespace MooVC.Syntax.CSharp
                     .WithInline(Snippet.Options.Blocks.Styles.Lambda));
 
             /// <summary>
-            /// Converts Property options into Attribute options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Attribute.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Attribute options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Attribute.Options" /> value.</returns>
             public static implicit operator Attribute.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Attribute.Options>(options);
@@ -115,10 +115,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts property options into type options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Qualification.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The type options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Qualification.Options" /> value.</returns>
             public static implicit operator Qualification.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Qualification.Options>(options);
@@ -127,10 +127,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts property options into scope options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Scopes" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The implied scope.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Scopes" /> value.</returns>
             public static implicit operator Scopes(Options options)
             {
                 Guard.Against.Conversion<Options, Scopes>(options);
@@ -139,10 +139,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts property options into snippet options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The snippet options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Property.cs
+++ b/src/MooVC.Syntax.CSharp/Property.cs
@@ -91,10 +91,10 @@ namespace MooVC.Syntax.CSharp
         public Symbol Type { get; internal set; } = Symbol.Undefined;
 
         /// <summary>
-        /// Defines the string operator for the Property.
+        /// Defines an implicit conversion from <see cref="Property" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="property">The property.</param>
-        /// <returns>The string.</returns>
+        /// <param name="property">The <see cref="Property" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Property property)
         {
             Guard.Against.Conversion<Property, string>(property);
@@ -103,10 +103,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Property.
+        /// Defines an implicit conversion from <see cref="Property" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="property">The property.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="property">The <see cref="Property" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Property property)
         {
             Guard.Against.Conversion<Property, Snippet>(property);
@@ -115,10 +115,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a property name and type into a property declaration.
+        /// Defines an implicit conversion to <see cref="Property" />.
         /// </summary>
-        /// <param name="property">The tuple that provides the property name and type.</param>
-        /// <returns>The Property.</returns>
+        /// <param name="property">The value to convert.</param>
+        /// <returns>The converted <see cref="Property" /> value.</returns>
         public static implicit operator Property((Name Name, Symbol Type) property)
         {
             Guard.Against.Conversion<(Name Name, Symbol Type), Property>(property);

--- a/src/MooVC.Syntax.CSharp/Qualification.cs
+++ b/src/MooVC.Syntax.CSharp/Qualification.cs
@@ -53,10 +53,10 @@ namespace MooVC.Syntax.CSharp
         public Qualifier Qualifier { get; internal set; } = Qualifier.Unqualified;
 
         /// <summary>
-        /// Defines the string operator for the Name.
+        /// Defines an implicit conversion from <see cref="Qualification" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="symbol">The symbol.</param>
-        /// <returns>The string.</returns>
+        /// <param name="symbol">The <see cref="Qualification" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Qualification symbol)
         {
             Guard.Against.Conversion<Qualification, string>(symbol);
@@ -65,10 +65,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Name.
+        /// Defines an implicit conversion from <see cref="Qualification" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="symbol">The symbol.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="symbol">The <see cref="Qualification" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Qualification symbol)
         {
             Guard.Against.Conversion<Qualification, Snippet>(symbol);
@@ -77,10 +77,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Name operator for the moniker.
+        /// Defines an implicit conversion from <see cref="string" /> to <see cref="Qualification" />.
         /// </summary>
-        /// <param name="moniker">The moniker.</param>
-        /// <returns>The qualification.</returns>
+        /// <param name="moniker">The <see cref="string" /> value to convert.</param>
+        /// <returns>The converted <see cref="Qualification" /> value.</returns>
         public static implicit operator Qualification(string moniker)
         {
             Guard.Against.Conversion<string, Qualification>(moniker);
@@ -90,10 +90,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Name operator for the moniker.
+        /// Defines an implicit conversion from <see cref="Moniker" /> to <see cref="Qualification" />.
         /// </summary>
-        /// <param name="moniker">The moniker.</param>
-        /// <returns>The qualification.</returns>
+        /// <param name="moniker">The <see cref="Moniker" /> value to convert.</param>
+        /// <returns>The converted <see cref="Qualification" /> value.</returns>
         public static implicit operator Qualification(Moniker moniker)
         {
             Guard.Against.Conversion<Moniker, Qualification>(moniker);
@@ -103,10 +103,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Name operator for the Name.
+        /// Defines an implicit conversion from <see cref="Kind" /> to <see cref="Qualification" />.
         /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>The symbol.</returns>
+        /// <param name="type">The <see cref="Kind" /> value to convert.</param>
+        /// <returns>The converted <see cref="Qualification" /> value.</returns>
         public static implicit operator Qualification(Kind type)
         {
             Guard.Against.Conversion<Kind, Qualification>(type);
@@ -117,10 +117,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a moniker and qualifier into a qualified name.
+        /// Defines an implicit conversion to <see cref="Qualification" />.
         /// </summary>
-        /// <param name="name">The tuple that provides the moniker and qualifier.</param>
-        /// <returns>The Name.</returns>
+        /// <param name="name">The value to convert.</param>
+        /// <returns>The converted <see cref="Qualification" /> value.</returns>
         public static implicit operator Qualification((Moniker Moniker, Qualifier Qualifier) name)
         {
             Guard.Against.Conversion<(Moniker Moniker, Qualifier Qualifier), Qualification>(name);

--- a/src/MooVC.Syntax.CSharp/Result.cs
+++ b/src/MooVC.Syntax.CSharp/Result.cs
@@ -89,10 +89,10 @@ namespace MooVC.Syntax.CSharp
         public Symbol Type { get; internal set; } = Symbol.Undefined;
 
         /// <summary>
-        /// Converts the return signature to its C# source representation, including modifiers and type.
+        /// Defines an implicit conversion from <see cref="Result" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="result">The result.</param>
-        /// <returns>The C# return signature text.</returns>
+        /// <param name="result">The <see cref="Result" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Result result)
         {
             Guard.Against.Conversion<Result, string>(result);
@@ -101,10 +101,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the return signature to a snippet for composing a method signature.
+        /// Defines an implicit conversion from <see cref="Result" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="result">The result.</param>
-        /// <returns>The return signature snippet.</returns>
+        /// <param name="result">The <see cref="Result" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Result result)
         {
             Guard.Against.Conversion<Result, Snippet>(result);
@@ -113,10 +113,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Creates a return signature from the specified runtime type, using the type name as the return symbol.
+        /// Defines an implicit conversion from <see cref="CType" /> to <see cref="Result" />.
         /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>The return signature.</returns>
+        /// <param name="type">The <see cref="CType" /> value to convert.</param>
+        /// <returns>The converted <see cref="Result" /> value.</returns>
         public static implicit operator Result(CType type)
         {
             Guard.Against.Conversion<CType, Result>(type);

--- a/src/MooVC.Syntax.CSharp/Scopes.cs
+++ b/src/MooVC.Syntax.CSharp/Scopes.cs
@@ -51,10 +51,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the accessibility scope to its C# source representation.
+        /// Defines an implicit conversion from <see cref="Scopes" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="scope">The scope to render.</param>
-        /// <returns>The accessibility modifier text.</returns>
+        /// <param name="scope">The <see cref="Scopes" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Scopes scope)
         {
             Guard.Against.Conversion<Scopes, string>(scope);
@@ -63,10 +63,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the accessibility scope to a snippet.
+        /// Defines an implicit conversion from <see cref="Scopes" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="scope">The scope to convert.</param>
-        /// <returns>The snippet containing the accessibility modifier.</returns>
+        /// <param name="scope">The <see cref="Scopes" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Scopes scope)
         {
             Guard.Against.Conversion<Scopes, Snippet>(scope);

--- a/src/MooVC.Syntax.CSharp/Symbol.cs
+++ b/src/MooVC.Syntax.CSharp/Symbol.cs
@@ -69,10 +69,10 @@ namespace MooVC.Syntax.CSharp
         public Qualification Name { get; internal set; } = Qualification.Unnamed;
 
         /// <summary>
-        /// Defines the string operator for the Symbol.
+        /// Defines an implicit conversion from <see cref="Symbol" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="symbol">The symbol.</param>
-        /// <returns>The string.</returns>
+        /// <param name="symbol">The <see cref="Symbol" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Symbol symbol)
         {
             Guard.Against.Conversion<Symbol, string>(symbol);
@@ -81,10 +81,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Symbol.
+        /// Defines an implicit conversion from <see cref="Symbol" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="symbol">The symbol.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="symbol">The <see cref="Symbol" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Symbol symbol)
         {
             Guard.Against.Conversion<Symbol, Snippet>(symbol);
@@ -93,10 +93,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Symbol operator for the Symbol.
+        /// Defines an implicit conversion from <see cref="CType" /> to <see cref="Symbol" />.
         /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>The symbol.</returns>
+        /// <param name="type">The <see cref="CType" /> value to convert.</param>
+        /// <returns>The converted <see cref="Symbol" /> value.</returns>
         public static implicit operator Symbol(CType type)
         {
             Guard.Against.Conversion<CType, Symbol>(type);
@@ -108,10 +108,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Implicitly converts a QualifiedName to a Symbol instance.
+        /// Defines an implicit conversion from <see cref="Qualification" /> to <see cref="Symbol" />.
         /// </summary>
-        /// <param name="name">The qualified name to convert. Cannot be <see langword="null" />.</param>
-        /// <returns>The Symbol.</returns>
+        /// <param name="name">The <see cref="Qualification" /> value to convert.</param>
+        /// <returns>The converted <see cref="Symbol" /> value.</returns>
         public static implicit operator Symbol(Qualification name)
         {
             Guard.Against.Conversion<Qualification, Symbol>(name);
@@ -121,10 +121,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a tuple containing a moniker and qualifier into a symbol.
+        /// Defines an implicit conversion to <see cref="Symbol" />.
         /// </summary>
-        /// <param name="name">The tuple that provides the moniker and qualifier.</param>
-        /// <returns>The symbol.</returns>
+        /// <param name="name">The value to convert.</param>
+        /// <returns>The converted <see cref="Symbol" /> value.</returns>
         public static implicit operator Symbol((Moniker Name, Qualifier Qualifier) name)
         {
             Guard.Against.Conversion<(Moniker Name, Qualifier Qualifier), Symbol>(name);

--- a/src/MooVC.Syntax.CSharp/Token.cs
+++ b/src/MooVC.Syntax.CSharp/Token.cs
@@ -43,9 +43,10 @@ namespace MooVC.Syntax.CSharp
         public Symbol Symbol { get; private set; } = Symbol.Undefined;
 
         /// <summary>
-        /// Converts the <see cref="Token" /> instance into its string representation.
+        /// Defines an implicit conversion from <see cref="Token" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="token">The token to convert. Cannot be <see langword="null" />.</param>
+        /// <param name="token">The <see cref="Token" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Token token)
         {
             Guard.Against.Conversion<Token, string>(token);
@@ -54,9 +55,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts the <see cref="Token" /> instance into a <see cref="Snippet" />.
+        /// Defines an implicit conversion from <see cref="Token" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="token">The token to convert. Cannot be <see langword="null" />.</param>
+        /// <param name="token">The <see cref="Token" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Token token)
         {
             Guard.Against.Conversion<Token, Snippet>(token);
@@ -65,9 +67,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a <see cref="Name" /> into a <see cref="Token" />.
+        /// Defines an implicit conversion from <see cref="Name" /> to <see cref="Token" />.
         /// </summary>
-        /// <param name="name">The name to convert. <see langword="null" /> or unnamed values return <see cref="Unspecified" />.</param>
+        /// <param name="name">The <see cref="Name" /> value to convert.</param>
+        /// <returns>The converted <see cref="Token" /> value.</returns>
         public static implicit operator Token(Name name)
         {
             if (name is null || name.IsUnnamed)
@@ -79,9 +82,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a <see cref="Symbol" /> into a <see cref="Token" />.
+        /// Defines an implicit conversion from <see cref="Symbol" /> to <see cref="Token" />.
         /// </summary>
-        /// <param name="symbol">The symbol to convert. <see langword="null" /> or undefined values return <see cref="Unspecified" />.</param>
+        /// <param name="symbol">The <see cref="Symbol" /> value to convert.</param>
+        /// <returns>The converted <see cref="Token" /> value.</returns>
         public static implicit operator Token(Symbol symbol)
         {
             if (symbol is null || symbol.IsUndefined)
@@ -93,9 +97,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Converts a <see cref="CType" /> into a <see cref="Token" />.
+        /// Defines an implicit conversion from <see cref="CType" /> to <see cref="Token" />.
         /// </summary>
-        /// <param name="type">The CLR type to convert. Cannot be <see langword="null" />.</param>
+        /// <param name="type">The <see cref="CType" /> value to convert.</param>
+        /// <returns>The converted <see cref="Token" /> value.</returns>
         public static implicit operator Token(CType type)
         {
             Guard.Against.Conversion<CType, Token>(type);

--- a/src/MooVC.Syntax.CSharp/Type.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Type.Options.cs
@@ -74,10 +74,10 @@ namespace MooVC.Syntax.CSharp
             public Snippet.Options Snippets { get; internal set; } = Snippet.Options.Unspecified;
 
             /// <summary>
-            /// Converts type options into Attribute options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Attribute.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Attribute options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Attribute.Options" /> value.</returns>
             public static implicit operator Attribute.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Attribute.Options>(options);
@@ -94,10 +94,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts type options into Event options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Event.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Event options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Event.Options" /> value.</returns>
             public static implicit operator Event.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Event.Options>(options);
@@ -106,10 +106,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts type options into Indexer options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Indexer.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Indexer options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Indexer.Options" /> value.</returns>
             public static implicit operator Indexer.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Indexer.Options>(options);
@@ -121,10 +121,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts type options into Method options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Method.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Method options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Method.Options" /> value.</returns>
             public static implicit operator Method.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Method.Options>(options);
@@ -135,10 +135,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts type options into Property options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Property.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The Property options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Property.Options" /> value.</returns>
             public static implicit operator Property.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Property.Options>(options);
@@ -155,10 +155,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts type options into symbol options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Qualification.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The symbol options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Qualification.Options" /> value.</returns>
             public static implicit operator Qualification.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Qualification.Options>(options);
@@ -167,10 +167,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts type options into snippet options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Snippet.Options" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The snippet options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Snippet.Options" /> value.</returns>
             public static implicit operator Snippet.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Snippet.Options>(options);

--- a/src/MooVC.Syntax.CSharp/Variable.Options.cs
+++ b/src/MooVC.Syntax.CSharp/Variable.Options.cs
@@ -56,15 +56,10 @@ namespace MooVC.Syntax.CSharp
             public bool UseUnderscore { get; internal set; }
 
             /// <summary>
-            /// Defines the Identifier.Options operator for the Options.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Identifier.Options" />.
             /// </summary>
-            /// <param name="options">The options.</param>
-            /// <returns>The identifier options.</returns>
-            /// <summary>
-            /// Converts variable options into identifier options.
-            /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The identifier options.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Identifier.Options" /> value.</returns>
             public static implicit operator Identifier.Options(Options options)
             {
                 Guard.Against.Conversion<Options, Identifier.Options>(options);
@@ -74,10 +69,10 @@ namespace MooVC.Syntax.CSharp
             }
 
             /// <summary>
-            /// Converts variable options into identifier casing.
+            /// Defines an implicit conversion from <see cref="Options" /> to <see cref="Identifier.Casing" />.
             /// </summary>
-            /// <param name="options">The source options.</param>
-            /// <returns>The identifier casing.</returns>
+            /// <param name="options">The <see cref="Options" /> value to convert.</param>
+            /// <returns>The converted <see cref="Identifier.Casing" /> value.</returns>
             public static implicit operator Identifier.Casing(Options options)
             {
                 Guard.Against.Conversion<Options, Identifier.Casing>(options);

--- a/src/MooVC.Syntax.CSharp/Variable.cs
+++ b/src/MooVC.Syntax.CSharp/Variable.cs
@@ -42,10 +42,10 @@ namespace MooVC.Syntax.CSharp
         public bool IsUnnamed => this == Unnamed;
 
         /// <summary>
-        /// Defines the string operator for the Variable.
+        /// Defines an implicit conversion from <see cref="Variable" /> to <see cref="string" />.
         /// </summary>
-        /// <param name="variable">The variable.</param>
-        /// <returns>The string.</returns>
+        /// <param name="variable">The <see cref="Variable" /> value to convert.</param>
+        /// <returns>The converted <see cref="string" /> value.</returns>
         public static implicit operator string(Variable variable)
         {
             Guard.Against.Conversion<Variable, string>(variable);
@@ -54,10 +54,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Snippet operator for the Variable.
+        /// Defines an implicit conversion from <see cref="Variable" /> to <see cref="Snippet" />.
         /// </summary>
-        /// <param name="variable">The variable.</param>
-        /// <returns>The snippet.</returns>
+        /// <param name="variable">The <see cref="Variable" /> value to convert.</param>
+        /// <returns>The converted <see cref="Snippet" /> value.</returns>
         public static implicit operator Snippet(Variable variable)
         {
             Guard.Against.Conversion<Variable, Snippet>(variable);
@@ -66,10 +66,10 @@ namespace MooVC.Syntax.CSharp
         }
 
         /// <summary>
-        /// Defines the Name operator for the Variable.
+        /// Defines an implicit conversion from <see cref="Name" /> to <see cref="Variable" />.
         /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>The variable.</returns>
+        /// <param name="name">The <see cref="Name" /> value to convert.</param>
+        /// <returns>The converted <see cref="Variable" /> value.</returns>
         public static implicit operator Variable(Name name)
         {
             Guard.Against.Conversion<Name, Variable>(name);


### PR DESCRIPTION
### Motivation
- XML documentation for many implicit conversion operators referenced types as plain text instead of using metadata `<see cref="..." />` tags, which reduces IDE/linking support and analyzer friendliness. 
- Standardizing these comments improves tooling, documentation generation, and compliance with project documentation conventions.

### Description
- Rewrote XML doc comments for implicit conversion operators across `src/MooVC.Syntax.CSharp` to use `<see cref="..." />` metadata tags in summaries, `<param>` and `<returns>` elements and to normalize wording describing source/target types. 
- Applied consistent phrasing such as "Defines an implicit conversion from <see cref=\"X\" /> to <see cref=\"Y\" />." and similar for single-direction and tuple conversions. 
- Changes are documentation-only and do not modify runtime logic or public APIs. 
- A scripted update was used to apply these edits across multiple files (42 files modified).

### Testing
- Ran a Python script to locate and update implicit conversion XML comments and it modified 42 files as part of the automated update. 
- Performed repository-wide greps/manual sampling to verify implicit operator docblocks now use `<see cref="..." />` tags. 
- Attempted to run `dotnet test` but the command could not be executed in this environment because the `dotnet` SDK is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9d694234832fa06906278c9d65da)