### PR TITLE
docs(AGENTS): add SDK bootstrap instructions and mandatory Codex workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ This repository hosts **MooVC**, a .NET library that contains a collection of fu
 - Restore packages with `dotnet restore`.
 - Run `dotnet test` to execute the test suite. This is the primary check before committing.
 - Tests are configured via `.runsettings` and use xUnit.
+- If `dotnet` is not available in the current container/session, install SDKs before running checks.
+  - Linux/macOS bootstrap:
+    - `curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh`
+    - `bash /tmp/dotnet-install.sh --channel 8.0 --install-dir "$HOME/.dotnet"`
+    - `bash /tmp/dotnet-install.sh --channel 9.0 --install-dir "$HOME/.dotnet"`
+    - `bash /tmp/dotnet-install.sh --channel 10.0 --install-dir "$HOME/.dotnet"`
+    - `export PATH="$HOME/.dotnet:$PATH"`
+    - `dotnet --list-sdks`
+  - Match CI SDK coverage (`8.0.x`, `9.0.x`, `10.0.x`) when validating the full solution.
 
 ## Coding Style
 
@@ -56,3 +65,40 @@ The [PR template](.github/pull_request_template.md) requires that you:
 - Add or update tests when necessary.
 - Ensure tests pass locally.
 - Update `CHANGELOG.md` when consumer-facing changes occur.
+
+## Mandatory Workflow for Codex
+
+To reduce regressions and incorrect API usage, Codex must follow this workflow for every code change:
+
+1. **Load repository rules first**
+   - Read `AGENTS.md`, `.editorconfig`, and `Directory.Build.props` before editing files.
+   - Determine whether the target project is a library, Roslyn project, or test project so the correct imported props/ruleset applies.
+2. **Verify symbols before writing code**
+   - Never assume a member exists based on similarly named types.
+   - Before using or changing APIs, confirm the exact symbol names from source files.
+3. **Make minimal, scoped edits**
+   - Change only files required by the task.
+   - Reuse existing patterns from neighboring files/tests.
+4. **Run required validation commands**
+   - Run `dotnet restore`.
+   - Run `dotnet test` (or at minimum run tests for each affected project/target framework).
+   - Do not create a commit if restore/build/tests fail.
+5. **Self-check before commit**
+   - Confirm no `.editorconfig` violations.
+   - Confirm no analyzer/ruleset violations from `analyzers/` as configured by imported props.
+   - Confirm test naming and structure conventions from this file are followed.
+
+## Rule Enforcement Notes
+
+- `.editorconfig` is authoritative for formatting, naming, `var` usage, namespace style, and newline behavior.
+- Analyzer severities are enforced through project configuration and rulesets in `analyzers/`.
+- Test projects use `build/Tests.props`, which assigns `analyzers/tests.ruleset`.
+- Non-test code paths use their corresponding imported props (`build/Libraries.props` or `build/Roslyn.props`) and configured analyzers.
+
+## Common Failure Prevention
+
+- If two option types have different static instances, always verify each concrete type instead of copying usage from another type.
+- When adding or updating tests, compile and run the affected test project immediately after the change.
+- If a requested symbol does not exist, stop and either:
+  - use an existing valid symbol, or
+  - add the symbol intentionally in production code with tests, if that is part of the requested change.


### PR DESCRIPTION
### Motivation

- Provide concrete bootstrapping steps for installing .NET SDKs in environments where `dotnet` is not available. 
- Define a mandatory workflow for Codex to reduce regressions and incorrect API usage when making code changes. 
- Centralize rule enforcement and common failure-prevention guidance to ensure edits follow repository conventions. 

### Description

- Added Linux/macOS SDK bootstrap instructions using the official `dotnet-install.sh` script and an `export PATH` step to the `Build and Test` section. 
- Introduced a `Mandatory Workflow for Codex` section that requires loading repository rules, verifying symbols, making minimal edits, running validation commands, and performing a self-check before committing. 
- Added `Rule Enforcement Notes` and `Common Failure Prevention` sections that reference `.editorconfig`, analyzer configuration, and testing/compilation best practices. 

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df760070e8832f88e2569085a83323)