### PR TITLE
Add unit tests for equality, conversions and hashing for value-like types

### DIFF
--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualityOperatorModifiersModifiersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualityOperatorModifiersModifiersIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenEqualityOperatorModifiersModifiersIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modifiers left = Result.Modifiers.Ref;
+        Result.Modifiers right = Result.Modifiers.Ref;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualityOperatorModifiersStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualityOperatorModifiersStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenEqualityOperatorModifiersStringIsCalled
+{
+    [Test]
+    public async Task GivenEqualValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modifiers subject = Result.Modifiers.RefReadOnly;
+
+        // Act
+        bool result = subject == "ref readonly";
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualsModifiersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualsModifiersIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenEqualsModifiersIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Result.Modifiers subject = Result.Modifiers.Ref;
+        Result.Modifiers other = Result.Modifiers.Unsafe;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentObjectThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modifiers subject = Result.Modifiers.Unsafe;
+        object other = Result.Modifiers.Unsafe;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualsStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenEqualsStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenEqualsStringIsCalled
+{
+    [Test]
+    public async Task GivenEqualStringThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modifiers subject = Result.Modifiers.Ref;
+
+        // Act
+        bool result = subject.Equals("ref");
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        Result.Modifiers first = Result.Modifiers.Ref;
+        Result.Modifiers second = Result.Modifiers.Ref;
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(firstHash).IsEqualTo(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenImplicitOperatorFromStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenImplicitOperatorFromStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenImplicitOperatorFromStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsModifiers()
+    {
+        // Arrange
+        const string value = "ref readonly";
+
+        // Act
+        Result.Modifiers subject = value;
+
+        // Assert
+        _ = await Assert.That(subject == value).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsString()
+    {
+        // Arrange
+        Result.Modifiers subject = Result.Modifiers.Unsafe;
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("unsafe");
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenInequalityOperatorModifiersModifiersIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenInequalityOperatorModifiersModifiersIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenInequalityOperatorModifiersModifiersIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modifiers left = Result.Modifiers.Ref;
+        Result.Modifiers right = Result.Modifiers.Unsafe;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenInequalityOperatorModifiersStringIsCalled.cs
+++ b/src/MooVC.Syntax.CSharp.Tests/ResultTests/ModifiersTests/WhenInequalityOperatorModifiersStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.CSharp.ResultTests.ModifiersTests;
+
+public sealed class WhenInequalityOperatorModifiersStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValueThenReturnsTrue()
+    {
+        // Arrange
+        Result.Modifiers subject = Result.Modifiers.Ref;
+
+        // Act
+        bool result = subject != "unsafe";
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualityOperatorCasingCasingIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualityOperatorCasingCasingIsCalled.cs
@@ -1,0 +1,46 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenEqualityOperatorCasingCasingIsCalled
+{
+    [Test]
+    public async Task GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Identifier.Casing? left = default;
+        Identifier.Casing? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Identifier.Casing left = "Pascal";
+        Identifier.Casing right = "Camel";
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Identifier.Casing left = "Pascal";
+        Identifier.Casing right = "Pascal";
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualityOperatorCasingStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualityOperatorCasingStringIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenEqualityOperatorCasingStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+
+        // Act
+        bool result = subject == "Snake";
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string casing = "Pascal";
+        Identifier.Casing subject = casing;
+
+        // Act
+        bool result = subject == casing;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualsCasingIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualsCasingIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenEqualsCasingIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+        Identifier.Casing other = "Camel";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+        Identifier.Casing other = "Pascal";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+
+        // Act
+        bool result = subject.Equals(3);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEquivalentCasingThenReturnsTrue()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+        object other = (Identifier.Casing)"Pascal";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualsStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenEqualsStringIsCalled.cs
@@ -1,0 +1,30 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenEqualsStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentStringThenReturnsFalse()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+
+        // Act
+        bool result = subject.Equals("Camel");
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualStringThenReturnsTrue()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+
+        // Act
+        bool result = subject.Equals("Pascal");
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,34 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenHashesDiffer()
+    {
+        // Arrange
+        Identifier.Casing first = "Pascal";
+        Identifier.Casing second = "Camel";
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(firstHash).IsNotEqualTo(secondHash);
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        Identifier.Casing first = "Pascal";
+        Identifier.Casing second = "Pascal";
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(firstHash).IsEqualTo(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsString()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Pascal");
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenInequalityOperatorCasingCasingIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenInequalityOperatorCasingCasingIsCalled.cs
@@ -1,0 +1,46 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenInequalityOperatorCasingCasingIsCalled
+{
+    [Test]
+    public async Task GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Identifier.Casing? left = default;
+        Identifier.Casing? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Identifier.Casing left = "Pascal";
+        Identifier.Casing right = "Camel";
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        Identifier.Casing left = "Pascal";
+        Identifier.Casing right = "Pascal";
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenInequalityOperatorCasingStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/IdentifierTests/CasingTests/WhenInequalityOperatorCasingStringIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.IdentifierTests.CasingTests;
+
+public sealed class WhenInequalityOperatorCasingStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Identifier.Casing subject = "Pascal";
+
+        // Act
+        bool result = subject != "Snake";
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        const string casing = "Pascal";
+        Identifier.Casing subject = casing;
+
+        // Act
+        bool result = subject != casing;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualityOperatorOptionsOptionsIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenEqualityOperatorOptionsOptionsIsCalled
+{
+    [Test]
+    public async Task GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier.Options? left = default;
+        Qualifier.Options? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        Qualifier.Options left = "Block";
+        Qualifier.Options right = "File";
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualityOperatorOptionsStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualityOperatorOptionsStringIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenEqualityOperatorOptionsStringIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string option = "Block";
+        Qualifier.Options subject = option;
+
+        // Act
+        bool result = subject == option;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenEquivalentOptionThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier.Options subject = "Block";
+        object other = (Qualifier.Options)"Block";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualsOptionsIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenEqualsOptionsIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier.Options subject = "Block";
+        Qualifier.Options other = "Block";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualsStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenEqualsStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenEqualsStringIsCalled
+{
+    [Test]
+    public async Task GivenEqualStringThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier.Options subject = "Block";
+
+        // Act
+        bool result = subject.Equals("Block");
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        Qualifier.Options first = "File";
+        Qualifier.Options second = "File";
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(firstHash).IsEqualTo(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsString()
+    {
+        // Arrange
+        Qualifier.Options subject = "File";
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("File");
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenInequalityOperatorOptionsOptionsIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenInequalityOperatorOptionsOptionsIsCalled
+{
+    [Test]
+    public async Task GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Qualifier.Options? left = default;
+        Qualifier.Options? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier.Options left = "Block";
+        Qualifier.Options right = "File";
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenInequalityOperatorOptionsStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenInequalityOperatorOptionsStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenInequalityOperatorOptionsStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        Qualifier.Options subject = "Block";
+
+        // Act
+        bool result = subject != "File";
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/QualifierTests/OptionsTests/WhenToStringIsCalled.cs
@@ -1,0 +1,17 @@
+namespace MooVC.Syntax.QualifierTests.OptionsTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsString()
+    {
+        // Arrange
+        Qualifier.Options subject = "Block";
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo("Block");
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualityOperatorPathPathIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualityOperatorPathPathIsCalled.cs
@@ -1,0 +1,47 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenEqualityOperatorPathPathIsCalled
+{
+    [Test]
+    public async Task GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Folder.Path? left = default;
+        Folder.Path? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Folder.Path("/Folder/");
+        var right = new Folder.Path("/Other/");
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var left = new Folder.Path(path);
+        var right = new Folder.Path(path);
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualityOperatorPathStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualityOperatorPathStringIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenEqualityOperatorPathStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+        const string other = "/Other/";
+
+        // Act
+        bool result = subject == other;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var subject = new Folder.Path(path);
+
+        // Act
+        bool result = subject == path;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,45 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenDifferentTypeThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+
+        // Act
+        bool result = subject.Equals("/Other/");
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+
+        // Act
+        bool result = subject.Equals(default(object));
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenPathWithSameValueThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var subject = new Folder.Path(path);
+        object other = new Folder.Path(path);
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualsPathIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualsPathIsCalled.cs
@@ -1,0 +1,47 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenEqualsPathIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+        var other = new Folder.Path("/Other/");
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var subject = new Folder.Path(path);
+        var other = new Folder.Path(path);
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+        Folder.Path? other = default;
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualsStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenEqualsStringIsCalled.cs
@@ -1,0 +1,44 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenEqualsStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValueThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+
+        // Act
+        bool result = subject.Equals("/Other/");
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValueThenReturnsTrue()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var subject = new Folder.Path(path);
+
+        // Act
+        bool result = subject.Equals(path);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenNullThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+
+        // Act
+        bool result = subject.Equals(default(string));
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,35 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenHashesDiffer()
+    {
+        // Arrange
+        var first = new Folder.Path("/Folder/");
+        var second = new Folder.Path("/Other/");
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(firstHash).IsNotEqualTo(secondHash);
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenHashesMatch()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var first = new Folder.Path(path);
+        var second = new Folder.Path(path);
+
+        // Act
+        int firstHash = first.GetHashCode();
+        int secondHash = second.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(firstHash).IsEqualTo(secondHash);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenImplicitOperatorToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenImplicitOperatorToStringIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenImplicitOperatorToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsValue()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var subject = new Folder.Path(path);
+
+        // Act
+        string result = subject;
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo(path);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenInequalityOperatorPathPathIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenInequalityOperatorPathPathIsCalled.cs
@@ -1,0 +1,47 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenInequalityOperatorPathPathIsCalled
+{
+    [Test]
+    public async Task GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Folder.Path? left = default;
+        Folder.Path? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Folder.Path("/Folder/");
+        var right = new Folder.Path("/Other/");
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var left = new Folder.Path(path);
+        var right = new Folder.Path(path);
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenInequalityOperatorPathStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenInequalityOperatorPathStringIsCalled.cs
@@ -1,0 +1,32 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenInequalityOperatorPathStringIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Folder.Path("/Folder/");
+        const string other = "/Other/";
+
+        // Act
+        bool result = subject != other;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var subject = new Folder.Path(path);
+
+        // Act
+        bool result = subject != path;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FolderTests/PathTests/WhenToStringIsCalled.cs
@@ -1,0 +1,18 @@
+namespace MooVC.Syntax.Solution.FolderTests.PathTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenValueThenReturnsValue()
+    {
+        // Arrange
+        const string path = "/Folder/";
+        var subject = new Folder.Path(path);
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo(path);
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve coverage for value-like types to ensure equality semantics, implicit conversions and string representations behave as expected.
- Verify operator overloads, `Equals` implementations and `GetHashCode` produce consistent results for `Identifier.Casing`, `Qualifier.Options`, `Folder.Path` and `Result.Modifiers`.

### Description

- Added a suite of NUnit-style tests under the test projects for `Identifier.Casing`, `Qualifier.Options`, `Folder.Path` and `Result.Modifiers` that exercise equality and inequality operators between same-type instances and against `string` values.
- Added tests for `Equals(object)`, `Equals(string)`, `GetHashCode`, `ToString`, and implicit conversion operators where applicable to ensure round-trip and consistency behavior.
- Tests were added across namespaces `MooVC.Syntax.IdentifierTests.CasingTests`, `MooVC.Syntax.QualifierTests.OptionsTests`, `MooVC.Syntax.Solution.FolderTests.PathTests`, and `MooVC.Syntax.CSharp.ResultTests.ModifiersTests` as new files in the test project tree.
- Tests use asynchronous `Task` signatures and the project assertion helper (`Assert.That(...)`) to validate expected outcomes.

### Testing

- No automated test run results are included in the rollout transcript, so no pass/fail status is available from this change set.
- The new files are test-only additions and should be exercised by running the project's unit test suite (for example via `dotnet test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf4cd9944832fbe807cc6326d960b)