### PR TITLE
Add unit tests for Solution types (Build, Configurations, File, Project.Name, Project.RelativePath)

### DIFF
--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenToFragmentsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenToFragmentsIsCalled.cs
@@ -1,0 +1,31 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+public sealed class WhenToFragmentsIsCalled
+{
+    [Test]
+    public async Task GivenUndefinedThenReturnsEmptyCollection()
+    {
+        // Arrange
+        var subject = new Build();
+
+        // Act
+        var result = subject.ToFragments();
+
+        // Assert
+        _ = await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    public async Task GivenDefinedValuesThenReturnsBuildFragment()
+    {
+        // Arrange
+        Build subject = BuildTestsData.Create();
+
+        // Act
+        var result = subject.ToFragments();
+
+        // Assert
+        _ = await Assert.That(result).HasSingleItem();
+        _ = await Assert.That(result[0].Name.LocalName).IsEqualTo(nameof(Build));
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenValidateIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/BuildTests/WhenValidateIsCalled.cs
@@ -1,0 +1,40 @@
+namespace MooVC.Syntax.Solution.BuildTests;
+
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+public sealed class WhenValidateIsCalled
+{
+    [Test]
+    public async Task GivenUndefinedThenReturnsNoValidationResults()
+    {
+        // Arrange
+        var subject = new Build();
+        var validationContext = new ValidationContext(subject);
+
+        // Act
+        var results = subject.Validate(validationContext).ToArray();
+
+        // Assert
+        _ = await Assert.That(results).IsEmpty();
+    }
+
+    [Test]
+    public async Task GivenMultiLineProjectOrSolutionThenReturnsValidationResults()
+    {
+        // Arrange
+        var subject = new Build
+        {
+            Project = Snippet.From("Debug", "AnyCPU"),
+            Solution = Snippet.From("Debug", "Any CPU"),
+        };
+
+        var validationContext = new ValidationContext(subject);
+
+        // Act
+        var results = subject.Validate(validationContext).ToArray();
+
+        // Assert
+        _ = await Assert.That(results).IsNotEmpty();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenEqualsConfigurationsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenEqualsConfigurationsIsCalled.cs
@@ -1,0 +1,50 @@
+namespace MooVC.Syntax.Solution.ConfigurationsTests;
+
+public sealed class WhenEqualsConfigurationsIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        var right = new Configurations
+        {
+            Builds = [Configurations.BuildType.Release],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        var right = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        bool result = left.Equals(right);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenEqualsObjectIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenEqualsObjectIsCalled.cs
@@ -1,0 +1,64 @@
+namespace MooVC.Syntax.Solution.ConfigurationsTests;
+
+public sealed class WhenEqualsObjectIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        object other = new Configurations
+        {
+            Builds = [Configurations.BuildType.Release],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var subject = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        object other = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenNonConfigurationsObjectThenReturnsFalse()
+    {
+        // Arrange
+        var subject = new Configurations();
+        object other = "not-a-configuration";
+
+        // Act
+        bool result = subject.Equals(other);
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenGetHashCodeIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenGetHashCodeIsCalled.cs
@@ -1,0 +1,52 @@
+namespace MooVC.Syntax.Solution.ConfigurationsTests;
+
+public sealed class WhenGetHashCodeIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsDifferentHashCodes()
+    {
+        // Arrange
+        var left = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        var right = new Configurations
+        {
+            Builds = [Configurations.BuildType.Release],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        int leftHashCode = left.GetHashCode();
+        int rightHashCode = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHashCode).IsNotEqualTo(rightHashCode);
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsSameHashCode()
+    {
+        // Arrange
+        var left = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        var right = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        int leftHashCode = left.GetHashCode();
+        int rightHashCode = right.GetHashCode();
+
+        // Assert
+        _ = await Assert.That(leftHashCode).IsEqualTo(rightHashCode);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenInequalityOperatorConfigurationsConfigurationsIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenInequalityOperatorConfigurationsConfigurationsIsCalled.cs
@@ -1,0 +1,50 @@
+namespace MooVC.Syntax.Solution.ConfigurationsTests;
+
+public sealed class WhenInequalityOperatorConfigurationsConfigurationsIsCalled
+{
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        var right = new Configurations
+        {
+            Builds = [Configurations.BuildType.Release],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        var right = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ConfigurationsTests/WhenToStringIsCalled.cs
@@ -1,0 +1,36 @@
+namespace MooVC.Syntax.Solution.ConfigurationsTests;
+
+public sealed class WhenToStringIsCalled
+{
+    [Test]
+    public async Task GivenDefaultThenReturnsEmptyString()
+    {
+        // Arrange
+        var subject = new Configurations();
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task GivenNonDefaultThenReturnsConfigurationElement()
+    {
+        // Arrange
+        var subject = new Configurations
+        {
+            Builds = [Configurations.BuildType.Debug],
+            Platforms = [Configurations.Platform.AnyCPU],
+        };
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).Contains("<Configurations>");
+        _ = await Assert.That(result).Contains("BuildType");
+        _ = await Assert.That(result).Contains("Platform");
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FileTests/WhenInequalityOperatorFileStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FileTests/WhenInequalityOperatorFileStringIsCalled.cs
@@ -1,0 +1,51 @@
+namespace MooVC.Syntax.Solution.FileTests;
+
+public sealed class WhenInequalityOperatorFileStringIsCalled
+{
+    private const string Same = "src/Readme.md";
+    private const string Different = "src/Other.md";
+
+    [Test]
+    public async Task GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        File? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        File left = Same;
+
+        // Act
+        bool resultLeftRight = left != Different;
+        bool resultRightLeft = Different != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        File left = Same;
+
+        // Act
+        bool resultLeftRight = left != Same;
+        bool resultRightLeft = Same != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/FileTests/WhenInequalityOperatorFileStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/FileTests/WhenInequalityOperatorFileStringIsCalled.cs
@@ -27,7 +27,8 @@ public sealed class WhenInequalityOperatorFileStringIsCalled
 
         // Act
         bool resultLeftRight = left != Different;
-        bool resultRightLeft = Different != left;
+        string right = Different;
+        bool resultRightLeft = right != left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsTrue();
@@ -42,7 +43,8 @@ public sealed class WhenInequalityOperatorFileStringIsCalled
 
         // Act
         bool resultLeftRight = left != Same;
-        bool resultRightLeft = Same != left;
+        string right = Same;
+        bool resultRightLeft = right != left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsFalse();

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenEqualityOperatorNameStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenEqualityOperatorNameStringIsCalled.cs
@@ -27,7 +27,8 @@ public sealed class WhenEqualityOperatorNameStringIsCalled
 
         // Act
         bool resultLeftRight = left == Different;
-        bool resultRightLeft = Different == left;
+        string right = Different;
+        bool resultRightLeft = right == left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsFalse();
@@ -42,7 +43,8 @@ public sealed class WhenEqualityOperatorNameStringIsCalled
 
         // Act
         bool resultLeftRight = left == Same;
-        bool resultRightLeft = Same == left;
+        string right = Same;
+        bool resultRightLeft = right == left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsTrue();

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenEqualityOperatorNameStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenEqualityOperatorNameStringIsCalled.cs
@@ -1,0 +1,51 @@
+namespace MooVC.Syntax.Solution.ProjectTests.NameTests;
+
+public sealed class WhenEqualityOperatorNameStringIsCalled
+{
+    private const string Same = "ProjectName";
+    private const string Different = "OtherProjectName";
+
+    [Test]
+    public async Task GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Project.Name? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Project.Name(Same);
+
+        // Act
+        bool resultLeftRight = left == Different;
+        bool resultRightLeft = Different == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Project.Name(Same);
+
+        // Act
+        bool resultLeftRight = left == Same;
+        bool resultRightLeft = Same == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenInequalityOperatorNameStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenInequalityOperatorNameStringIsCalled.cs
@@ -27,7 +27,8 @@ public sealed class WhenInequalityOperatorNameStringIsCalled
 
         // Act
         bool resultLeftRight = left != Different;
-        bool resultRightLeft = Different != left;
+        string right = Different;
+        bool resultRightLeft = right != left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsTrue();
@@ -42,7 +43,8 @@ public sealed class WhenInequalityOperatorNameStringIsCalled
 
         // Act
         bool resultLeftRight = left != Same;
-        bool resultRightLeft = Same != left;
+        string right = Same;
+        bool resultRightLeft = right != left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsFalse();

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenInequalityOperatorNameStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenInequalityOperatorNameStringIsCalled.cs
@@ -1,0 +1,51 @@
+namespace MooVC.Syntax.Solution.ProjectTests.NameTests;
+
+public sealed class WhenInequalityOperatorNameStringIsCalled
+{
+    private const string Same = "ProjectName";
+    private const string Different = "OtherProjectName";
+
+    [Test]
+    public async Task GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Project.Name? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Project.Name(Same);
+
+        // Act
+        bool resultLeftRight = left != Different;
+        bool resultRightLeft = Different != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Project.Name(Same);
+
+        // Act
+        bool resultLeftRight = left != Same;
+        bool resultRightLeft = Same != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/NameTests/WhenToStringIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.Solution.ProjectTests.NameTests;
+
+public sealed class WhenToStringIsCalled
+{
+    private const string Value = "ProjectName";
+
+    [Test]
+    public async Task GivenNameThenReturnsUnderlyingValue()
+    {
+        // Arrange
+        var subject = new Project.Name(Value);
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo(Value);
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenEqualityOperatorRelativePathStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenEqualityOperatorRelativePathStringIsCalled.cs
@@ -1,0 +1,51 @@
+namespace MooVC.Syntax.Solution.ProjectTests.RelativePathTests;
+
+public sealed class WhenEqualityOperatorRelativePathStringIsCalled
+{
+    private const string Same = "src/Project.csproj";
+    private const string Different = "src/Other.csproj";
+
+    [Test]
+    public async Task GivenBothNullThenReturnsTrue()
+    {
+        // Arrange
+        Project.RelativePath? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left == right;
+
+        // Assert
+        _ = await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Project.RelativePath(Same);
+
+        // Act
+        bool resultLeftRight = left == Different;
+        bool resultRightLeft = Different == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Project.RelativePath(Same);
+
+        // Act
+        bool resultLeftRight = left == Same;
+        bool resultRightLeft = Same == left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenEqualityOperatorRelativePathStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenEqualityOperatorRelativePathStringIsCalled.cs
@@ -27,7 +27,8 @@ public sealed class WhenEqualityOperatorRelativePathStringIsCalled
 
         // Act
         bool resultLeftRight = left == Different;
-        bool resultRightLeft = Different == left;
+        string right = Different;
+        bool resultRightLeft = right == left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsFalse();
@@ -42,7 +43,8 @@ public sealed class WhenEqualityOperatorRelativePathStringIsCalled
 
         // Act
         bool resultLeftRight = left == Same;
-        bool resultRightLeft = Same == left;
+        string right = Same;
+        bool resultRightLeft = right == left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsTrue();

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenInequalityOperatorRelativePathStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenInequalityOperatorRelativePathStringIsCalled.cs
@@ -27,7 +27,8 @@ public sealed class WhenInequalityOperatorRelativePathStringIsCalled
 
         // Act
         bool resultLeftRight = left != Different;
-        bool resultRightLeft = Different != left;
+        string right = Different;
+        bool resultRightLeft = right != left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsTrue();
@@ -42,7 +43,8 @@ public sealed class WhenInequalityOperatorRelativePathStringIsCalled
 
         // Act
         bool resultLeftRight = left != Same;
-        bool resultRightLeft = Same != left;
+        string right = Same;
+        bool resultRightLeft = right != left;
 
         // Assert
         _ = await Assert.That(resultLeftRight).IsFalse();

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenInequalityOperatorRelativePathStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenInequalityOperatorRelativePathStringIsCalled.cs
@@ -1,0 +1,51 @@
+namespace MooVC.Syntax.Solution.ProjectTests.RelativePathTests;
+
+public sealed class WhenInequalityOperatorRelativePathStringIsCalled
+{
+    private const string Same = "src/Project.csproj";
+    private const string Different = "src/Other.csproj";
+
+    [Test]
+    public async Task GivenBothNullThenReturnsFalse()
+    {
+        // Arrange
+        Project.RelativePath? left = default;
+        string? right = default;
+
+        // Act
+        bool result = left != right;
+
+        // Assert
+        _ = await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task GivenDifferentValuesThenReturnsTrue()
+    {
+        // Arrange
+        var left = new Project.RelativePath(Same);
+
+        // Act
+        bool resultLeftRight = left != Different;
+        bool resultRightLeft = Different != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsTrue();
+        _ = await Assert.That(resultRightLeft).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenEqualValuesThenReturnsFalse()
+    {
+        // Arrange
+        var left = new Project.RelativePath(Same);
+
+        // Act
+        bool resultLeftRight = left != Same;
+        bool resultRightLeft = Same != left;
+
+        // Assert
+        _ = await Assert.That(resultLeftRight).IsFalse();
+        _ = await Assert.That(resultRightLeft).IsFalse();
+    }
+}

--- a/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenToStringIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Solution/ProjectTests/RelativePathTests/WhenToStringIsCalled.cs
@@ -1,0 +1,19 @@
+namespace MooVC.Syntax.Solution.ProjectTests.RelativePathTests;
+
+public sealed class WhenToStringIsCalled
+{
+    private const string Value = "src/Project.csproj";
+
+    [Test]
+    public async Task GivenRelativePathThenReturnsUnderlyingValue()
+    {
+        // Arrange
+        var subject = new Project.RelativePath(Value);
+
+        // Act
+        string result = subject.ToString();
+
+        // Assert
+        _ = await Assert.That(result).IsEqualTo(Value);
+    }
+}


### PR DESCRIPTION
### Motivation

- Add coverage for solution-related value types and small domain types to ensure correct equality semantics, string representation, and validation behavior.
- Exercise operator overloads and hash code behavior to prevent regressions in comparisons between typed wrappers and raw `string` values.
- Verify `Build.ToFragments()` and `Build.Validate()` behavior for undefined and populated values.

### Description

- Added multiple new test classes under `src/MooVC.Syntax.Tests/Solution` including `BuildTests`, `ConfigurationsTests`, `FileTests`, and `ProjectTests` to validate domain behavior. 
- Added `Build` tests: `WhenToFragmentsIsCalled.cs` to assert `ToFragments()` returns expected fragments or empty collection, and `WhenValidateIsCalled.cs` to assert `Validate()` yields expected validation results. 
- Added `Configurations` tests covering `Equals`, `Equals(object)`, `GetHashCode`, inequality operator, and `ToString()` in `WhenEqualsConfigurationsIsCalled.cs`, `WhenEqualsObjectIsCalled.cs`, `WhenGetHashCodeIsCalled.cs`, `WhenInequalityOperatorConfigurationsConfigurationsIsCalled.cs`, and `WhenToStringIsCalled.cs`. 
- Added operator and `ToString` tests for lightweight wrappers: `File` inequality in `WhenInequalityOperatorFileStringIsCalled.cs`, `Project.Name` equality/inequality and `ToString()` in `NameTests`, and `Project.RelativePath` equality/inequality and `ToString()` in `RelativePathTests`.

### Testing

- Ran the unit test suite with `dotnet test` to exercise the newly added tests. 
- All added tests executed and passed successfully. 
- New tests cover null/empty cases, equality/inequality operator behavior, `GetHashCode` consistency, `ToString()` output, and `Build` validation/fragment generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfc46ca7c832fa9484ca6680f495e)