### PR TITLE
Render Project SDKs as single 'Sdk' attribute and default to Microsoft.NET.Sdk

### DIFF
--- a/src/MooVC.Syntax.Tests/Project/ProjectTests/WhenToDocumentIsCalled.cs
+++ b/src/MooVC.Syntax.Tests/Project/ProjectTests/WhenToDocumentIsCalled.cs
@@ -56,11 +56,6 @@ public sealed class WhenToDocumentIsCalled
 
         var propertyGroupElement = new XElement(nameof(PropertyGroup), propertyElement);
 
-        var sdkElement = new XElement(
-            nameof(Sdk),
-            new XAttribute(nameof(Sdk.Name), ProjectTestsData.DefaultSdkName.ToString()),
-            new XAttribute(nameof(Sdk.Version), ProjectTestsData.DefaultSdkVersion));
-
         var targetElement = new XElement(
             nameof(Target),
             new XAttribute(nameof(Target.Name), ProjectTestsData.DefaultTargetName));
@@ -69,11 +64,11 @@ public sealed class WhenToDocumentIsCalled
             new XDeclaration("1.0", "utf-8", "yes"),
             new XElement(
                 nameof(Project),
+                new XAttribute("Sdk", $"{ProjectTestsData.DefaultSdkName}/{ProjectTestsData.DefaultSdkVersion}"),
                 propertyGroupElement,
                 itemGroupElement,
                 resourceItemGroupElement,
                 importElement,
-                sdkElement,
                 targetElement));
 
         // Act
@@ -85,5 +80,20 @@ public sealed class WhenToDocumentIsCalled
         _ = await Assert.That(declaration.Encoding).IsEqualTo("utf-8");
         _ = await Assert.That(declaration.Standalone).IsEqualTo("yes");
         _ = await Assert.That(XNode.DeepEquals(expected, result)).IsTrue();
+    }
+
+    [Test]
+    public async Task GivenUnspecifiedSdkThenDefaultsToMicrosoftNetSdk()
+    {
+        // Arrange
+        Project subject = ProjectTestsData.Create(sdk: Sdk.Unspecified);
+
+        // Act
+        XDocument result = subject.ToDocument();
+
+        // Assert
+        XElement project = await Assert.That(result.Root).IsNotNull();
+        XAttribute sdk = await Assert.That(project.Attribute("Sdk")).IsNotNull();
+        _ = await Assert.That(sdk.Value).IsEqualTo("Microsoft.NET.Sdk");
     }
 }

--- a/src/MooVC.Syntax/Project/Project.cs
+++ b/src/MooVC.Syntax/Project/Project.cs
@@ -27,6 +27,8 @@ namespace MooVC.Syntax.Project
         /// </summary>
         public static readonly Project Undefined = new Project();
 
+        private const string DefaultSdk = "Microsoft.NET.Sdk";
+
         /// <summary>
         /// Gets the imports on the Project.
         /// </summary>
@@ -133,10 +135,11 @@ namespace MooVC.Syntax.Project
                 .SelectMany(group => group.ToFragments())
                 .ToArray();
 
-            XElement[] sdks = Sdks
-                .Where(sdk => !sdk.IsUnspecified)
-                .SelectMany(sdk => sdk.ToFragments())
-                .ToArray();
+            string monikers = Sdks
+                .Where(candidate => !candidate.IsUnspecified)
+                .Select(ToSdkMoniker)
+                .ToArray()
+                .ForkOn(values => values.Length > 0, @true: values => string.Join(";", values), @false: _ => DefaultSdk);
 
             XElement[] targets = Targets
                 .Where(target => !target.IsUndefined)
@@ -147,11 +150,11 @@ namespace MooVC.Syntax.Project
 
             var project = new XElement(
                 nameof(Project),
+                monikers.ToXmlAttribute("Sdk"),
                 propertyGroups,
                 itemGroups,
                 resourceItemGroups,
                 imports,
-                sdks,
                 targets);
 
             return new XDocument(declaration, project);
@@ -174,6 +177,13 @@ namespace MooVC.Syntax.Project
         private static IEnumerable<XElement> CreateResourcesGroup(IEnumerable<XElement> resources)
         {
             yield return new XElement(nameof(ItemGroup), resources);
+        }
+
+        private static string ToSdkMoniker(Sdk sdk)
+        {
+            return sdk.Version.IsEmpty
+                ? sdk.Name.ToString()
+                : $"{sdk.Name}/{sdk.Version}";
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure the project SDKs are expressed as the standard `Sdk` attribute on the root `Project` element instead of separate `Sdk` child elements.
- Provide a sensible default of `Microsoft.NET.Sdk` when no SDK is specified to produce valid SDK-style project files.

### Description

- Added `DefaultSdk` constant set to `"Microsoft.NET.Sdk"` and removed the previous `Sdk` element fragments approach.
- Compute a single SDK moniker string by joining `Sdks` via `ToSdkMoniker` and use `monikers.ToXmlAttribute("Sdk")` to render the attribute on the `Project` element, falling back to `DefaultSdk` when none are specified.
- Implemented `ToSdkMoniker(Sdk)` to format `Sdk` values as either `Name` or `Name/Version` depending on whether a version is present.
- Updated tests to expect the `Sdk` attribute on the `Project` element and added `GivenUnspecifiedSdkThenDefaultsToMicrosoftNetSdk` to verify the default behavior.

### Testing

- Ran the unit tests in the `src/MooVC.Syntax.Tests` project including `WhenToDocumentIsCalled` and the new `GivenUnspecifiedSdkThenDefaultsToMicrosoftNetSdk` test.
- All executed tests passed (no failing tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc334e0e4832f8f6fbfab552078ab)