### PR TITLE
Increase FileSystemWriter branch coverage for root-path and directory handling

### DIFF
--- a/src/MooVC.Modelling.Tests/FileSystemWriterTests/WhenWriteIsCalled.cs
+++ b/src/MooVC.Modelling.Tests/FileSystemWriterTests/WhenWriteIsCalled.cs
@@ -90,6 +90,56 @@ public sealed class WhenWriteIsCalled
         _ = await Assert.That(fileSystem.CreatedDirectories).HasSingleItem();
     }
 
+    [Test]
+    public async Task GivenFileStreamWithEmptyDirectoryNameThenCurrentDirectoryIsUsed()
+    {
+        // Arrange
+        File testFile = new(Content, Extension, Name, PathValue);
+        IAsyncEnumerable<File> files = CreateFiles(testFile);
+        var fileSystem = new NullDirectoryNameFileSystem();
+        IOptionsSnapshot<FileSystemWriter.Options> optionsSnapshot = CreateOptionsSnapshot();
+        IWriter writer = new FileSystemWriter(fileSystem, optionsSnapshot);
+        string streamPath = Path.GetTempFileName();
+
+        try
+        {
+            await using var stream = new FileStream(streamPath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            string expectedPath = fileSystem.GetFullPath(Path.Combine(Environment.CurrentDirectory, testFile.FullPath));
+
+            // Act
+            await writer.Write(files, stream, CancellationToken.None);
+
+            // Assert
+            bool isFound = fileSystem.TryGetFileContent(expectedPath, out _);
+            _ = await Assert.That(isFound).IsTrue();
+        }
+        finally
+        {
+            if (FileObject.Exists(streamPath))
+            {
+                FileObject.Delete(streamPath);
+            }
+        }
+    }
+
+    [Test]
+    public async Task GivenFilePathWithoutDirectoryThenDirectoryCreationIsSkipped()
+    {
+        // Arrange
+        File testFile = new(Content, Extension, Name, PathValue);
+        IAsyncEnumerable<File> files = CreateFiles(testFile);
+        var fileSystem = new NullDirectoryNameFileSystem();
+        IOptionsSnapshot<FileSystemWriter.Options> optionsSnapshot = CreateOptionsSnapshot();
+        IWriter writer = new FileSystemWriter(fileSystem, optionsSnapshot);
+        await using var stream = new MemoryStream();
+
+        // Act
+        await writer.Write(files, stream, CancellationToken.None);
+
+        // Assert
+        _ = await Assert.That(fileSystem.CreatedDirectories).IsEmpty();
+    }
+
     private static IOptionsSnapshot<FileSystemWriter.Options> CreateOptionsSnapshot()
     {
         IOptionsSnapshot<FileSystemWriter.Options> options = Substitute.For<IOptionsSnapshot<FileSystemWriter.Options>>();
@@ -106,6 +156,44 @@ public sealed class WhenWriteIsCalled
             yield return file;
 
             await Task.Yield();
+        }
+    }
+
+    private sealed class NullDirectoryNameFileSystem
+        : IFileSystem
+    {
+        private readonly Dictionary<string, byte[]> _fileContents = new(StringComparer.Ordinal);
+
+        public HashSet<string> CreatedDirectories { get; } = new(StringComparer.Ordinal);
+
+        public void CreateDirectory(string path)
+        {
+            _ = CreatedDirectories.Add(path);
+        }
+
+        public Stream CreateFileStream(string path, int bufferSize)
+        {
+            return new InMemoryFileStream(path, bufferSize, _fileContents);
+        }
+
+        public string GetCurrentDirectory()
+        {
+            return Environment.CurrentDirectory;
+        }
+
+        public string? GetDirectoryName(string path)
+        {
+            return null;
+        }
+
+        public string GetFullPath(string path)
+        {
+            return Path.GetFullPath(path, Environment.CurrentDirectory);
+        }
+
+        public bool TryGetFileContent(string path, out byte[]? fileContent)
+        {
+            return _fileContents.TryGetValue(path, out fileContent);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Exercise previously untested branches in `FileSystemWriter` that resolve root paths when a `Stream` provides no usable directory and when the file-system abstraction returns no directory for the target path.

### Description

- Added two unit tests to `src/MooVC.Modelling.Tests/FileSystemWriterTests/WhenWriteIsCalled.cs`: `GivenFileStreamWithEmptyDirectoryNameThenCurrentDirectoryIsUsed` and `GivenFilePathWithoutDirectoryThenDirectoryCreationIsSkipped` to validate fallback and directory-creation skipping behavior.
- Introduced a test-only `NullDirectoryNameFileSystem` in the same test file that implements `IFileSystem`, returns `null` from `GetDirectoryName`, and still captures created directories and written content to allow deterministic assertions.
- Wrapped temporary `FileStream` usage in a `try`/`finally` and added explicit cleanup to avoid leaving temp artifacts, and removed trailing newlines from modified test files to satisfy style rules (`SA1518`).

### Testing

- Ran `dotnet restore` successfully to restore packages for the solution.
- Ran `dotnet test --project src/MooVC.Modelling.Tests/MooVC.Modelling.Tests.csproj --no-restore` and observed the `MooVC.Modelling.Tests` project tests passed.
- Ran `dotnet test --no-restore` for the whole solution and observed all test projects passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfba04d518832fb465ec04a222f359)